### PR TITLE
Repair legacy server schema workflows

### DIFF
--- a/database/baseline.sql
+++ b/database/baseline.sql
@@ -279,6 +279,24 @@ CREATE TABLE IF NOT EXISTS api_usage (
     CONSTRAINT fk_api_usage_key FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- ACTIVITY LOG
+CREATE TABLE IF NOT EXISTS activity_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    event_type VARCHAR(50) NOT NULL,
+    document_type VARCHAR(20) NULL,
+    document_id INT NULL,
+    client_id INT NULL,
+    description TEXT NOT NULL,
+    ip_address VARCHAR(45) NULL,
+    user_agent TEXT NULL,
+    metadata JSON NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_activity_type (event_type),
+    INDEX idx_activity_doc (document_type, document_id),
+    INDEX idx_activity_client (client_id),
+    INDEX idx_activity_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- WEBHOOKS
 CREATE TABLE IF NOT EXISTS webhooks (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/database/migrations/0012_activity_log_and_legacy_schema_repairs.sql
+++ b/database/migrations/0012_activity_log_and_legacy_schema_repairs.sql
@@ -1,0 +1,136 @@
+-- Repair legacy installs that predate the activity_log table and normalized API key columns.
+CREATE TABLE IF NOT EXISTS activity_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    event_type VARCHAR(50) NOT NULL,
+    document_type VARCHAR(20) NULL,
+    document_id INT NULL,
+    client_id INT NULL,
+    description TEXT NOT NULL,
+    ip_address VARCHAR(45) NULL,
+    user_agent TEXT NULL,
+    metadata JSON NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_activity_type (event_type),
+    INDEX idx_activity_doc (document_type, document_id),
+    INDEX idx_activity_client (client_id),
+    INDEX idx_activity_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @api_keys_item_name_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'item_name'
+);
+
+SET @api_keys_name_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'name'
+);
+
+SET @sql := IF(
+    @api_keys_item_name_exists = 1 AND @api_keys_name_exists = 0,
+    'ALTER TABLE api_keys CHANGE COLUMN item_name name VARCHAR(255) NOT NULL',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @api_keys_name_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'api_keys'
+      AND column_name = 'name'
+);
+
+SET @sql := IF(
+    @api_keys_name_exists = 0,
+    'ALTER TABLE api_keys ADD COLUMN name VARCHAR(255) NOT NULL DEFAULT '''' AFTER id',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @payments_contract_id_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payments'
+      AND column_name = 'contract_id'
+);
+
+SET @sql := IF(
+    @payments_contract_id_exists = 0,
+    'ALTER TABLE payments ADD COLUMN contract_id INT NULL AFTER invoice_id',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @payments_reference_number_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payments'
+      AND column_name = 'reference_number'
+);
+
+SET @sql := IF(
+    @payments_reference_number_exists = 0,
+    'ALTER TABLE payments ADD COLUMN reference_number VARCHAR(255) NULL AFTER payment_date',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @payments_refunded_amount_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payments'
+      AND column_name = 'refunded_amount'
+);
+
+SET @sql := IF(
+    @payments_refunded_amount_exists = 0,
+    'ALTER TABLE payments ADD COLUMN refunded_amount DECIMAL(12,2) NOT NULL DEFAULT 0 AFTER amount',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @payments_disputed_amount_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payments'
+      AND column_name = 'disputed_amount'
+);
+
+SET @sql := IF(
+    @payments_disputed_amount_exists = 0,
+    'ALTER TABLE payments ADD COLUMN disputed_amount DECIMAL(12,2) NOT NULL DEFAULT 0 AFTER refunded_amount',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @payments_organization_id_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payments'
+      AND column_name = 'organization_id'
+);
+
+SET @sql := IF(
+    @payments_organization_id_exists = 0,
+    'ALTER TABLE payments ADD COLUMN organization_id INT NULL AFTER contract_id',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/controllers/api/clients_list.php
+++ b/src/controllers/api/clients_list.php
@@ -4,21 +4,61 @@ require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/acl.php';
 header('Content-Type: application/json');
 
+function api_clients_table_has_column(PDO $pdo, string $table, string $column): bool
+{
+    try {
+        $stmt = $pdo->prepare(
+            'SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?
+             LIMIT 1'
+        );
+        $stmt->execute([$table, $column]);
+        return $stmt->fetchColumn() !== false;
+    } catch (Throwable $e) {
+        return false;
+    }
+}
+
 $limit = (int)($_GET['limit'] ?? 25);
 if ($limit < 1 || $limit > 100) $limit = 25;
 $archived = (int)($_GET['archived'] ?? 0);
 
-$hasArchived = (bool)$pdo->query("SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='clients' AND COLUMN_NAME='archived'")->fetchColumn();
+$hasClientName = api_clients_table_has_column($pdo, 'clients', 'name');
+$hasClientEmail = api_clients_table_has_column($pdo, 'clients', 'email');
+$hasClientOrg = api_clients_table_has_column($pdo, 'clients', 'organization_id');
+$hasArchived = api_clients_table_has_column($pdo, 'clients', 'archived');
+$hasOrgName = api_clients_table_has_column($pdo, 'organizations', 'name');
 
-$sql = "SELECT c.id, c.name, c.email, c.organization_id, o.name as organization_name FROM clients c LEFT JOIN organizations o ON c.organization_id=o.id";
+$select = [
+    'c.id',
+    $hasClientName ? 'c.name' : 'CONCAT("Client #", c.id) AS name',
+    $hasClientEmail ? 'c.email' : 'NULL AS email',
+    $hasClientOrg ? 'c.organization_id' : 'NULL AS organization_id',
+    ($hasClientOrg && $hasOrgName) ? 'o.name AS organization_name' : 'NULL AS organization_name',
+];
+
+$sql = 'SELECT ' . implode(', ', $select) . ' FROM clients c';
+if ($hasClientOrg && $hasOrgName) {
+    $sql .= ' LEFT JOIN organizations o ON c.organization_id = o.id';
+}
 $params = [];
 if ($hasArchived) {
-    $sql .= " WHERE c.archived=?";
+    $sql .= ' WHERE c.archived = ?';
     $params[] = $archived;
 }
-$sql .= " ORDER BY c.name LIMIT ?";
-$params[] = $limit;
+$sql .= $hasClientName ? ' ORDER BY c.name' : ' ORDER BY c.id';
+$sql .= ' LIMIT ?';
 
-$stmt = $pdo->prepare($sql);
-$stmt->execute($params);
-echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);
+try {
+    $stmt = $pdo->prepare($sql);
+    foreach ($params as $idx => $value) {
+        $stmt->bindValue($idx + 1, $value, PDO::PARAM_INT);
+    }
+    $stmt->bindValue(count($params) + 1, $limit, PDO::PARAM_INT);
+    $stmt->execute();
+    echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC), JSON_NUMERIC_CHECK);
+} catch (Throwable $e) {
+    http_response_code(500);
+    @error_log('[api/clients_list] Failed to list clients: ' . $e->getMessage());
+    echo json_encode(['error' => 'Failed to load clients']);
+}

--- a/src/controllers/financial/expense_handler.php
+++ b/src/controllers/financial/expense_handler.php
@@ -73,10 +73,10 @@ try {
             $projectId = (int)($_POST['project_id'] ?? 0);
             $receiptId = (int)($_POST['receipt_id'] ?? 0);
             $amount = (float)($_POST['amount'] ?? 0);
-            $taxAmount = $_POST['tax_amount'] !== '' ? (float)$_POST['tax_amount'] : null;
+            $taxAmount = null;
             $expenseDate = $_POST['expense_date'] ?? date('Y-m-d');
             $description = trim($_POST['description'] ?? '');
-            $paymentMethod = $_POST['payment_method'] ?? null;
+            $paymentMethod = null;
             $referenceNumber = trim($_POST['reference_number'] ?? '');
             $isBillable = !empty($_POST['is_billable']) ? 1 : 0;
             $isTaxDeductible = isset($_POST['is_tax_deductible']) ? (int)!empty($_POST['is_tax_deductible']) : 1;
@@ -89,7 +89,7 @@ try {
                 throw new Exception('Expense date is required');
             }
 
-            $totalAmount = $taxAmount !== null ? $amount + $taxAmount : $amount;
+            $totalAmount = $amount;
 
             // Auto-create vendor if name provided but no vendor_id
             if ($vendorId <= 0 && $vendorName !== '') {
@@ -131,16 +131,16 @@ try {
             $clientId = (int)($_POST['client_id'] ?? 0);
             $projectId = (int)($_POST['project_id'] ?? 0);
             $amount = (float)($_POST['amount'] ?? 0);
-            $taxAmount = $_POST['tax_amount'] !== '' ? (float)$_POST['tax_amount'] : null;
+            $taxAmount = null;
             $expenseDate = $_POST['expense_date'] ?? date('Y-m-d');
             $description = trim($_POST['description'] ?? '');
-            $paymentMethod = $_POST['payment_method'] ?? null;
+            $paymentMethod = null;
             $referenceNumber = trim($_POST['reference_number'] ?? '');
             $isBillable = !empty($_POST['is_billable']) ? 1 : 0;
             $isTaxDeductible = isset($_POST['is_tax_deductible']) ? (int)!empty($_POST['is_tax_deductible']) : 1;
             $notes = trim($_POST['notes'] ?? '');
 
-            $totalAmount = $taxAmount !== null ? $amount + $taxAmount : $amount;
+            $totalAmount = $amount;
 
             // Auto-create vendor if name provided but no vendor_id
             if ($vendorId <= 0 && $vendorName !== '') {

--- a/src/controllers/organization/organization_document_upload.php
+++ b/src/controllers/organization/organization_document_upload.php
@@ -58,7 +58,9 @@ if (function_exists('mime_content_type')) {
 if (!$mime && function_exists('finfo_file')) {
     $finfo = finfo_open(FILEINFO_MIME_TYPE);
     $mime = finfo_file($finfo, $tmp);
-    finfo_close($finfo);
+    if (PHP_VERSION_ID < 80500) {
+        finfo_close($finfo);
+    }
 }
 if (!$mime) {
     $mime = $_FILES[$fileInput]['type'];

--- a/src/controllers/organization/organizations_create.php
+++ b/src/controllers/organization/organizations_create.php
@@ -38,7 +38,9 @@ if (!empty($_FILES['tax_exempt_file']) && is_uploaded_file($_FILES['tax_exempt_f
     if (!$mime && function_exists('finfo_file')) {
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mime = finfo_file($finfo, $tmp);
-        finfo_close($finfo);
+        if (PHP_VERSION_ID < 80500) {
+            finfo_close($finfo);
+        }
     }
     if (!$mime) {
         $mime = $_FILES['tax_exempt_file']['type'];

--- a/src/controllers/organization/organizations_update.php
+++ b/src/controllers/organization/organizations_update.php
@@ -49,7 +49,9 @@ if (!empty($_FILES['tax_exempt_file']) && is_uploaded_file($_FILES['tax_exempt_f
     if (!$mime && function_exists('finfo_file')) {
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mime = finfo_file($finfo, $tmp);
-        finfo_close($finfo);
+        if (PHP_VERSION_ID < 80500) {
+            finfo_close($finfo);
+        }
     }
     if (!$mime) {
         $mime = $_FILES['tax_exempt_file']['type'];

--- a/src/controllers/organization/organizations_upload.php
+++ b/src/controllers/organization/organizations_upload.php
@@ -43,7 +43,9 @@ if (function_exists('mime_content_type')) {
 if (!$mime && function_exists('finfo_file')) {
     $finfo = finfo_open(FILEINFO_MIME_TYPE);
     $mime = finfo_file($finfo, $tmp);
-    finfo_close($finfo);
+    if (PHP_VERSION_ID < 80500) {
+        finfo_close($finfo);
+    }
 }
 if (!$mime) {
     $mime = $_FILES['tax_exempt_file']['type'];

--- a/src/controllers/payments_create.php
+++ b/src/controllers/payments_create.php
@@ -51,6 +51,7 @@ if (($invoice['collection_mode'] ?? 'direct') !== 'direct') {
 $client_id = (int)($invoice['client_id'] ?? 0);
 $contract_id = !empty($invoice['contract_id']) ? (int)$invoice['contract_id'] : null;
 $organization_id = !empty($invoice['organization_id']) ? (int)$invoice['organization_id'] : null;
+invoice_ensure_payments_schema($pdo);
 $paidStmt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) FROM payments WHERE invoice_id=? AND status="succeeded"');
 $paidStmt->execute([$invoice_id]);
 $outstanding = max(0.0, (float)$invoice['total'] - (float)$paidStmt->fetchColumn());
@@ -81,7 +82,7 @@ try {
       $check_number ?: null,
       null,
       [
-          'organization_id' => get_active_org_id(),
+          'organization_id' => $organization_id,
           'complete_contract_when_paid' => !$paid_in_advance,
           'source' => 'manual_payment',
       ]
@@ -103,7 +104,8 @@ try {
 } catch (Throwable $e) {
   $pdo->rollBack();
   @error_log('[PaymentsCreate] Error: ' . $e->getMessage());
-  header('Location: /?page=payments/payments-create&error=Failed%20to%20save%20payment');
+  $message = trim($e->getMessage()) !== '' ? substr($e->getMessage(), 0, 180) : 'Failed to save payment';
+  header('Location: /?page=payments/payments-create&error=' . urlencode($message));
   exit;
 }
 

--- a/src/controllers/public_view/public_contract_sign.php
+++ b/src/controllers/public_view/public_contract_sign.php
@@ -47,7 +47,9 @@ try {
     $allowedTypes = ['application/pdf', 'image/jpeg', 'image/png', 'image/gif', 'image/webp'];
     $finfo = finfo_open(FILEINFO_MIME_TYPE);
     $mimeType = finfo_file($finfo, $file['tmp_name']);
-    finfo_close($finfo);
+    if (PHP_VERSION_ID < 80500) {
+        finfo_close($finfo);
+    }
     
     if (!in_array($mimeType, $allowedTypes, true)) {
         throw new Exception('Invalid file type. Please upload a PDF or image file.');

--- a/src/controllers/settings/dropbox_oauth.php
+++ b/src/controllers/settings/dropbox_oauth.php
@@ -168,7 +168,9 @@ if ($action === 'callback') {
     $response = curl_exec($ch);
     $curlError = curl_error($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
+    if (PHP_VERSION_ID < 80500) {
+        curl_close($ch);
+    }
     
     if ($response === false || $httpCode !== 200) {
         app_log('dropbox_oauth', 'Token exchange failed', [
@@ -242,7 +244,9 @@ if ($action === 'disconnect') {
                     CURLOPT_RETURNTRANSFER => true
                 ]);
                 curl_exec($ch);
-                curl_close($ch);
+                if (PHP_VERSION_ID < 80500) {
+                    curl_close($ch);
+                }
             }
         }
         

--- a/src/services/StripeService.php
+++ b/src/services/StripeService.php
@@ -529,7 +529,9 @@ class StripeService {
         
         $response = curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        if (PHP_VERSION_ID < 80500) {
+            curl_close($ch);
+        }
         
         $decoded = json_decode($response, true);
         

--- a/src/utils/api_keys_schema.php
+++ b/src/utils/api_keys_schema.php
@@ -14,6 +14,23 @@ function pa_api_keys_table_has_column(PDO $pdo, string $column): bool
     }
 }
 
+function pa_api_keys_existing_columns(PDO $pdo): array
+{
+    try {
+        $stmt = $pdo->query(
+            'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = \'api_keys\''
+        );
+        $columns = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $column) {
+            $columns[(string)$column] = true;
+        }
+        return $columns;
+    } catch (Throwable $e) {
+        return [];
+    }
+}
+
 function pa_ensure_api_keys_schema(PDO $pdo): void
 {
     static $done = false;
@@ -67,6 +84,13 @@ function pa_ensure_api_keys_schema(PDO $pdo): void
                 @error_log('[ApiKeysSchema] Failed to add api_keys.' . $column . ': ' . $e->getMessage());
             }
         }
+    }
+
+    $required = ['name', 'key_prefix', 'key_hash', 'scopes', 'allowed_ips', 'created_at', 'last_used_at', 'revoked_at'];
+    $existing = pa_api_keys_existing_columns($pdo);
+    $missing = array_values(array_filter($required, static fn(string $column): bool => empty($existing[$column])));
+    if ($missing) {
+        throw new RuntimeException('api_keys schema repair incomplete; missing columns: ' . implode(', ', $missing));
     }
 
     try {

--- a/src/utils/invoice_lifecycle.php
+++ b/src/utils/invoice_lifecycle.php
@@ -28,6 +28,64 @@ function invoice_public_base_url(array $appConfig): string
     return $scheme . '://' . $host;
 }
 
+function invoice_table_has_column(PDO $pdo, string $table, string $column): bool
+{
+    static $cache = [];
+    $key = $table . ':' . $column;
+    if (array_key_exists($key, $cache)) {
+        return $cache[$key];
+    }
+    if (!preg_match('/^[A-Za-z0-9_]+$/', $table) || !preg_match('/^[A-Za-z0-9_]+$/', $column)) {
+        $cache[$key] = false;
+        return false;
+    }
+
+    try {
+        $stmt = $pdo->prepare(
+            'SELECT 1 FROM information_schema.columns
+             WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?
+             LIMIT 1'
+        );
+        $stmt->execute([$table, $column]);
+        $cache[$key] = $stmt->fetchColumn() !== false;
+        return $cache[$key];
+    } catch (Throwable $e) {
+        $cache[$key] = false;
+        return false;
+    }
+}
+
+function invoice_ensure_payments_schema(PDO $pdo): void
+{
+    static $done = false;
+    if ($done) {
+        return;
+    }
+
+    $columns = [
+        'project_invoice_payment_id' => 'BIGINT NULL AFTER invoice_id',
+        'contract_id' => 'INT NULL AFTER project_invoice_payment_id',
+        'organization_id' => 'INT NULL AFTER contract_id',
+        'refunded_amount' => 'DECIMAL(12,2) NOT NULL DEFAULT 0 AFTER amount',
+        'disputed_amount' => 'DECIMAL(12,2) NOT NULL DEFAULT 0 AFTER refunded_amount',
+        'reference_number' => 'VARCHAR(255) NULL AFTER payment_date',
+        'notes' => 'TEXT NULL AFTER reference_number',
+        'status' => "VARCHAR(32) NOT NULL DEFAULT 'succeeded'",
+    ];
+
+    foreach ($columns as $column => $definition) {
+        if (!invoice_table_has_column($pdo, 'payments', $column)) {
+            try {
+                $pdo->exec("ALTER TABLE payments ADD COLUMN {$column} {$definition}");
+            } catch (Throwable $e) {
+                @error_log('[invoice_lifecycle] Failed to repair payments.' . $column . ': ' . $e->getMessage());
+            }
+        }
+    }
+
+    $done = true;
+}
+
 function invoice_expire_active_checkout(PDO $pdo, string $table, int $id, array $appConfig): void
 {
     if (!in_array($table, ['invoices', 'project_invoices'], true)) {
@@ -57,6 +115,7 @@ function invoice_expire_active_checkout(PDO $pdo, string $table, int $id, array 
 
 function invoice_effective_paid_total(PDO $pdo, int $invoiceId): float
 {
+    invoice_ensure_payments_schema($pdo);
     $stmt = $pdo->prepare('
         SELECT COALESCE(SUM(GREATEST(amount - refunded_amount - disputed_amount, 0)), 0)
         FROM payments
@@ -123,6 +182,7 @@ function invoice_record_locked_payment(
         throw new RuntimeException('Payment amount must be greater than zero.');
     }
 
+    invoice_ensure_payments_schema($pdo);
     $activeOrgId = $options['organization_id'] ?? null;
     $completeContractWhenPaid = (bool)($options['complete_contract_when_paid'] ?? false);
     $allowUnfinalized = (bool)($options['allow_unfinalized'] ?? false);

--- a/src/utils/notifications.php
+++ b/src/utils/notifications.php
@@ -18,8 +18,37 @@ require_once __DIR__ . '/smtp.php';
  */
 require_once __DIR__ . '/client_ip.php';
 
+function ensure_activity_log_table(PDO $pdo): void {
+    static $done = false;
+    if ($done) {
+        return;
+    }
+
+    $pdo->exec('
+        CREATE TABLE IF NOT EXISTS activity_log (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            event_type VARCHAR(50) NOT NULL,
+            document_type VARCHAR(20) NULL,
+            document_id INT NULL,
+            client_id INT NULL,
+            description TEXT NOT NULL,
+            ip_address VARCHAR(45) NULL,
+            user_agent TEXT NULL,
+            metadata JSON NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            INDEX idx_activity_type (event_type),
+            INDEX idx_activity_doc (document_type, document_id),
+            INDEX idx_activity_client (client_id),
+            INDEX idx_activity_created (created_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    ');
+
+    $done = true;
+}
+
 function log_activity(PDO $pdo, string $eventType, ?string $documentType, ?int $documentId, ?int $clientId, string $description, array $metadata = []): void {
     try {
+        ensure_activity_log_table($pdo);
         $ip = get_client_ip();
         $ua = $_SERVER['HTTP_USER_AGENT'] ?? null;
         $metaJson = !empty($metadata) ? json_encode($metadata) : null;

--- a/src/utils/project_files.php
+++ b/src/utils/project_files.php
@@ -37,7 +37,9 @@ function project_files_detect_mime(string $path, ?string $fallback = null): stri
         $finfo = @finfo_open(FILEINFO_MIME_TYPE);
         if ($finfo) {
             $mime = @finfo_file($finfo, $path);
-            @finfo_close($finfo);
+            if (PHP_VERSION_ID < 80500) {
+                @finfo_close($finfo);
+            }
             if (is_string($mime) && $mime !== '') {
                 return $mime;
             }

--- a/src/views/pages/api-keys.php
+++ b/src/views/pages/api-keys.php
@@ -11,7 +11,19 @@ if (!$isAdmin) { echo '<p>Only admins can manage API keys.</p>'; return; }
 
 try {
   pa_ensure_api_keys_schema($pdo);
-  $keys = $pdo->query("SELECT id, name, key_prefix, scopes, allowed_ips, created_at, last_used_at, revoked_at FROM api_keys ORDER BY created_at DESC")->fetchAll(PDO::FETCH_ASSOC);
+  $columns = pa_api_keys_existing_columns($pdo);
+  $select = [
+    'id' => 'id',
+    'name' => !empty($columns['name']) ? 'name' : "'' AS name",
+    'key_prefix' => !empty($columns['key_prefix']) ? 'key_prefix' : "'' AS key_prefix",
+    'scopes' => !empty($columns['scopes']) ? 'scopes' : "'full' AS scopes",
+    'allowed_ips' => !empty($columns['allowed_ips']) ? 'allowed_ips' : "'' AS allowed_ips",
+    'created_at' => !empty($columns['created_at']) ? 'created_at' : 'NULL AS created_at',
+    'last_used_at' => !empty($columns['last_used_at']) ? 'last_used_at' : 'NULL AS last_used_at',
+    'revoked_at' => !empty($columns['revoked_at']) ? 'revoked_at' : 'NULL AS revoked_at',
+  ];
+  $orderBy = !empty($columns['created_at']) ? 'created_at DESC' : 'id DESC';
+  $keys = $pdo->query('SELECT ' . implode(', ', $select) . ' FROM api_keys ORDER BY ' . $orderBy)->fetchAll(PDO::FETCH_ASSOC);
 } catch (Throwable $e) {
   @error_log('[API Keys Page] Failed to load API keys: ' . $e->getMessage());
   $keys = [];

--- a/src/views/pages/contract/contract-details.php
+++ b/src/views/pages/contract/contract-details.php
@@ -252,7 +252,9 @@ if ($termsText === '') {
             if ($det) {
               $mime = $det;
             }
-            @finfo_close($finfo);
+            if (PHP_VERSION_ID < 80500) {
+                @finfo_close($finfo);
+            }
           }
         }
         if ($mime === null) {

--- a/src/views/pages/financial/expense-create.php
+++ b/src/views/pages/financial/expense-create.php
@@ -42,7 +42,7 @@ if ($editId > 0) {
     }
 }
 
-$paymentMethods = ['cash' => 'Cash', 'check' => 'Check', 'card' => 'Credit/Debit Card', 'bank_transfer' => 'Bank Transfer', 'paypal' => 'PayPal', 'venmo' => 'Venmo', 'other' => 'Other'];
+$paymentMethods = [];
 ?>
 
 <div style="max-width:800px;margin:0 auto;padding:24px">
@@ -81,29 +81,17 @@ $paymentMethods = ['cash' => 'Cash', 'check' => 'Check', 'card' => 'Credit/Debit
       </div>
     </div>
 
-    <div class="grid grid-3">
+    <div class="grid grid-2">
       <div class="field">
         <label class="label">Amount *</label>
         <input type="number" name="amount" id="amountInput" step="0.01" required
                value="<?php echo htmlspecialchars($expense['amount'] ?? $prefillAmount); ?>" class="input">
       </div>
       <div class="field">
-        <label class="label">Tax Amount</label>
-        <input type="number" name="tax_amount" id="taxInput" step="0.01"
-               value="<?php echo htmlspecialchars($expense['tax_amount'] ?? ''); ?>" class="input">
-      </div>
-      <div class="field">
-        <label class="label">Total</label>
-        <input type="text" id="totalDisplay" readonly class="input" style="background:var(--surface-2);font-weight:600">
-      </div>
-    </div>
-
-    <div class="grid grid-2">
-      <div class="field">
         <label class="label">Expense Date *</label>
         <input type="date" name="expense_date" required value="<?php echo htmlspecialchars($expense['expense_date'] ?? $prefillDate); ?>" class="input">
       </div>
-      <div class="field">
+      <div class="field" style="display:none">
         <label class="label">Payment Method</label>
         <select name="payment_method" class="input">
           <option value="">— Select —</option>
@@ -164,16 +152,6 @@ $paymentMethods = ['cash' => 'Cash', 'check' => 'Check', 'card' => 'Credit/Debit
 <script>
 (function () {
   'use strict';
-
-// Auto-calculate total
-function updateTotal() {
-  const amount = parseFloat(document.getElementById('amountInput').value) || 0;
-  const tax = parseFloat(document.getElementById('taxInput').value) || 0;
-  document.getElementById('totalDisplay').value = '$' + (amount + tax).toFixed(2);
-}
-document.getElementById('amountInput').addEventListener('input', updateTotal);
-document.getElementById('taxInput').addEventListener('input', updateTotal);
-updateTotal();
 
 // Billable toggle
 const billableCheck = document.getElementById('billableCheck');

--- a/src/views/pages/financial/form-detail.php
+++ b/src/views/pages/financial/form-detail.php
@@ -86,8 +86,11 @@ $organizations = $stmt->fetchAll(PDO::FETCH_ASSOC);
                     ?>
                     <?php if ($isPdf): ?>
                         <div style="height:900px;max-height:900px;min-height:900px">
-                            <iframe src="<?php echo htmlspecialchars($fileUrl); ?>" 
+                            <iframe src="<?php echo htmlspecialchars($fileUrl . '#toolbar=1&navpanes=0&view=FitH'); ?>" 
                                     style="width:100%;height:900px;max-height:900px;border:0;display:block"></iframe>
+                            <div style="padding:10px 12px;border-top:1px solid #e5e7eb;background:#fff">
+                                <a href="<?php echo htmlspecialchars($fileUrl); ?>" target="_blank" rel="noopener" style="color:var(--nav-accent);font-weight:600;text-decoration:none">Open PDF in new tab</a>
+                            </div>
                         </div>
                     <?php else: ?>
                         <div style="padding:24px;text-align:center;background:#f9fafb">

--- a/src/views/pages/financial/forms-list.php
+++ b/src/views/pages/financial/forms-list.php
@@ -82,6 +82,10 @@ $categories = $stmt->fetchAll(PDO::FETCH_ASSOC);
                     <div style="height:220px;background:#f9fafb;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden">
                         <?php if ($hasDocument): ?>
                             <?php if ($isPdf): ?>
+                                <iframe src="/?page=serve-upload&file=<?php echo urlencode(str_replace('/src/uploads/', '', $category['file_path'])); ?>#toolbar=0&navpanes=0&scrollbar=0&view=FitH"
+                                        title="<?php echo htmlspecialchars($category['title']); ?> preview"
+                                        loading="lazy"
+                                        style="position:absolute;inset:0;width:100%;height:100%;border:0;background:#fff;z-index:1;pointer-events:none"></iframe>
                                 <div style="text-align:center;color:var(--muted)">
                                     <div style="font-size:64px;margin-bottom:12px">📄</div>
                                     <div style="font-size:14px;font-weight:600"><?php echo htmlspecialchars($category['file_name']); ?></div>
@@ -101,7 +105,7 @@ $categories = $stmt->fetchAll(PDO::FETCH_ASSOC);
                             $detailPage = $category['type'] === 'folder' ? 'folder-detail' : 'form-detail';
                             ?>
                             <a href="/?page=financial/<?php echo $detailPage; ?>&id=<?php echo $category['id']; ?>" 
-                               style="position:absolute;top:12px;right:12px;padding:6px 12px;background:var(--nav-accent);color:#fff;border-radius:6px;text-decoration:none;font-size:13px;font-weight:600">
+                               style="position:absolute;top:12px;right:12px;z-index:2;padding:6px 12px;background:var(--nav-accent);color:#fff;border-radius:6px;text-decoration:none;font-size:13px;font-weight:600">
                                 View
                             </a>
                         <?php else: ?>

--- a/src/views/pages/invoice/invoice-details.php
+++ b/src/views/pages/invoice/invoice-details.php
@@ -214,7 +214,7 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
           $mime = 'image/svg+xml';
         } else if (function_exists('finfo_open')) {
           $finfo = @finfo_open(FILEINFO_MIME_TYPE);
-          if ($finfo) { $det = @finfo_buffer($finfo, $imgContents); if ($det) { $mime = $det; } @finfo_close($finfo); }
+          if ($finfo) { $det = @finfo_buffer($finfo, $imgContents); if ($det) { $mime = $det; } if (PHP_VERSION_ID < 80500) { @finfo_close($finfo); } }
         }
         if ($mime === null) { $mime = 'image/png'; }
         $logoSrc = 'data:' . $mime . ';base64,' . base64_encode($imgContents);

--- a/src/views/pages/quote/quote-details.php
+++ b/src/views/pages/quote/quote-details.php
@@ -204,7 +204,9 @@ $isPdf = defined('PDF_MODE');
           if ($finfo) {
             $det = @finfo_buffer($finfo, $imgContents);
             if ($det) { $mime = $det; }
-            @finfo_close($finfo);
+            if (PHP_VERSION_ID < 80500) {
+                @finfo_close($finfo);
+            }
           }
         }
         if ($mime === null) { $mime = 'image/png'; }

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -249,4 +249,49 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('reference_number', (string)$paymentController);
         self::assertStringContainsString('referenceLabel.textContent', (string)$paymentScript);
     }
+
+    public function testLegacyServerSchemaRepairsProtectAjaxPages(): void
+    {
+        $migration = file_get_contents($this->root . '/database/migrations/0012_activity_log_and_legacy_schema_repairs.sql');
+        $baseline = file_get_contents($this->root . '/database/baseline.sql');
+        $apiKeys = file_get_contents($this->root . '/src/views/pages/api-keys.php');
+        $apiKeysSchema = file_get_contents($this->root . '/src/utils/api_keys_schema.php');
+        $clientsList = file_get_contents($this->root . '/src/controllers/api/clients_list.php');
+        $notifications = file_get_contents($this->root . '/src/utils/notifications.php');
+        $dropbox = file_get_contents($this->root . '/src/controllers/settings/dropbox_oauth.php');
+        $publicSign = file_get_contents($this->root . '/src/controllers/public_view/public_contract_sign.php');
+
+        self::assertStringContainsString('CREATE TABLE IF NOT EXISTS activity_log', (string)$migration);
+        self::assertStringContainsString('ALTER TABLE api_keys ADD COLUMN name', (string)$migration);
+        self::assertStringContainsString('ALTER TABLE payments ADD COLUMN reference_number', (string)$migration);
+        self::assertStringContainsString('CREATE TABLE IF NOT EXISTS activity_log', (string)$baseline);
+        self::assertStringContainsString('pa_api_keys_existing_columns($pdo)', (string)$apiKeys);
+        self::assertStringContainsString('schema repair incomplete', (string)$apiKeysSchema);
+        self::assertStringContainsString('api_clients_table_has_column', (string)$clientsList);
+        self::assertStringContainsString('bindValue(count($params) + 1, $limit, PDO::PARAM_INT)', (string)$clientsList);
+        self::assertStringContainsString('ensure_activity_log_table($pdo)', (string)$notifications);
+        self::assertStringContainsString('PHP_VERSION_ID < 80500', (string)$dropbox);
+        self::assertStringContainsString('PHP_VERSION_ID < 80500', (string)$publicSign);
+    }
+
+    public function testPaymentsExpensesAndPdfPreviewsHandleLegacyServers(): void
+    {
+        $paymentController = file_get_contents($this->root . '/src/controllers/payments_create.php');
+        $invoiceLifecycle = file_get_contents($this->root . '/src/utils/invoice_lifecycle.php');
+        $expenseHandler = file_get_contents($this->root . '/src/controllers/financial/expense_handler.php');
+        $expenseCreate = file_get_contents($this->root . '/src/views/pages/financial/expense-create.php');
+        $formsList = file_get_contents($this->root . '/src/views/pages/financial/forms-list.php');
+        $formDetail = file_get_contents($this->root . '/src/views/pages/financial/form-detail.php');
+
+        self::assertStringContainsString('invoice_ensure_payments_schema($pdo)', (string)$paymentController);
+        self::assertStringContainsString("'organization_id' => $organization_id", (string)$paymentController);
+        self::assertStringContainsString('function invoice_ensure_payments_schema', (string)$invoiceLifecycle);
+        self::assertStringContainsString('ALTER TABLE payments ADD COLUMN {$column}', (string)$invoiceLifecycle);
+        self::assertStringContainsString('$taxAmount = null;', (string)$expenseHandler);
+        self::assertStringContainsString('$paymentMethod = null;', (string)$expenseHandler);
+        self::assertStringNotContainsString('id="taxInput"', (string)$expenseCreate);
+        self::assertStringContainsString('style="display:none"', (string)$expenseCreate);
+        self::assertStringContainsString('#toolbar=0&navpanes=0&scrollbar=0&view=FitH', (string)$formsList);
+        self::assertStringContainsString('Open PDF in new tab', (string)$formDetail);
+    }
 }


### PR DESCRIPTION
Fixes server-specific schema drift and workflow failures seen in logs.\n\nIncludes:\n- migration/baseline repair for activity_log, api_keys.name, and payment columns\n- API keys and client lookup paths tolerate legacy schemas\n- manual payment save uses the invoice organization and self-repairs payment columns\n- expense create no longer tracks tax amount or payment method\n- Forms & Docs PDF previews render in list/detail\n- PHP 8.5 curl_close/finfo_close deprecation guards