### PR TITLE
fix(api): financial_summary endpoint — 3 non-existent column references

### DIFF
--- a/src/controllers/api/financial_summary.php
+++ b/src/controllers/api/financial_summary.php
@@ -7,7 +7,7 @@ $period = (int)($_GET['days'] ?? 30);
 if ($period < 1 || $period > 365) $period = 30;
 $start = gmdate('Y-m-d', strtotime("-$period days"));
 
-$stmt = $pdo->prepare("SELECT COALESCE(SUM(amount),0) FROM payments WHERE status='succeeded' AND DATE(paid_at)>=?");
+$stmt = $pdo->prepare("SELECT COALESCE(SUM(amount),0) FROM payments WHERE status='succeeded' AND DATE(payment_date)>=?");
 $stmt->execute([$start]);
 $revenue = (float) $stmt->fetchColumn();
 
@@ -15,7 +15,7 @@ $stmt = $pdo->prepare("SELECT COALESCE(SUM(total),0) FROM invoices WHERE status=
 $stmt->execute([$start]);
 $invoicedPaid = (float) $stmt->fetchColumn();
 
-$stmt = $pdo->prepare("SELECT COALESCE(SUM(amount),0) FROM expenses WHERE DATE(date)>=?");
+$stmt = $pdo->prepare("SELECT COALESCE(SUM(total_amount),0) FROM expenses WHERE DATE(expense_date)>=?");
 $stmt->execute([$start]);
 $expenses = (float) $stmt->fetchColumn();
 


### PR DESCRIPTION
## What's in this PR

`financial_summary.php` queried three columns that don't exist in the schema:
1. `payments.paid_at` → fixed to `payment_date`
2. `expenses.date` → fixed to `expense_date`
3. `expenses.amount` → fixed to `total_amount`

The endpoint was returning HTTP 500 (crash). Now returns 200 with valid JSON.

## Verification
- Built from source locally, tested both `api-financial-summary` and `api-dashboard-summary` endpoints end-to-end
- Both return HTTP 200 with valid JSON
- php -l passes