### PR TITLE
Brand editors exclude client orgs; Terms switcher works; checkbox-save tab gating

### DIFF
--- a/src/controllers/settings_handler.php
+++ b/src/controllers/settings_handler.php
@@ -143,11 +143,12 @@ if (isset($_POST['app_host'])) {
     $settings['app_host'] = $h !== '' ? mb_substr($h, 0, 255) : null;
 }
 // Public links in email checkbox (was MISSING — never saved before)
-$settings['public_links_in_email'] = !empty($_POST['public_links_in_email']) ? 1 : 0;
-// Multi-brand toggle only on the System tab; unchecked checkboxes don't POST so we must gate by tab
+// System-tab toggles: gate by tab because unchecked checkboxes don't POST
 if (isset($_POST['tab']) && $_POST['tab'] === 'system') {
+    $settings['public_links_in_email'] = !empty($_POST['public_links_in_email']) ? 1 : 0;
     $settings['multi_brand_enabled'] = !empty($_POST['multi_brand_enabled']) ? 1 : 0;
     $settings['default_brand_org_id'] = (int)($_POST['default_brand_org_id'] ?? 0);
+    $settings['suppress_assets_warning'] = !empty($_POST['suppress_assets_warning']) ? 1 : 0;
 }
 
 // From and contact fields
@@ -177,7 +178,10 @@ if (isset($_POST['documents_valid_days'])) {
     $settings['documents_valid_days'] = $dv;
 }
 // Toggle terms on quotes (moved to Documents → Quotes tab)
-$settings['quotes_show_terms'] = !empty($_POST['quotes_show_terms']) ? 1 : 0;
+// Documents-tab toggles: gate by tab because unchecked checkboxes don't POST
+if (isset($_POST['tab']) && $_POST['tab'] === 'documents') {
+    $settings['quotes_show_terms'] = !empty($_POST['quotes_show_terms']) ? 1 : 0;
+}
 
 // On-demand document terms (new)
 if (isset($_POST['on_demand_terms'])) {
@@ -217,8 +221,6 @@ if (isset($_POST['net_terms_days'])) {
     if ($nd < 0) $nd = 0;
     $settings['net_terms_days'] = $nd;
 }
-// Suppress assets warning checkbox
-$settings['suppress_assets_warning'] = !empty($_POST['suppress_assets_warning']) ? 1 : 0;
 // Payment methods (JSON from modernized UI)
 if (isset($_POST['payment_methods_json'])) {
     $jsonData = json_decode((string)$_POST['payment_methods_json'], true);
@@ -403,71 +405,57 @@ foreach ($orgIds as $oid) {
 }
 
 // Cron/recurring invoice settings
-if (isset($_POST['cron_enabled'])) {
+// Notifications-tab toggles: gate by tab because unchecked checkboxes don't POST
+if (isset($_POST['tab']) && $_POST['tab'] === 'notifications') {
     $settings['cron_enabled'] = !empty($_POST['cron_enabled']) ? 1 : 0;
+    $settings['invoice_auto_send_due_7days'] = !empty($_POST['invoice_auto_send_due_7days']) ? 1 : 0;
+    $settings['invoice_auto_send_overdue_weekly'] = !empty($_POST['invoice_auto_send_overdue_weekly']) ? 1 : 0;
+    $settings['auto_terminate_contracts'] = !empty($_POST['auto_terminate_contracts']) ? 1 : 0;
+    $settings['link_expiration_checker'] = !empty($_POST['link_expiration_checker']) ? 1 : 0;
+    $settings['contract_expiring_warning'] = !empty($_POST['contract_expiring_warning']) ? 1 : 0;
+    $settings['contract_expired_alert'] = !empty($_POST['contract_expired_alert']) ? 1 : 0;
+    $settings['payment_failure_alert'] = !empty($_POST['payment_failure_alert']) ? 1 : 0;
+    $settings['payment_received_notification'] = !empty($_POST['payment_received_notification']) ? 1 : 0;
+    $settings['link_expiration_warning'] = !empty($_POST['link_expiration_warning']) ? 1 : 0;
 }
-if (isset($_POST['cron_schedule'])) {
+if (isset($_POST['tab']) && $_POST['tab'] === 'notifications' && isset($_POST['cron_schedule'])) {
     $sched = trim((string)$_POST['cron_schedule']);
     $allowed = ['hourly','every_6hours','daily_midnight','daily_2am','daily_6am','daily_noon','custom'];
     if (in_array($sched, $allowed, true)) {
         $settings['cron_schedule'] = $sched;
     }
 }
-if (isset($_POST['cron_custom'])) {
+if (isset($_POST['tab']) && $_POST['tab'] === 'notifications' && isset($_POST['cron_custom'])) {
     $settings['cron_custom'] = trim((string)$_POST['cron_custom']) ?: '0 2 * * *';
 }
 
 // Automatic invoice email settings
-$settings['invoice_auto_send_due_7days'] = !empty($_POST['invoice_auto_send_due_7days']) ? 1 : 0;
-$settings['invoice_auto_send_overdue_weekly'] = !empty($_POST['invoice_auto_send_overdue_weekly']) ? 1 : 0;
-
-// System automation settings
-$settings['auto_terminate_contracts'] = !empty($_POST['auto_terminate_contracts']) ? 1 : 0;
-$settings['link_expiration_checker'] = !empty($_POST['link_expiration_checker']) ? 1 : 0;
-
-// Contract notification settings
-$settings['contract_expiring_warning'] = !empty($_POST['contract_expiring_warning']) ? 1 : 0;
-if (isset($_POST['contract_expiring_days'])) {
+// Contract notification days (notifications tab)
+if (isset($_POST['tab']) && $_POST['tab'] === 'notifications' && isset($_POST['contract_expiring_days'])) {
     $settings['contract_expiring_days'] = max(1, min(90, (int)$_POST['contract_expiring_days']));
 }
-$settings['contract_expired_alert'] = !empty($_POST['contract_expired_alert']) ? 1 : 0;
-
-// Payment notification settings
-$settings['payment_failure_alert'] = !empty($_POST['payment_failure_alert']) ? 1 : 0;
-$settings['payment_received_notification'] = !empty($_POST['payment_received_notification']) ? 1 : 0;
-
-// Link expiration warning settings
-$settings['link_expiration_warning'] = !empty($_POST['link_expiration_warning']) ? 1 : 0;
-if (isset($_POST['link_expiration_warning_days'])) {
+if (isset($_POST['tab']) && $_POST['tab'] === 'notifications' && isset($_POST['link_expiration_warning_days'])) {
     $settings['link_expiration_warning_days'] = max(1, min(90, (int)$_POST['link_expiration_warning_days']));
 }
 
 // Invoice document settings
-if (isset($_POST['invoice_show_terms'])) {
+// Documents-tab toggles: gate by tab because unchecked checkboxes don't POST
+if (isset($_POST['tab']) && $_POST['tab'] === 'documents') {
     $settings['invoice_show_terms'] = !empty($_POST['invoice_show_terms']) ? 1 : 0;
-}
-if (isset($_POST['invoice_show_project_code'])) {
     $settings['invoice_show_project_code'] = !empty($_POST['invoice_show_project_code']) ? 1 : 0;
-}
-if (isset($_POST['invoice_show_due_date'])) {
     $settings['invoice_show_due_date'] = !empty($_POST['invoice_show_due_date']) ? 1 : 0;
-}
-
-    // Quote settings — default to enabled unless explicitly unchecked
     $settings['quote_scope_enabled'] = !empty($_POST['quote_scope_enabled']) ? 1 : 0;
     $settings['quote_auto_create_contract'] = !empty($_POST['quote_auto_create_contract']) ? 1 : 0;
     $settings['quote_auto_create_invoice'] = !empty($_POST['quote_auto_create_invoice']) ? 1 : 0;
-
-// Contract settings
-$settings['contract_scope_enabled'] = !empty($_POST['contract_scope_enabled']) ? 1 : 0;
-$settings['contract_memo_enabled'] = !empty($_POST['contract_memo_enabled']) ? 1 : 0;
-if (isset($_POST['signature_agreement'])) {
+    $settings['contract_scope_enabled'] = !empty($_POST['contract_scope_enabled']) ? 1 : 0;
+    $settings['contract_memo_enabled'] = !empty($_POST['contract_memo_enabled']) ? 1 : 0;
+}
+if (isset($_POST['tab']) && $_POST['tab'] === 'documents' && isset($_POST['signature_agreement'])) {
     $sig = trim((string)$_POST['signature_agreement']);
     $settings['signature_agreement'] = $sig !== '' ? mb_substr($sig, 0, 500) : 'By signing below, I acknowledge that this is a multi-page contract and that I have read and agree to the terms and conditions.';
 }
-
 // Custom contract sections
-if (isset($_POST['section_title']) && is_array($_POST['section_title'])) {
+if (isset($_POST['tab']) && $_POST['tab'] === 'documents' && isset($_POST['section_title']) && is_array($_POST['section_title'])) {
     $sections = [];
     $titles = $_POST['section_title'];
     $contents = $_POST['section_content'] ?? [];

--- a/src/views/pages/settings/system.php
+++ b/src/views/pages/settings/system.php
@@ -159,11 +159,20 @@
 </fieldset>
 
 <?php
-$__primaryOrgId = (int)$pdo->query('SELECT MIN(id) FROM organizations')->fetchColumn();
-$__orgs = $pdo->prepare('SELECT id, name, brand_name, brand_from_name, brand_from_email, brand_from_phone, brand_address_line1, brand_address_line2, brand_city, brand_state, brand_postal, brand_logo_path FROM organizations WHERE id <> ? ORDER BY name');
-$__orgs->execute([$__primaryOrgId]);
-$__orgs = $__orgs->fetchAll(PDO::FETCH_ASSOC);
-$__allOrgs = $pdo->query('SELECT id, name FROM organizations ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$__userId = (int)($_SESSION['user']['id'] ?? 0);
+$__userOrgRows = $pdo->prepare('SELECT uo.organization_id AS id, uo.is_default, o.name, o.brand_name, o.brand_from_name, o.brand_from_email, o.brand_from_phone, o.brand_address_line1, o.brand_address_line2, o.brand_city, o.brand_state, o.brand_postal, o.brand_logo_path FROM user_organizations uo JOIN organizations o ON o.id = uo.organization_id WHERE uo.user_id = ? ORDER BY uo.is_default DESC, o.name ASC');
+$__userOrgRows->execute([$__userId]);
+$__userOrgRows = $__userOrgRows->fetchAll(PDO::FETCH_ASSOC);
+$__primaryOrgId = null;
+foreach ($__userOrgRows as $o) {
+    if (!empty($o['is_default'])) { $__primaryOrgId = (int)$o['id']; break; }
+}
+if ($__primaryOrgId === null && !empty($__userOrgRows)) { $__primaryOrgId = (int)min(array_column($__userOrgRows, 'id')); }
+$__primaryOrgId = $__primaryOrgId ?? 0;
+$__orgs = [];
+foreach ($__userOrgRows as $o) {
+    if ((int)$o['id'] !== $__primaryOrgId) { $__orgs[] = $o; }
+}
 $__defaultBrand = (int)($appConfig['default_brand_org_id'] ?? 0);
 ?>
 <div id="perOrgBrandEditors" style="<?php echo !empty($appConfig['multi_brand_enabled']) ? '' : 'display:none'; ?>">
@@ -171,7 +180,7 @@ $__defaultBrand = (int)($appConfig['default_brand_org_id'] ?? 0);
     <div style="font-weight:500">Default brand for new documents</div>
     <select name="default_brand_org_id" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
       <option value="0">Primary brand (default)</option>
-      <?php foreach ($__allOrgs as $ob): ?>
+      <?php foreach ($__userOrgRows as $ob): ?>
         <option value="<?php echo (int)$ob['id']; ?>" <?php echo $__defaultBrand === (int)$ob['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($ob['name']); ?></option>
       <?php endforeach; ?>
     </select>

--- a/src/views/pages/settings/terms.php
+++ b/src/views/pages/settings/terms.php
@@ -3,8 +3,16 @@
 ?>
 
 <?php
-$__primaryId = (int)$pdo->query('SELECT MIN(id) FROM organizations')->fetchColumn();
-$__termsOrgs = $pdo->query('SELECT id, name, brand_terms, brand_long_term_terms, brand_on_demand_terms FROM organizations ORDER BY (id = ' . (int)$__primaryId . ') DESC, name')->fetchAll(PDO::FETCH_ASSOC);
+$__userId = (int)($_SESSION['user']['id'] ?? 0);
+$__termsOrgs = $pdo->prepare('SELECT uo.organization_id AS id, uo.is_default, o.name, o.brand_terms, o.brand_long_term_terms, o.brand_on_demand_terms FROM user_organizations uo JOIN organizations o ON o.id = uo.organization_id WHERE uo.user_id = ? ORDER BY uo.is_default DESC, o.name ASC');
+$__termsOrgs->execute([$__userId]);
+$__termsOrgs = $__termsOrgs->fetchAll(PDO::FETCH_ASSOC);
+$__primaryId = null;
+foreach ($__termsOrgs as $o) {
+    if (!empty($o['is_default'])) { $__primaryId = (int)$o['id']; break; }
+}
+if ($__primaryId === null && !empty($__termsOrgs)) { $__primaryId = (int)min(array_column($__termsOrgs, 'id')); }
+$__primaryId = $__primaryId ?? 0;
 ?>
 
 <?php if (!empty($appConfig['multi_brand_enabled'])): ?>
@@ -64,3 +72,5 @@ $__termsOrgs = $pdo->query('SELECT id, name, brand_terms, brand_long_term_terms,
   </div>
   <?php endforeach; ?>
 <?php endif; ?>
+
+<script src="/assets/js/settings-system.js" defer></script>


### PR DESCRIPTION
## Three fixes (verified E2E locally)

### 1. Brand/Terms editors only show user-owned orgs (exclude client orgs)
The System + Terms settings brand editors SELECTed FROM organizations (ALL rows), so client orgs (orgs linked to clients via clients.organization_id, NOT in user_organizations) appeared as brand editors — e.g. 'Hemp for Horses', 'Exodus'. Now filtered to the current user's orgs via user_organizations (role owner/admin/member), primary = the user's default org (is_default=1) else lowest-id owned. Client orgs no longer appear. Software stays generic (enumerates 'the orgs you operate under', never a hardcoded list).

### 2. Terms brand-switcher buttons work
settings-system.js (the .terms-brand-btn click handler) was only loaded by system.php, not terms.php — so the switcher buttons rendered on the Terms page but did nothing. Now terms.php loads the script too.

### 3. Checkbox toggles no longer uncheck when a different tab is saved (systemic)
settings_handler.php wrote ~18 checkbox toggles (public_links_in_email, quotes_show_terms, cron_enabled, all notifications/docs toggles) UNCONDITIONALLY on every tab save. Since unchecked checkboxes don't POST, saving a different tab zeroed them — e.g. 'include public payment links in emails' unchecks on every prod update. Now each is gated on its owning tab (`if (isset($_POST['tab']) && $_POST['tab'] === '<tab>'))`. Same fix as the prior multi_brand_enabled gate.

### Verified locally (pabrand-test stack, fresh build)
Seeded 2 owner orgs (LTT/LTDS in user_organizations) + 2 client orgs (Hemp/Exodus, NOT linked) + clients mapped to client orgs + multi-brand on:
- System tab: brand editors show only LTT/LTDS (NOT Hemp/Exodus) ✅, LTT marked (Main), Save button present
- Terms tab: switcher lists only LTT/LTDS ✅, JS loaded ✅, editor-sets only for owner orgs
- public_links_in_email: System save WITH checkbox=1 → 1 ✅; Terms save (no checkbox) → STAYS 1 ✅ (gate prevents zeroing); System save WITHOUT checkbox → 0 ✅ (correct uncheck)
- Per-org brand save round-trips (LTDS brand_name persisted) + default_brand_org_id persists

### Commits
```
ec10a16 fix(brand): brand/terms editors only show user-owned orgs; Terms JS loads; gate checkbox writes on owning tab
```
No schema changes. All php -l / node --check clean. CI on dev green.