### PR TITLE
Fix invoice payment and content links

### DIFF
--- a/src/controllers/email_send.php
+++ b/src/controllers/email_send.php
@@ -90,7 +90,7 @@ try {
       document_type VARCHAR(50) NOT NULL,
       document_id INT NOT NULL,
       redirect VARCHAR(255) NULL,
-      expires_at DATETIME NOT NULL,
+      expires_at DATETIME NULL,
       expire_when_paid TINYINT(1) NOT NULL DEFAULT 0,
       revoked TINYINT(1) NOT NULL DEFAULT 0,
       access_count INT NOT NULL DEFAULT 0,
@@ -100,17 +100,25 @@ try {
       INDEX idx_public_type_document (document_type, document_id)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
   } catch (Throwable $e) { /* ignore */ }
+  try {
+    $pdo->exec('ALTER TABLE public_links MODIFY COLUMN expires_at DATETIME NULL');
+  } catch (Throwable $e) { /* ignore */ }
+  try {
+    $pdo->exec('ALTER TABLE public_links ADD COLUMN expire_when_paid TINYINT(1) NOT NULL DEFAULT 0');
+  } catch (Throwable $e) { /* ignore */ }
 
-  // Insert a fresh token for this share (do not reuse old links)
+  // Insert a fresh token for this share (do not reuse old links).
+  // Invoice links stay valid until payment or manual revocation; other
+  // document links keep the configured date-based expiration.
   $token = bin2hex(random_bytes(16));
-  // Use configured documents_valid_days from settings (fallback to 14)
   $days = isset($appConfig['documents_valid_days']) ? (int)$appConfig['documents_valid_days'] : 14;
   if ($days <= 0) { $days = 14; }
-  $exp = date('Y-m-d H:i:s', time() + ($days * 24 * 60 * 60));
+  $expireWhenPaid = $type === 'invoice';
+  $exp = $expireWhenPaid ? null : date('Y-m-d H:i:s', time() + ($days * 24 * 60 * 60));
   try {
-  $ins = $pdo->prepare('INSERT INTO public_links (document_type, document_id, token, redirect, expires_at) VALUES (?,?,?,?,?)');
+  $ins = $pdo->prepare('INSERT INTO public_links (document_type, document_id, token, redirect, expires_at, expire_when_paid) VALUES (?,?,?,?,?,?)');
   // No redirect by default; callers may update this row later if desired
-  $ins->execute([$type, $id, $token, null, $exp]);
+  $ins->execute([$type, $id, $token, null, $exp, $expireWhenPaid ? 1 : 0]);
   } catch (Throwable $e) { /* ignore */ }
 
   // Build absolute URL to public view
@@ -155,7 +163,7 @@ try {
         if ($invRow) {
           $invStatus = strtolower($invRow['status'] ?? '');
           $amountDue = (float)($invRow['total'] ?? 0) - (float)($invRow['amount_paid'] ?? 0);
-          if (in_array($invStatus, ['unpaid', 'partial'], true) && $amountDue > 0) {
+          if (in_array($invStatus, ['sent', 'unpaid', 'partial', 'overdue'], true) && $amountDue > 0) {
             $payUrl = $scheme . '://' . $host . '/?page=stripe-checkout&token=' . rawurlencode($token);
             $body .= '<div style="margin:24px 0;padding:20px;background:#f0f7ff;border:1px solid #93c5fd;border-radius:8px;text-align:center">';
             $body .= '<p style="margin:0 0 12px;color:#1e40af;font-weight:600;font-size:16px">Ready to pay? Use our secure online payment option:</p>';
@@ -168,7 +176,10 @@ try {
     }
   }
 
-  $body .= '<p>This link will expire in '.htmlspecialchars((string)$days).' day'.($days===1?'':'s').'. Do not share this link with untrusted parties!</p>' .
+  $expiryCopy = $expireWhenPaid
+    ? 'This invoice link remains active until the invoice is paid in full or manually revoked.'
+    : 'This link will expire in ' . htmlspecialchars((string)$days) . ' day' . ($days===1?'':'s') . '.';
+  $body .= '<p>' . $expiryCopy . ' Do not share this link with untrusted parties!</p>' .
     '<p>Thank you.</p>';
 
   // Optionally render PDF attachment using Dompdf

--- a/src/controllers/public_link_create.php
+++ b/src/controllers/public_link_create.php
@@ -45,6 +45,9 @@ if (!in_array($type, ['quote', 'contract', 'invoice', 'project_invoice'], true) 
 if ($expireWhenPaid && !in_array($type, ['invoice', 'project_invoice'], true)) {
     $expireWhenPaid = false;
 }
+if (in_array($type, ['invoice', 'project_invoice'], true)) {
+    $expireWhenPaid = true;
+}
 
 // Use default days if not specified (unless expire_when_paid is set)
 if (!$expireWhenPaid && $days <= 0) {
@@ -118,6 +121,12 @@ try {
             INDEX idx_public_type_doc (document_type, document_id)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;");
     } catch (Throwable $e) { /* table exists */ }
+    try {
+        $pdo->exec('ALTER TABLE public_links MODIFY COLUMN expires_at DATETIME NULL');
+    } catch (Throwable $e) { /* older/non-MySQL schemas can ignore */ }
+    try {
+        $pdo->exec('ALTER TABLE public_links ADD COLUMN expire_when_paid TINYINT(1) NOT NULL DEFAULT 0');
+    } catch (Throwable $e) { /* column already exists */ }
     
     // If force_new is set, revoke all existing links for this document
     if ($forceNew) {
@@ -128,6 +137,16 @@ try {
     // Check if a valid link already exists for this document (only if not forcing new)
     $existing = null;
     if (!$forceNew) {
+        if (in_array($type, ['invoice', 'project_invoice'], true)) {
+            try {
+                $upgrade = $pdo->prepare('
+                    UPDATE public_links
+                    SET expire_when_paid = 1, expires_at = NULL
+                    WHERE document_type = ? AND document_id = ? AND revoked = 0
+                ');
+                $upgrade->execute([$type, $id]);
+            } catch (Throwable $e) { /* older schemas are handled by the existing query fallback */ }
+        }
         $existingStmt = $pdo->prepare('
             SELECT token, expires_at, expire_when_paid 
             FROM public_links 

--- a/src/controllers/public_view/public_doc.php
+++ b/src/controllers/public_view/public_doc.php
@@ -43,6 +43,18 @@ try {
   }
   
   if (!$row) { throw new Exception('notfound'); }
+
+  if (in_array((string)$row['document_type'], ['invoice', 'project_invoice'], true) && empty($row['expire_when_paid'])) {
+    try {
+      $pdo->exec("ALTER TABLE public_links MODIFY COLUMN expires_at DATETIME NULL");
+      $up = $pdo->prepare('UPDATE public_links SET expire_when_paid=1, expires_at=NULL WHERE token=? AND revoked=0 AND document_type IN ("invoice","project_invoice")');
+      $up->execute([$token]);
+      $row['expire_when_paid'] = 1;
+      $row['expires_at'] = null;
+    } catch (Throwable $e) {
+      // Keep serving the link with its existing expiration if the schema cannot be adjusted here.
+    }
+  }
   
   // Check if revoked
   if ((int)($row['revoked'] ?? 0) === 1) {
@@ -93,7 +105,7 @@ try {
     if ($invStatus === '') {
       throw new Exception('invoice_not_found:' . $rid);
     }
-    if (!in_array($invStatus, ['unpaid', 'partial'], true)) {
+    if (!in_array($invStatus, ['sent', 'unpaid', 'partial', 'overdue'], true)) {
       throw new Exception('invoice_status_blocked:' . $invStatus);
     }
     if (empty($publicInvoice['finalized_at']) || ($publicInvoice['collection_mode'] ?? 'direct') !== 'direct') {

--- a/src/controllers/public_view/public_doc_pdf.php
+++ b/src/controllers/public_view/public_doc_pdf.php
@@ -32,6 +32,23 @@ try {
     if (!$row) {
         throw new Exception('Link not found');
     }
+
+    if (in_array((string)$row['document_type'], ['invoice', 'project_invoice'], true) && empty($row['expire_when_paid'])) {
+        try {
+            $pdo->exec("ALTER TABLE public_links ADD COLUMN expire_when_paid TINYINT(1) NOT NULL DEFAULT 0");
+        } catch (Throwable $e) {
+        }
+        try {
+            $pdo->exec("ALTER TABLE public_links MODIFY COLUMN expires_at DATETIME NULL");
+            $up = $pdo->prepare('UPDATE public_links SET expire_when_paid=1, expires_at=NULL WHERE token=? AND revoked=0 AND document_type IN ("invoice","project_invoice")');
+            $up->execute([$token]);
+            $row['expire_when_paid'] = 1;
+            $row['expires_at'] = null;
+        } catch (Throwable $e) {
+            // Keep serving the link with its existing expiration if the schema cannot be adjusted here.
+        }
+    }
+
     if ((int)($row['revoked'] ?? 0) === 1) {
         $redirect = trim((string)($row['redirect'] ?? ''));
         if ($redirect !== '') {

--- a/src/controllers/stripe/stripe_checkout.php
+++ b/src/controllers/stripe/stripe_checkout.php
@@ -36,6 +36,22 @@ try {
     if (!$linkRow) {
         throw new Exception('Link not found');
     }
+
+    if (in_array((string)$linkRow['document_type'], ['invoice', 'project_invoice'], true) && empty($linkRow['expire_when_paid'])) {
+        try {
+            $pdo->exec("ALTER TABLE public_links ADD COLUMN expire_when_paid TINYINT(1) NOT NULL DEFAULT 0");
+        } catch (Throwable $e) {
+        }
+        try {
+            $pdo->exec("ALTER TABLE public_links MODIFY COLUMN expires_at DATETIME NULL");
+            $up = $pdo->prepare('UPDATE public_links SET expire_when_paid=1, expires_at=NULL WHERE token=? AND revoked=0 AND document_type IN ("invoice","project_invoice")');
+            $up->execute([$token]);
+            $linkRow['expire_when_paid'] = 1;
+            $linkRow['expires_at'] = null;
+        } catch (Throwable $e) {
+            // Keep validating against the existing expiration if the schema cannot be adjusted here.
+        }
+    }
     
     // Check if revoked
     if ((int)($linkRow['revoked'] ?? 0) === 1) {
@@ -79,7 +95,7 @@ try {
     
     // Check invoice status
     $status = strtolower($invoice['status'] ?? '');
-    if (!in_array($status, ['unpaid', 'partial'], true)) {
+    if (!in_array($status, ['sent', 'unpaid', 'partial', 'overdue'], true)) {
         throw new Exception('This invoice cannot be paid online. Status: ' . $status);
     }
     if (empty($invoice['finalized_at'])) {

--- a/src/utils/invoice_lifecycle.php
+++ b/src/utils/invoice_lifecycle.php
@@ -305,13 +305,18 @@ function invoice_send_finalized(PDO $pdo, int $invoiceId, array $appConfig, stri
         }
     }
 
+    try {
+        $pdo->exec('ALTER TABLE public_links MODIFY COLUMN expires_at DATETIME NULL');
+    } catch (Throwable $e) { /* ignore */ }
+    try {
+        $pdo->exec('ALTER TABLE public_links ADD COLUMN expire_when_paid TINYINT(1) NOT NULL DEFAULT 0');
+    } catch (Throwable $e) { /* ignore */ }
+
     $token = bin2hex(random_bytes(32));
-    $days = max(1, (int)($appConfig['documents_valid_days'] ?? 14));
-    $expiresAt = date('Y-m-d H:i:s', strtotime('+' . $days . ' days'));
     $pdo->prepare(
-        'INSERT INTO public_links (document_type,document_id,token,expires_at,revoked,created_at)
-         VALUES ("invoice",?,?,?,0,NOW())'
-    )->execute([$invoiceId, $token, $expiresAt]);
+        'INSERT INTO public_links (document_type,document_id,token,expires_at,expire_when_paid,revoked,created_at)
+         VALUES ("invoice",?,?,NULL,1,0,NOW())'
+    )->execute([$invoiceId, $token]);
 
     $base = invoice_public_base_url($appConfig);
     $url = $base . '/?page=public-doc&token=' . rawurlencode($token);

--- a/src/utils/invoice_links.php
+++ b/src/utils/invoice_links.php
@@ -77,8 +77,11 @@ function pa_invoice_links_for_invoice(PDO $pdo, int $invoiceId): array
     $projectDepartmentSelect = pa_table_has_column($pdo, 'projects', 'department_id') ? 'p.department_id' : 'NULL AS department_id';
     $stmt = $pdo->prepare("
         SELECT i.project_id, i.organization_id, i.client_id,
-               p.organization_id AS project_organization_id, {$projectDepartmentSelect}
+               p.organization_id AS project_organization_id,
+               c.organization_id AS client_organization_id,
+               {$projectDepartmentSelect}
         FROM invoices i
+        LEFT JOIN clients c ON c.id = i.client_id
         LEFT JOIN projects p ON p.id = i.project_id
         WHERE i.id = ?
         LIMIT 1
@@ -92,7 +95,7 @@ function pa_invoice_links_for_invoice(PDO $pdo, int $invoiceId): array
     return pa_invoice_links_for_context(
         $pdo,
         (int)($invoice['project_id'] ?? 0) ?: null,
-        (int)($invoice['organization_id'] ?: $invoice['project_organization_id'] ?: 0) ?: null,
+        (int)($invoice['organization_id'] ?: $invoice['project_organization_id'] ?: $invoice['client_organization_id'] ?: 0) ?: null,
         (int)($invoice['department_id'] ?? 0) ?: null,
         (int)($invoice['client_id'] ?? 0) ?: null,
         null

--- a/src/utils/project_invoice_billing.php
+++ b/src/utils/project_invoice_billing.php
@@ -149,11 +149,16 @@ function project_invoice_client_recipients(PDO $pdo, int $projectInvoiceId, ?arr
 
 function project_invoice_create_public_link(PDO $pdo, int $projectInvoiceId, array $appConfig): string
 {
+    try {
+        $pdo->exec('ALTER TABLE public_links MODIFY COLUMN expires_at DATETIME NULL');
+    } catch (Throwable $e) { /* ignore */ }
+    try {
+        $pdo->exec('ALTER TABLE public_links ADD COLUMN expire_when_paid TINYINT(1) NOT NULL DEFAULT 0');
+    } catch (Throwable $e) { /* ignore */ }
+
     $token = bin2hex(random_bytes(16));
-    $days = max(1, (int)($appConfig['documents_valid_days'] ?? 14));
-    $expiresAt = date('Y-m-d H:i:s', strtotime('+' . $days . ' days'));
-    $stmt = $pdo->prepare('INSERT INTO public_links (document_type, document_id, token, expires_at, revoked) VALUES ("project_invoice", ?, ?, ?, 0)');
-    $stmt->execute([$projectInvoiceId, $token, $expiresAt]);
+    $stmt = $pdo->prepare('INSERT INTO public_links (document_type, document_id, token, expires_at, expire_when_paid, revoked) VALUES ("project_invoice", ?, ?, NULL, 1, 0)');
+    $stmt->execute([$projectInvoiceId, $token]);
     return $token;
 }
 

--- a/src/views/pages/invoice/invoice-details.php
+++ b/src/views/pages/invoice/invoice-details.php
@@ -478,8 +478,8 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
     <div id="shareLinkContent">
       <p style="color:#6b7280;margin:0 0 16px">Generate a public link that clients can use to view and pay this invoice.</p>
       <label style="display:flex;align-items:center;gap:8px;margin-bottom:12px;cursor:pointer">
-        <input type="checkbox" id="expireWhenPaid" onchange="toggleDaysInput()" style="width:18px;height:18px">
-        <span style="font-weight:500">Expire when invoice is paid in full</span>
+        <input type="checkbox" id="expireWhenPaid" onchange="toggleDaysInput()" style="width:18px;height:18px" checked disabled>
+        <span style="font-weight:500">Invoice links expire when paid in full or manually revoked</span>
       </label>
       <label id="daysLabel" style="display:block;margin-bottom:12px">
         <div style="font-weight:500;margin-bottom:4px">Link expires in (days)</div>
@@ -513,7 +513,7 @@ function generatePublicLink() {
   formData.append('type', 'invoice');
   formData.append('id', '<?php echo (int)$id; ?>');
   formData.append('days', '<?php echo (int)($appConfig['documents_valid_days'] ?? 14); ?>');
-  formData.append('expire_when_paid', '0');
+  formData.append('expire_when_paid', '1');
   formData.append('csrf', '<?php echo htmlspecialchars(csrf_token()); ?>');
   
   fetch('/?page=public-link-create', {
@@ -540,7 +540,7 @@ function generatePublicLink() {
       // No existing link, show the create form
       document.getElementById('shareLinkContent').style.display = 'block';
       document.getElementById('shareLinkResult').style.display = 'none';
-      document.getElementById('expireWhenPaid').checked = false;
+      document.getElementById('expireWhenPaid').checked = true;
       toggleDaysInput();
     }
   })
@@ -548,7 +548,7 @@ function generatePublicLink() {
     // On error, show the create form
     document.getElementById('shareLinkContent').style.display = 'block';
     document.getElementById('shareLinkResult').style.display = 'none';
-    document.getElementById('expireWhenPaid').checked = false;
+    document.getElementById('expireWhenPaid').checked = true;
     toggleDaysInput();
   });
 }
@@ -558,7 +558,7 @@ function closeShareModal() {
 }
 
 function toggleDaysInput() {
-  const expireWhenPaid = document.getElementById('expireWhenPaid').checked;
+  const expireWhenPaid = true;
   const daysLabel = document.getElementById('daysLabel');
   const daysInput = document.getElementById('linkDays');
   if (expireWhenPaid) {
@@ -571,7 +571,7 @@ function toggleDaysInput() {
 }
 
 function createPublicLink() {
-  const expireWhenPaid = document.getElementById('expireWhenPaid').checked;
+  const expireWhenPaid = true;
   const days = document.getElementById('linkDays').value || 14;
   const formData = new FormData();
   formData.append('type', 'invoice');
@@ -655,7 +655,7 @@ function revokeAndCreateNew() {
       document.getElementById('linkExpiry').textContent = '';
       // Reset to default days
       document.getElementById('linkDays').value = '<?php echo (int)($appConfig['documents_valid_days'] ?? 14); ?>';
-      document.getElementById('expireWhenPaid').checked = false;
+      document.getElementById('expireWhenPaid').checked = true;
       toggleDaysInput();
     } else {
       alert('Error: ' + (data.error || 'Failed to revoke link'));

--- a/src/views/public/doc-wrapper.php
+++ b/src/views/public/doc-wrapper.php
@@ -58,7 +58,7 @@ if (in_array($type, ['invoice', 'project_invoice'], true)) {
             $showPayButton = $stripeConfigured
                 && !empty($invoiceData['finalized_at'])
                 && ($invoiceData['collection_mode'] ?? 'direct') === 'direct'
-                && in_array($invStatus, ['unpaid', 'partial'], true)
+                && in_array($invStatus, ['sent', 'unpaid', 'partial', 'overdue'], true)
                 && $calculatedAmountDue > 0;
             
             // Calculate surcharge info


### PR DESCRIPTION
## Summary

- Make invoice and project invoice public links stay active until paid or manually revoked instead of expiring after the document-valid-days window.
- Retrofit existing invoice public links when they are opened, viewed as PDF, used for Stripe checkout, or regenerated from the share modal.
- Allow sent and overdue invoices to show Stripe payment actions in public invoice views and invoice emails.
- Include organization content links when an invoice client belongs to an organization even if the invoice row itself does not store an organization id.

## Root Cause

Invoice public links were still created as normal date-expiring document links in several paths, and the Stripe payment display only treated unpaid/partial as payable. Content link lookup also missed the client organization fallback for invoices tied to a client org with no division.

## Validation

- php -l on all touched PHP files
- git diff --check