### PR TITLE
Fix expense saves and PDF previews

### DIFF
--- a/src/utils/security_headers.php
+++ b/src/utils/security_headers.php
@@ -8,8 +8,8 @@ function send_security_headers(): void {
         || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
         || (!empty($_SERVER['HTTP_CF_VISITOR']) && strpos((string)$_SERVER['HTTP_CF_VISITOR'], 'https') !== false);
 
-    // Prevent clickjacking by denying framing entirely.
-    header('X-Frame-Options: DENY');
+    // Prevent cross-site clickjacking while allowing PA to embed its own PDF previews.
+    header('X-Frame-Options: SAMEORIGIN');
     // Prevent MIME-sniffing attacks.
     header('X-Content-Type-Options: nosniff');
     // Deprecated but retained for legacy browser defense-in-depth.
@@ -25,7 +25,7 @@ function send_security_headers(): void {
     // Hardened Content Security Policy. unsafe-inline is required by the existing
     // inline scripts/styles in this legacy codebase; remove as code is migrated.
     // Upgrade mixed content only when serving over HTTPS.
-    $csp = "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; connect-src 'self' https://api.stripe.com; frame-src https://js.stripe.com https://hooks.stripe.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';";
+    $csp = "Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob:; connect-src 'self' https://api.stripe.com; frame-src 'self' https://js.stripe.com https://hooks.stripe.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self';";
     if ($isHttps) {
         $csp .= ' upgrade-insecure-requests;';
     }

--- a/src/views/pages/financial/expense-create.php
+++ b/src/views/pages/financial/expense-create.php
@@ -51,6 +51,13 @@ $paymentMethods = [];
     <a href="/?page=financial/expenses-list" class="btn btn-sm">Back to Expenses</a>
   </div>
 
+  <?php if (!empty($_GET['error'])): ?>
+    <div class="alert alert-danger" style="margin-bottom:16px"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['created']) || !empty($_GET['updated'])): ?>
+    <div class="alert alert-success" style="margin-bottom:16px">Expense saved.</div>
+  <?php endif; ?>
+
   <form id="expenseForm" method="post" action="/?page=financial/expense-handler" class="card">
     <input type="hidden" name="_token" value="<?php echo htmlspecialchars(csrf_sf_token('expense')); ?>">
     <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
@@ -173,24 +180,5 @@ vendorNameInput.addEventListener('change', function() {
   if (!found) vendorIdInput.value = 0;
 });
 
-// Form submit via fetch
-document.getElementById('expenseForm').addEventListener('submit', async function(e) {
-  e.preventDefault();
-  const form = this;
-  const formData = new FormData(this);
-  try {
-    const resp = await fetch(form.action || '/?page=financial/expense-handler', {
-      method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' }, body: formData
-    });
-    const data = await resp.json();
-    if (data.success && data.redirect) {
-      const redirectUrl = new URL(data.redirect, window.location.origin);
-      redirectUrl.searchParams.set(data.status_param || (formData.get('action') === 'update' ? 'updated' : 'created'), '1');
-      window.location.href = redirectUrl.pathname + redirectUrl.search + redirectUrl.hash;
-    } else {
-      alert(data.error || 'Failed to save expense');
-    }
-  } catch (err) { alert('Error: ' + err.message); }
-});
 })();
 </script>

--- a/tests/Workflows/FinancialAssetsTest.php
+++ b/tests/Workflows/FinancialAssetsTest.php
@@ -55,7 +55,8 @@ final class FinancialAssetsTest extends TestCase
         $form = $this->read('src/views/pages/financial/expense-create.php');
         self::assertStringContainsString('action="/?page=financial/expense-handler"', $form);
         self::assertStringContainsString('(function () {', $form);
-        self::assertStringContainsString("form.action || '/?page=financial/expense-handler'", $form);
+        self::assertStringNotContainsString('fetch(form.action', $form);
+        self::assertStringContainsString('$_GET[\'error\']', $form);
 
         $handler = $this->read('src/controllers/financial/expense_handler.php');
         self::assertStringContainsString('function expense_handler_is_ajax()', $handler);

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -282,6 +282,7 @@ final class ProjectWorkflowUiTest extends TestCase
         $expenseCreate = file_get_contents($this->root . '/src/views/pages/financial/expense-create.php');
         $formsList = file_get_contents($this->root . '/src/views/pages/financial/forms-list.php');
         $formDetail = file_get_contents($this->root . '/src/views/pages/financial/form-detail.php');
+        $securityHeaders = file_get_contents($this->root . '/src/utils/security_headers.php');
 
         self::assertStringContainsString('invoice_ensure_payments_schema($pdo)', (string)$paymentController);
         self::assertStringContainsString("'organization_id' => $organization_id", (string)$paymentController);
@@ -290,8 +291,13 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('$taxAmount = null;', (string)$expenseHandler);
         self::assertStringContainsString('$paymentMethod = null;', (string)$expenseHandler);
         self::assertStringNotContainsString('id="taxInput"', (string)$expenseCreate);
+        self::assertStringNotContainsString('fetch(form.action', (string)$expenseCreate);
+        self::assertStringContainsString('$_GET[\'error\']', (string)$expenseCreate);
         self::assertStringContainsString('style="display:none"', (string)$expenseCreate);
         self::assertStringContainsString('#toolbar=0&navpanes=0&scrollbar=0&view=FitH', (string)$formsList);
         self::assertStringContainsString('Open PDF in new tab', (string)$formDetail);
+        self::assertStringContainsString('X-Frame-Options: SAMEORIGIN', (string)$securityHeaders);
+        self::assertStringContainsString("frame-src 'self'", (string)$securityHeaders);
+        self::assertStringContainsString("frame-ancestors 'self'", (string)$securityHeaders);
     }
 }


### PR DESCRIPTION
## Summary
- submit expenses with a normal POST instead of AJAX so proxy/login HTML cannot break JSON parsing
- keep expense create success/error handling visible after redirects
- allow same-origin PDF iframe previews while preserving cross-site framing protection

## Verification
- php -l src/utils/security_headers.php
- php -l tests/Workflows/ProjectWorkflowUiTest.php
- vendor/bin/phpunit tests/Workflows/ProjectWorkflowUiTest.php (local vendor is incomplete: missing PHPUnit\\TextUI\\Application)