### PR TITLE
Repair API key schema compatibility

### DIFF
--- a/database/migrations/0004_repair_api_keys_schema.sql
+++ b/database/migrations/0004_repair_api_keys_schema.sql
@@ -1,0 +1,193 @@
+CREATE TABLE IF NOT EXISTS api_keys (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    organization_id INT NULL,
+    name VARCHAR(255) NOT NULL,
+    key_prefix VARCHAR(32) NOT NULL,
+    key_hash CHAR(64) NULL,
+    scopes VARCHAR(1024) NULL,
+    allowed_ips TEXT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at TIMESTAMP NULL,
+    revoked_at TIMESTAMP NULL,
+    INDEX idx_api_keys_prefix (key_prefix),
+    INDEX idx_api_keys_revoked (revoked_at),
+    INDEX idx_api_keys_org (organization_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @api_keys_item_name_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'item_name'
+);
+
+SET @api_keys_name_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'name'
+);
+
+SET @sql := IF(
+    @api_keys_item_name_exists = 1 AND @api_keys_name_exists = 0,
+    'ALTER TABLE api_keys CHANGE COLUMN item_name name VARCHAR(255) NOT NULL',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_organization_id_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'organization_id'
+);
+
+SET @sql := IF(
+    @api_keys_organization_id_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN organization_id INT NULL AFTER id',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_name_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'name'
+);
+
+SET @sql := IF(
+    @api_keys_name_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN name VARCHAR(255) NOT NULL DEFAULT '''' AFTER organization_id',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_key_prefix_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'key_prefix'
+);
+
+SET @sql := IF(
+    @api_keys_key_prefix_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN key_prefix VARCHAR(32) NOT NULL DEFAULT '''' AFTER name',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_key_hash_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'key_hash'
+);
+
+SET @sql := IF(
+    @api_keys_key_hash_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN key_hash CHAR(64) NULL AFTER key_prefix',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_scopes_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'scopes'
+);
+
+SET @sql := IF(
+    @api_keys_scopes_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN scopes VARCHAR(1024) NULL DEFAULT ''full'' AFTER key_hash',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_allowed_ips_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'allowed_ips'
+);
+
+SET @sql := IF(
+    @api_keys_allowed_ips_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN allowed_ips TEXT NULL AFTER scopes',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_created_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'created_at'
+);
+
+SET @sql := IF(
+    @api_keys_created_at_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER allowed_ips',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_last_used_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'last_used_at'
+);
+
+SET @sql := IF(
+    @api_keys_last_used_at_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN last_used_at TIMESTAMP NULL AFTER created_at',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_revoked_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'revoked_at'
+);
+
+SET @sql := IF(
+    @api_keys_revoked_at_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN revoked_at TIMESTAMP NULL AFTER last_used_at',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+UPDATE api_keys
+SET scopes = 'full'
+WHERE scopes IS NULL OR scopes = '';
+
+CREATE TABLE IF NOT EXISTS api_usage (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    api_key_id INT NOT NULL,
+    used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_api_usage_key_time (api_key_id, used_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/config/bootstrap.php
+++ b/src/config/bootstrap.php
@@ -64,6 +64,7 @@ try {
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
     );
     // API keys and usage
+    require_once __DIR__ . '/../utils/api_keys_schema.php';
     $pdo->exec(
         "CREATE TABLE IF NOT EXISTS api_keys (
             id INT AUTO_INCREMENT PRIMARY KEY,
@@ -89,6 +90,7 @@ try {
             CONSTRAINT fk_api_usage_key FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE CASCADE
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
     );
+    try { pa_ensure_api_keys_schema($pdo); } catch (Throwable $e) {}
     // Two-Factor Authentication tables
     $pdo->exec(
         "CREATE TABLE IF NOT EXISTS user_2fa (

--- a/src/controllers/api_keys_create.php
+++ b/src/controllers/api_keys_create.php
@@ -2,6 +2,7 @@
 // src/controllers/api_keys_create.php
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../utils/api_keys_schema.php';
 
 if (empty($_SESSION['user']) || (($_SESSION['user']['role'] ?? 'user') !== 'admin')) {
   header('Location: /?page=api-keys&error=' . urlencode('Only admins can create API keys'));
@@ -16,6 +17,7 @@ if ($name === '') {
 }
 
 try {
+  pa_ensure_api_keys_schema($pdo);
   $prefix = substr(bin2hex(random_bytes(6)), 0, 12);
   $secret = 'pa_live_' . $prefix . '_' . bin2hex(random_bytes(32));
   $hash = hash('sha256', $secret);

--- a/src/controllers/api_keys_revoke.php
+++ b/src/controllers/api_keys_revoke.php
@@ -2,6 +2,7 @@
 // src/controllers/api_keys_revoke.php
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../utils/api_keys_schema.php';
 
 if (empty($_SESSION['user']) || (($_SESSION['user']['role'] ?? 'user') !== 'admin')) {
   header('Location: /?page=api-keys&error=' . urlencode('Only admins can revoke API keys'));
@@ -12,6 +13,7 @@ $id = (int)($_POST['id'] ?? 0);
 if ($id <= 0) { header('Location: /?page=api-keys&error=' . urlencode('Invalid key')); exit; }
 
 try {
+  pa_ensure_api_keys_schema($pdo);
   $pdo->prepare('UPDATE api_keys SET revoked_at=NOW() WHERE id=?')->execute([$id]);
   header('Location: /?page=api-keys&revoked=1');
   exit;

--- a/src/migrations/migration_lib.php
+++ b/src/migrations/migration_lib.php
@@ -259,7 +259,8 @@ function migration_schema_health(PDO $pdo): void
         'quotes' => ['organization_id', 'created_by'],
         'contracts' => ['organization_id', 'created_by'],
         'invoices' => ['organization_id', 'created_by', 'collection_mode'],
-        'api_keys' => ['name', 'key_hash', 'scopes', 'revoked_at'],
+        'api_keys' => ['name', 'key_prefix', 'key_hash', 'scopes', 'allowed_ips', 'created_at', 'last_used_at', 'revoked_at'],
+        'api_usage' => ['api_key_id', 'used_at'],
         'client_onboarding_invitations' => ['organization_id', 'invited_email', 'token_hash', 'status'],
         'client_onboarding_submissions' => ['invitation_id', 'proposed_data', 'status'],
     ];

--- a/src/utils/api_auth.php
+++ b/src/utils/api_auth.php
@@ -2,6 +2,7 @@
 // src/utils/api_auth.php
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/api_keys_schema.php';
 
 function api_json_error(int $code, string $msg): void {
     header('Content-Type: application/json');
@@ -32,6 +33,7 @@ function api_require_key(array $requiredScopes = []) {
     if (!$token) api_json_error(401, 'Missing API key');
     $hash = hash('sha256', $token);
     try {
+        pa_ensure_api_keys_schema($pdo);
         $st = $pdo->prepare('SELECT * FROM api_keys WHERE key_hash=? AND (revoked_at IS NULL)');
         $st->execute([$hash]);
         $row = $st->fetch(PDO::FETCH_ASSOC);

--- a/src/utils/api_keys_schema.php
+++ b/src/utils/api_keys_schema.php
@@ -1,0 +1,101 @@
+<?php
+
+function pa_api_keys_table_has_column(PDO $pdo, string $column): bool
+{
+    try {
+        $stmt = $pdo->prepare(
+            'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?'
+        );
+        $stmt->execute(['api_keys', $column]);
+        return (bool)$stmt->fetchColumn();
+    } catch (Throwable $e) {
+        return false;
+    }
+}
+
+function pa_ensure_api_keys_schema(PDO $pdo): void
+{
+    static $done = false;
+    if ($done) {
+        return;
+    }
+
+    $pdo->exec(
+        "CREATE TABLE IF NOT EXISTS api_keys (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            organization_id INT NULL,
+            name VARCHAR(255) NOT NULL,
+            key_prefix VARCHAR(32) NOT NULL,
+            key_hash CHAR(64) NULL,
+            scopes VARCHAR(1024) NULL,
+            allowed_ips TEXT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            last_used_at TIMESTAMP NULL,
+            revoked_at TIMESTAMP NULL,
+            INDEX idx_api_keys_prefix (key_prefix),
+            INDEX idx_api_keys_revoked (revoked_at),
+            INDEX idx_api_keys_org (organization_id)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    );
+
+    if (pa_api_keys_table_has_column($pdo, 'item_name') && !pa_api_keys_table_has_column($pdo, 'name')) {
+        try {
+            $pdo->exec('ALTER TABLE api_keys CHANGE COLUMN item_name name VARCHAR(255) NOT NULL');
+        } catch (Throwable $e) {
+            @error_log('[ApiKeysSchema] Failed to rename item_name to name: ' . $e->getMessage());
+        }
+    }
+
+    $columns = [
+        'organization_id' => 'INT NULL AFTER id',
+        'name' => "VARCHAR(255) NOT NULL DEFAULT '' AFTER organization_id",
+        'key_prefix' => "VARCHAR(32) NOT NULL DEFAULT '' AFTER name",
+        'key_hash' => 'CHAR(64) NULL AFTER key_prefix',
+        'scopes' => "VARCHAR(1024) NULL DEFAULT 'full' AFTER key_hash",
+        'allowed_ips' => 'TEXT NULL AFTER scopes',
+        'created_at' => 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER allowed_ips',
+        'last_used_at' => 'TIMESTAMP NULL AFTER created_at',
+        'revoked_at' => 'TIMESTAMP NULL AFTER last_used_at',
+    ];
+
+    foreach ($columns as $column => $definition) {
+        if (!pa_api_keys_table_has_column($pdo, $column)) {
+            try {
+                $pdo->exec("ALTER TABLE api_keys ADD COLUMN {$column} {$definition}");
+            } catch (Throwable $e) {
+                @error_log('[ApiKeysSchema] Failed to add api_keys.' . $column . ': ' . $e->getMessage());
+            }
+        }
+    }
+
+    try {
+        $pdo->exec('UPDATE api_keys SET scopes = COALESCE(NULLIF(scopes, ""), "full") WHERE scopes IS NULL OR scopes = ""');
+    } catch (Throwable $e) {
+        @error_log('[ApiKeysSchema] Failed to normalize api key scopes: ' . $e->getMessage());
+    }
+
+    foreach ([
+        'CREATE UNIQUE INDEX uq_key_hash ON api_keys (key_hash)',
+        'CREATE INDEX idx_api_keys_prefix ON api_keys (key_prefix)',
+        'CREATE INDEX idx_api_keys_revoked ON api_keys (revoked_at)',
+        'CREATE INDEX idx_api_keys_org ON api_keys (organization_id)',
+    ] as $sql) {
+        try {
+            $pdo->exec($sql);
+        } catch (Throwable $e) {
+            // Index likely already exists under this or an older generated name.
+        }
+    }
+
+    $pdo->exec(
+        "CREATE TABLE IF NOT EXISTS api_usage (
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
+            api_key_id INT NOT NULL,
+            used_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_api_usage_key_time (api_key_id, used_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+    );
+
+    $done = true;
+}

--- a/src/views/pages/api-keys.php
+++ b/src/views/pages/api-keys.php
@@ -3,12 +3,20 @@
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/csrf.php';
+require_once __DIR__ . '/../../utils/api_keys_schema.php';
 
 if (empty($_SESSION['user'])) { echo '<p>Unauthorized</p>'; return; }
 $isAdmin = (($_SESSION['user']['role'] ?? 'user') === 'admin');
 if (!$isAdmin) { echo '<p>Only admins can manage API keys.</p>'; return; }
 
-$keys = $pdo->query("SELECT id, name, key_prefix, scopes, allowed_ips, created_at, last_used_at, revoked_at FROM api_keys ORDER BY created_at DESC")->fetchAll();
+try {
+  pa_ensure_api_keys_schema($pdo);
+  $keys = $pdo->query("SELECT id, name, key_prefix, scopes, allowed_ips, created_at, last_used_at, revoked_at FROM api_keys ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+} catch (Throwable $e) {
+  @error_log('[API Keys Page] Failed to load API keys: ' . $e->getMessage());
+  $keys = [];
+  $loadError = 'API key storage needs repair. Run the latest database migrations, then reload this page.';
+}
 $flash = $_SESSION['flash_api_key'] ?? null; unset($_SESSION['flash_api_key']);
 ?>
 <section>
@@ -19,6 +27,9 @@ $flash = $_SESSION['flash_api_key'] ?? null; unset($_SESSION['flash_api_key']);
   </div>
 
   <h2>API Keys</h2>
+  <?php if (!empty($loadError)): ?>
+    <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#fff3f3;color:#991b1b;border:1px solid #fecaca"><?php echo htmlspecialchars($loadError); ?></div>
+  <?php endif; ?>
   <?php if ($flash): ?>
     <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfeff;color:#164e63;border:1px solid #a5f3fc">
       New key generated. Copy it now — it will not be shown again:<br>


### PR DESCRIPTION
## Summary
- Adds migration 0004 to fully repair stale api_keys/api_usage schema on migrated installs.
- Adds a runtime API key schema guard so the API Keys page, create/revoke actions, and API auth do not white-screen on stale tables.
- Expands migration health checks to validate all API key columns the app uses.

## Validation
- php -l src/utils/api_keys_schema.php
- php -l src/views/pages/api-keys.php
- php -l src/controllers/api_keys_create.php
- php -l src/controllers/api_keys_revoke.php
- php -l src/utils/api_auth.php
- php -l src/config/bootstrap.php
- php src/migrations/run_migrations.php --validate-files