### PR TITLE
Fix assets and expenses workflows

### DIFF
--- a/public/assets/js/receipt-detail-logic.js
+++ b/public/assets/js/receipt-detail-logic.js
@@ -20,6 +20,7 @@ document.getElementById('editForm').addEventListener('submit', async function (e
     try {
         const response = await fetch('/?page=receipts-handler', {
             method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
             body: formData
         });
 
@@ -55,6 +56,7 @@ async function confirmDelete() {
     try {
         const response = await fetch('/?page=receipts-handler', {
             method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
             body: formData
         });
 

--- a/public/assets/js/receipt-upload-logic.js
+++ b/public/assets/js/receipt-upload-logic.js
@@ -34,6 +34,7 @@ document.getElementById('receiptUploadForm').addEventListener('submit', async fu
     try {
         const response = await fetch('/?page=receipts-handler', {
             method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
             body: formData
         });
 

--- a/src/controllers/financial/asset_handler.php
+++ b/src/controllers/financial/asset_handler.php
@@ -12,11 +12,39 @@ require_once __DIR__ . '/../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/audit.php';
 
-header('Content-Type: application/json');
+function asset_handler_is_ajax(): bool
+{
+    return strtolower((string)($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '')) === 'xmlhttprequest'
+        || str_contains(strtolower((string)($_SERVER['HTTP_ACCEPT'] ?? '')), 'application/json');
+}
+
+function asset_redirect_with_message(string $url, string $key, string $message): void
+{
+    $separator = str_contains($url, '?') ? '&' : '?';
+    header('Location: ' . $url . $separator . rawurlencode($key) . '=' . rawurlencode($message));
+    exit;
+}
+
+function asset_handler_finish(array $response, int $status = 200, string $fallback = '/?page=financial/expenses-list&tab=assets'): void
+{
+    if (asset_handler_is_ajax()) {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo json_encode($response);
+        exit;
+    }
+
+    if (!empty($response['success'])) {
+        header('Location: ' . (string)($response['redirect'] ?? '/?page=financial/expenses-list&tab=assets'));
+        exit;
+    }
+
+    asset_redirect_with_message($fallback, 'error', (string)($response['message'] ?? 'Asset request failed'));
+}
 
 function asset_json_response(bool $success, string $message, array $extra = []): void
 {
-    echo json_encode(array_merge(['success' => $success, 'message' => $message], $extra));
+    asset_handler_finish(array_merge(['success' => $success, 'message' => $message], $extra), $success ? 200 : 400);
     exit;
 }
 
@@ -55,13 +83,12 @@ function asset_assert_org_row(PDO $pdo, string $table, int $id, int $orgId, stri
 
 $userId = (int)($_SESSION['user']['id'] ?? 0);
 if ($userId <= 0) {
-    asset_json_response(false, 'Authentication required');
+    asset_handler_finish(['success' => false, 'message' => 'Authentication required'], 401, '/?page=login');
 }
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
 if ($orgId <= 0 || !user_can($pdo, $userId, 'financial.manage', $orgId)) {
-    http_response_code(403);
-    asset_json_response(false, 'Permission denied');
+    asset_handler_finish(['success' => false, 'message' => 'Permission denied'], 403, '/?page=financial/expenses-list&tab=assets');
 }
 
 $submitted = $_POST['_token'] ?? '';
@@ -69,7 +96,7 @@ $csrfOk = is_string($submitted) && $submitted !== ''
     ? csrf_sf_is_valid('asset', $submitted)
     : csrf_validate();
 if (!$csrfOk) {
-    asset_json_response(false, 'Invalid request. Please refresh and try again.');
+    asset_handler_finish(['success' => false, 'message' => 'Invalid request. Please refresh and try again.'], 400, '/?page=financial/asset-form');
 }
 
 $allowedStatuses = ['planned', 'active', 'maintenance', 'retired', 'sold', 'lost', 'disposed'];
@@ -78,12 +105,14 @@ $action = (string)($_POST['action'] ?? '');
 
 try {
     if ($action === 'delete') {
+        $fallback = '/?page=financial/expenses-list&tab=assets';
         $id = (int)($_POST['id'] ?? 0);
         if ($id <= 0) {
             throw new RuntimeException('Invalid asset ID.');
         }
-        $stmt = $pdo->prepare('UPDATE financial_assets SET status = "disposed", disposed_on = COALESCE(disposed_on, CURDATE()) WHERE id = ? AND organization_id = ?');
-        $stmt->execute([$id, $orgId]);
+        [$assetScopeWhere, $assetScopeParams] = finance_scope_clause($pdo, 'a', $userId, $orgId, 'created_by');
+        $stmt = $pdo->prepare('UPDATE financial_assets a SET status = "disposed", disposed_on = COALESCE(disposed_on, CURDATE()) WHERE a.id = ? AND ' . $assetScopeWhere);
+        $stmt->execute(array_merge([$id], $assetScopeParams));
         audit_log($pdo, 'asset.dispose', 'financial_asset', $id, ['organization_id' => $orgId]);
         asset_json_response(true, 'Asset marked disposed.', ['redirect' => '/?page=financial/expenses-list&tab=assets&disposed=1']);
     }
@@ -93,6 +122,7 @@ try {
     }
 
     $id = (int)($_POST['id'] ?? 0);
+    $fallback = $id > 0 ? '/?page=financial/asset-form&id=' . $id : '/?page=financial/asset-form';
     if ($action === 'update' && $id <= 0) {
         throw new RuntimeException('Invalid asset ID.');
     }
@@ -156,7 +186,12 @@ try {
         asset_assert_org_row($pdo, 'expense_categories', $categoryId, $orgId, 'Category');
     }
     if ($expenseId !== null) {
-        asset_assert_org_row($pdo, 'expenses', $expenseId, $orgId, 'Expense');
+        [$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
+        $expenseCheck = $pdo->prepare('SELECT 1 FROM expenses e WHERE e.id = ? AND ' . $expenseScopeWhere . ' LIMIT 1');
+        $expenseCheck->execute(array_merge([$expenseId], $expenseScopeParams));
+        if (!$expenseCheck->fetchColumn()) {
+            throw new RuntimeException('Expense was not found for the active organization.');
+        }
     }
 
     if ($action === 'create') {
@@ -178,8 +213,9 @@ try {
         asset_json_response(true, 'Asset created.', ['id' => $assetId, 'redirect' => '/?page=financial/asset-detail&id=' . $assetId . '&created=1']);
     }
 
-    $exists = $pdo->prepare('SELECT 1 FROM financial_assets WHERE id = ? AND organization_id = ?');
-    $exists->execute([$id, $orgId]);
+    [$assetScopeWhere, $assetScopeParams] = finance_scope_clause($pdo, 'a', $userId, $orgId, 'created_by');
+    $exists = $pdo->prepare('SELECT 1 FROM financial_assets a WHERE a.id = ? AND ' . $assetScopeWhere);
+    $exists->execute(array_merge([$id], $assetScopeParams));
     if (!$exists->fetchColumn()) {
         throw new RuntimeException('Asset not found.');
     }
@@ -202,5 +238,5 @@ try {
     asset_json_response(true, 'Asset updated.', ['id' => $id, 'redirect' => '/?page=financial/asset-detail&id=' . $id . '&updated=1']);
 } catch (Throwable $e) {
     error_log('[asset_handler] Error: ' . $e->getMessage());
-    asset_json_response(false, $e->getMessage());
+    asset_handler_finish(['success' => false, 'message' => $e->getMessage()], 400, $fallback ?? '/?page=financial/asset-form');
 }

--- a/src/controllers/financial/category_handler.php
+++ b/src/controllers/financial/category_handler.php
@@ -15,24 +15,44 @@ require_once __DIR__ . '/../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/audit.php';
 
-header('Content-Type: application/json');
+function category_handler_is_ajax(): bool
+{
+    return strtolower((string)($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '')) === 'xmlhttprequest'
+        || str_contains(strtolower((string)($_SERVER['HTTP_ACCEPT'] ?? '')), 'application/json');
+}
+
+function category_handler_finish(array $response, int $status = 200, string $fallback = '/?page=financial/expenses-list&tab=categories'): void
+{
+    if (category_handler_is_ajax()) {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo json_encode($response);
+        exit;
+    }
+
+    $base = !empty($response['success'])
+        ? (string)($response['redirect'] ?? '/?page=financial/expenses-list&tab=categories')
+        : $fallback;
+    $key = !empty($response['success']) ? 'success' : 'error';
+    $message = (string)($response['message'] ?? (!empty($response['success']) ? 'Category saved' : 'Category request failed'));
+    $join = str_contains($base, '?') ? '&' : '?';
+    header('Location: ' . $base . $join . $key . '=' . rawurlencode($message));
+    exit;
+}
 
 $response = ['success' => false, 'message' => ''];
 
 // Auth required
 if (empty($_SESSION['user']['id'])) {
     $response['message'] = 'Authentication required';
-    echo json_encode($response);
-    exit;
+    category_handler_finish($response, 401, '/?page=login');
 }
 
 $userId = (int)$_SESSION['user']['id'];
-$orgId  = get_active_org_id();
+$orgId  = active_or_default_org_id($pdo);
 if ($orgId <= 0 || !user_can($pdo, $userId, 'financial.manage', $orgId)) {
-    http_response_code(403);
     $response['message'] = 'Permission denied';
-    echo json_encode($response);
-    exit;
+    category_handler_finish($response, 403);
 }
 
 // CSRF required: accept legacy 'csrf' or Symfony '_token'
@@ -45,15 +65,13 @@ if (is_string($submitted) && $submitted !== '') {
 }
 if (!$csrfOk) {
     $response['message'] = 'Invalid request (CSRF validation failed)';
-    echo json_encode($response);
-    exit;
+    category_handler_finish($response, 400);
 }
 
 $action = $_POST['action'] ?? '';
 
 function jsonResponse(bool $success, string $message, array $extra = []): void {
-    echo json_encode(array_merge(['success' => $success, 'message' => $message], $extra));
-    exit;
+    category_handler_finish(array_merge(['success' => $success, 'message' => $message], $extra), $success ? 200 : 400);
 }
 
 function trimNullable(string $value): ?string {

--- a/src/controllers/financial/csv_import.php
+++ b/src/controllers/financial/csv_import.php
@@ -30,7 +30,7 @@ if (!$csrfOk) {
     exit;
 }
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
 if ($orgId <= 0 || !user_can($pdo, (int)$userId, 'financial.manage', $orgId)) {
     http_response_code(403);
     echo json_encode(['success' => false, 'error' => 'Permission denied']);
@@ -99,7 +99,7 @@ try {
 
         // Suggest mapping based on format
         $suggestedMapping = [];
-        $expenseFields = ['expense_date', 'vendor_name', 'description', 'amount', 'tax_amount', 'total_amount', 'reference_number', 'payment_method'];
+        $expenseFields = ['expense_date', 'vendor_name', 'description', 'amount', 'total_amount', 'reference_number'];
 
         if ($format === 'amazon') {
             foreach ($headers as $i => $h) {
@@ -108,10 +108,8 @@ try {
                 elseif ($hl === 'seller' || $hl === 'seller name') $suggestedMapping['vendor_name'] = $i;
                 elseif ($hl === 'title') $suggestedMapping['description'] = $i;
                 elseif ($hl === 'purchase price per unit' || $hl === 'purchase price') $suggestedMapping['amount'] = $i;
-                elseif ($hl === 'order tax') $suggestedMapping['tax_amount'] = $i;
                 elseif ($hl === 'order total') $suggestedMapping['total_amount'] = $i;
                 elseif ($hl === 'order id') $suggestedMapping['reference_number'] = $i;
-                elseif ($hl === 'payment instrument type') $suggestedMapping['payment_method'] = $i;
             }
         } else {
             // Generic: try to match common column names
@@ -183,26 +181,26 @@ try {
 
         // Cache vendors to avoid repeated lookups
         $vendorCache = [];
+        $mappedIndex = static function (array $mapping, string $field): ?int {
+            return array_key_exists($field, $mapping) && $mapping[$field] !== null ? (int)$mapping[$field] : null;
+        };
 
         foreach ($rows as $rowIdx => $row) {
             try {
                 // Extract fields using mapping
-                $expenseDate = $mapping['expense_date'] !== null && isset($row[$mapping['expense_date']])
-                    ? trim($row[$mapping['expense_date']]) : '';
-                $vendorName = $mapping['vendor_name'] !== null && isset($row[$mapping['vendor_name']])
-                    ? trim($row[$mapping['vendor_name']]) : '';
-                $description = $mapping['description'] !== null && isset($row[$mapping['description']])
-                    ? trim($row[$mapping['description']]) : '';
-                $amountStr = $mapping['amount'] !== null && isset($row[$mapping['amount']])
-                    ? trim($row[$mapping['amount']]) : '0';
-                $taxStr = $mapping['tax_amount'] !== null && isset($row[$mapping['tax_amount']])
-                    ? trim($row[$mapping['tax_amount']]) : '';
-                $totalStr = $mapping['total_amount'] !== null && isset($row[$mapping['total_amount']])
-                    ? trim($row[$mapping['total_amount']]) : '';
-                $reference = $mapping['reference_number'] !== null && isset($row[$mapping['reference_number']])
-                    ? trim($row[$mapping['reference_number']]) : '';
-                $paymentMethod = $mapping['payment_method'] !== null && isset($row[$mapping['payment_method']])
-                    ? trim($row[$mapping['payment_method']]) : '';
+                $expenseDateIdx = $mappedIndex($mapping, 'expense_date');
+                $vendorNameIdx = $mappedIndex($mapping, 'vendor_name');
+                $descriptionIdx = $mappedIndex($mapping, 'description');
+                $amountIdx = $mappedIndex($mapping, 'amount');
+                $totalIdx = $mappedIndex($mapping, 'total_amount');
+                $referenceIdx = $mappedIndex($mapping, 'reference_number');
+
+                $expenseDate = $expenseDateIdx !== null && isset($row[$expenseDateIdx]) ? trim($row[$expenseDateIdx]) : '';
+                $vendorName = $vendorNameIdx !== null && isset($row[$vendorNameIdx]) ? trim($row[$vendorNameIdx]) : '';
+                $description = $descriptionIdx !== null && isset($row[$descriptionIdx]) ? trim($row[$descriptionIdx]) : '';
+                $amountStr = $amountIdx !== null && isset($row[$amountIdx]) ? trim($row[$amountIdx]) : '0';
+                $totalStr = $totalIdx !== null && isset($row[$totalIdx]) ? trim($row[$totalIdx]) : '';
+                $reference = $referenceIdx !== null && isset($row[$referenceIdx]) ? trim($row[$referenceIdx]) : '';
 
                 // Parse date (try multiple formats)
                 $parsedDate = null;
@@ -228,25 +226,9 @@ try {
                 }
                 $amount = abs($amount);
 
-                $taxAmount = $taxStr !== '' ? abs((float)preg_replace('/[^0-9.\-]/', '', $taxStr)) : null;
-                $totalAmount = $totalStr !== '' ? abs((float)preg_replace('/[^0-9.\-]/', '', $totalStr)) : ($taxAmount !== null ? $amount + $taxAmount : $amount);
-
-                // Map payment method
-                $pmLower = strtolower($paymentMethod);
-                $pm = 'other';
-                if (strpos($pmLower, 'visa') !== false || strpos($pmLower, 'master') !== false || strpos($pmLower, 'card') !== false || strpos($pmLower, 'credit') !== false) {
-                    $pm = 'card';
-                } elseif (strpos($pmLower, 'bank') !== false || strpos($pmLower, 'ach') !== false || strpos($pmLower, 'transfer') !== false) {
-                    $pm = 'bank_transfer';
-                } elseif (strpos($pmLower, 'check') !== false) {
-                    $pm = 'check';
-                } elseif (strpos($pmLower, 'cash') !== false) {
-                    $pm = 'cash';
-                } elseif (strpos($pmLower, 'paypal') !== false) {
-                    $pm = 'paypal';
-                } elseif (strpos($pmLower, 'venmo') !== false) {
-                    $pm = 'venmo';
-                }
+                $taxAmount = null;
+                $totalAmount = $totalStr !== '' ? abs((float)preg_replace('/[^0-9.\-]/', '', $totalStr)) : $amount;
+                $pm = null;
 
                 // Find or create vendor
                 $vendorId = null;

--- a/src/controllers/financial/expense_export.php
+++ b/src/controllers/financial/expense_export.php
@@ -14,7 +14,7 @@ if (!$userId) {
     exit;
 }
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
 if ($orgId <= 0 || !user_can($pdo, (int)$userId, 'financial.manage', $orgId)) {
     http_response_code(403);
     exit('Permission denied');
@@ -30,8 +30,9 @@ $billable = $_GET['billable'] ?? '';
 $taxDeductible = $_GET['tax_deductible'] ?? '';
 $status = $_GET['status'] ?? '';
 
-$where = ['e.organization_id = ?'];
-$params = [$orgId];
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', (int)$userId, $orgId, 'created_by');
+$where = [$expenseScopeWhere];
+$params = $expenseScopeParams;
 
 if ($start) { $where[] = 'e.expense_date >= ?'; $params[] = $start; }
 if ($end) { $where[] = 'e.expense_date <= ?'; $params[] = $end; }
@@ -67,7 +68,7 @@ header('Content-Disposition: attachment; filename="expenses-' . date('Y-m-d') . 
 $out = fopen('php://output', 'w');
 
 // Header row
-csv_write_row($out, ['Date', 'Vendor', 'Description', 'Category', 'Amount', 'Tax', 'Total', 'Payment Method', 'Reference', 'Billable', 'Client', 'Project', 'Tax-Deductible', 'Reimbursed', 'Reconciled', 'Status', 'Notes']);
+csv_write_row($out, ['Date', 'Vendor', 'Description', 'Category', 'Amount', 'Total', 'Reference', 'Billable', 'Client', 'Project', 'Tax-Deductible', 'Reimbursed', 'Reconciled', 'Status', 'Notes']);
 
 foreach ($expenses as $e) {
     csv_write_row($out, [
@@ -76,9 +77,7 @@ foreach ($expenses as $e) {
         $e['description'] ?? '',
         $e['category_name'] ?? '',
         number_format((float)$e['amount'], 2, '.', ''),
-        $e['tax_amount'] ? number_format((float)$e['tax_amount'], 2, '.', '') : '',
         $e['total_amount'] ? number_format((float)$e['total_amount'], 2, '.', '') : number_format((float)$e['amount'], 2, '.', ''),
-        $e['payment_method'] ?? '',
         $e['reference_number'] ?? '',
         $e['is_billable'] ? 'Yes' : 'No',
         $e['client_name'] ?? '',

--- a/src/controllers/financial/expense_handler.php
+++ b/src/controllers/financial/expense_handler.php
@@ -39,6 +39,44 @@ function expense_handler_finish(array $response, int $status = 200, string $fall
     expense_handler_redirect_with_message($fallback, 'error', (string)($response['error'] ?? 'Expense request failed'));
 }
 
+function expense_handler_assert_org_row(PDO $pdo, string $table, int $id, int $orgId, string $label, ?string $ownerColumn = null, int $userId = 0): void
+{
+    if ($id <= 0) {
+        return;
+    }
+    if (!preg_match('/^[A-Za-z0-9_]+$/', $table)) {
+        throw new RuntimeException('Invalid table.');
+    }
+
+    $where = 'id = ? AND organization_id = ?';
+    $params = [$id, $orgId];
+    if ($ownerColumn !== null && ($_SESSION['user']['role'] ?? '') !== 'admin') {
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $ownerColumn)) {
+            throw new RuntimeException('Invalid owner column.');
+        }
+        $where .= " AND {$ownerColumn} = ?";
+        $params[] = $userId;
+    }
+
+    $stmt = $pdo->prepare("SELECT 1 FROM {$table} WHERE {$where} LIMIT 1");
+    $stmt->execute($params);
+    if (!$stmt->fetchColumn()) {
+        throw new RuntimeException($label . ' was not found for the active organization.');
+    }
+}
+
+function expense_handler_assert_client(PDO $pdo, int $clientId, int $orgId): void
+{
+    if ($clientId <= 0) {
+        return;
+    }
+    $stmt = $pdo->prepare('SELECT 1 FROM clients WHERE id = ? AND organization_id = ? LIMIT 1');
+    $stmt->execute([$clientId, $orgId]);
+    if (!$stmt->fetchColumn()) {
+        throw new RuntimeException('Client was not found for the active organization.');
+    }
+}
+
 $userId = $_SESSION['user']['id'] ?? null;
 if (!$userId) {
     expense_handler_finish(['success' => false, 'error' => 'Not authenticated'], 401, '/?page=login');
@@ -88,6 +126,14 @@ try {
             if (empty($expenseDate)) {
                 throw new Exception('Expense date is required');
             }
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', (string)$expenseDate)) {
+                throw new Exception('Expense date must be in YYYY-MM-DD format');
+            }
+
+            if ($isBillable !== 1) {
+                $clientId = 0;
+                $projectId = 0;
+            }
 
             $totalAmount = $amount;
 
@@ -103,6 +149,12 @@ try {
                 }
             }
 
+            expense_handler_assert_org_row($pdo, 'vendors', $vendorId, $orgId, 'Vendor');
+            expense_handler_assert_org_row($pdo, 'expense_categories', $categoryId, $orgId, 'Category');
+            expense_handler_assert_client($pdo, $clientId, $orgId);
+            expense_handler_assert_org_row($pdo, 'projects', $projectId, $orgId, 'Project');
+            expense_handler_assert_org_row($pdo, 'receipts', $receiptId, $orgId, 'Receipt', 'uploaded_by', (int)$userId);
+
             $stmt = $pdo->prepare('
                 INSERT INTO expenses (organization_id, vendor_id, category_id, client_id, project_id, receipt_id,
                     amount, tax_amount, total_amount, expense_date, description, payment_method, reference_number,
@@ -117,13 +169,19 @@ try {
             ]);
             $expenseId = (int)$pdo->lastInsertId();
             audit_log($pdo, 'expense.create', 'expense', $expenseId, ['amount' => $amount, 'vendor_id' => $vendorId]);
-            $response = ['success' => true, 'id' => $expenseId, 'redirect' => '/?page=financial/expense-detail&id=' . $expenseId, 'status_param' => 'created'];
+            $response = ['success' => true, 'id' => $expenseId, 'redirect' => '/?page=financial/expense-detail&id=' . $expenseId . '&created=1', 'status_param' => 'created'];
             break;
 
         case 'update':
             $id = (int)($_POST['id'] ?? 0);
             $fallback = $id > 0 ? '/?page=financial/expense-create&id=' . $id : '/?page=financial/expense-create';
             if ($id <= 0) throw new Exception('Invalid expense ID');
+            [$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', (int)$userId, $orgId, 'created_by');
+            $exists = $pdo->prepare('SELECT 1 FROM expenses e WHERE e.id = ? AND ' . $expenseScopeWhere . ' LIMIT 1');
+            $exists->execute(array_merge([$id], $expenseScopeParams));
+            if (!$exists->fetchColumn()) {
+                throw new Exception('Expense not found');
+            }
 
             $vendorId = (int)($_POST['vendor_id'] ?? 0);
             $vendorName = trim($_POST['vendor_name'] ?? '');
@@ -140,6 +198,20 @@ try {
             $isTaxDeductible = isset($_POST['is_tax_deductible']) ? (int)!empty($_POST['is_tax_deductible']) : 1;
             $notes = trim($_POST['notes'] ?? '');
 
+            if ($amount <= 0) {
+                throw new Exception('Amount must be greater than 0');
+            }
+            if (empty($expenseDate)) {
+                throw new Exception('Expense date is required');
+            }
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', (string)$expenseDate)) {
+                throw new Exception('Expense date must be in YYYY-MM-DD format');
+            }
+            if ($isBillable !== 1) {
+                $clientId = 0;
+                $projectId = 0;
+            }
+
             $totalAmount = $amount;
 
             // Auto-create vendor if name provided but no vendor_id
@@ -154,6 +226,11 @@ try {
                 }
             }
 
+            expense_handler_assert_org_row($pdo, 'vendors', $vendorId, $orgId, 'Vendor');
+            expense_handler_assert_org_row($pdo, 'expense_categories', $categoryId, $orgId, 'Category');
+            expense_handler_assert_client($pdo, $clientId, $orgId);
+            expense_handler_assert_org_row($pdo, 'projects', $projectId, $orgId, 'Project');
+
             $stmt = $pdo->prepare('
                 UPDATE expenses SET vendor_id=?, category_id=?, client_id=?, project_id=?, amount=?,
                     tax_amount=?, total_amount=?, expense_date=?, description=?, payment_method=?,
@@ -167,14 +244,15 @@ try {
                 $id, $orgId
             ]);
             audit_log($pdo, 'expense.update', 'expense', $id);
-            $response = ['success' => true, 'redirect' => '/?page=financial/expense-detail&id=' . $id, 'status_param' => 'updated'];
+            $response = ['success' => true, 'redirect' => '/?page=financial/expense-detail&id=' . $id . '&updated=1', 'status_param' => 'updated'];
             break;
 
         case 'delete':
             $id = (int)($_POST['id'] ?? 0);
             $fallback = $id > 0 ? '/?page=financial/expense-detail&id=' . $id : '/?page=financial/expenses-list&tab=expenses';
             if ($id <= 0) throw new Exception('Invalid expense ID');
-            $pdo->prepare('UPDATE expenses SET status="void" WHERE id=? AND organization_id=?')->execute([$id, $orgId]);
+            [$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', (int)$userId, $orgId, 'created_by');
+            $pdo->prepare('UPDATE expenses e SET status="void" WHERE e.id=? AND ' . $expenseScopeWhere)->execute(array_merge([$id], $expenseScopeParams));
             audit_log($pdo, 'expense.delete', 'expense', $id);
             $response = ['success' => true, 'redirect' => '/?page=financial/expenses-list&tab=expenses&deleted=1'];
             break;
@@ -183,7 +261,8 @@ try {
             $id = (int)($_POST['id'] ?? 0);
             $fallback = $id > 0 ? '/?page=financial/expense-detail&id=' . $id : '/?page=financial/expenses-list&tab=expenses';
             if ($id <= 0) throw new Exception('Invalid expense ID');
-            $pdo->prepare('UPDATE expenses SET is_reimbursed=1, status="reimbursed" WHERE id=? AND organization_id=?')->execute([$id, $orgId]);
+            [$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', (int)$userId, $orgId, 'created_by');
+            $pdo->prepare('UPDATE expenses e SET is_reimbursed=1, status="reimbursed" WHERE e.id=? AND ' . $expenseScopeWhere)->execute(array_merge([$id], $expenseScopeParams));
             audit_log($pdo, 'expense.mark_reimbursed', 'expense', $id);
             $response = ['success' => true, 'redirect' => '/?page=financial/expense-detail&id=' . $id . '&reimbursed=1'];
             break;
@@ -192,7 +271,8 @@ try {
             $id = (int)($_POST['id'] ?? 0);
             $fallback = $id > 0 ? '/?page=financial/expense-detail&id=' . $id : '/?page=financial/expenses-list&tab=expenses';
             if ($id <= 0) throw new Exception('Invalid expense ID');
-            $pdo->prepare('UPDATE expenses SET is_reconciled=1 WHERE id=? AND organization_id=?')->execute([$id, $orgId]);
+            [$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', (int)$userId, $orgId, 'created_by');
+            $pdo->prepare('UPDATE expenses e SET is_reconciled=1 WHERE e.id=? AND ' . $expenseScopeWhere)->execute(array_merge([$id], $expenseScopeParams));
             audit_log($pdo, 'expense.mark_reconciled', 'expense', $id);
             $response = ['success' => true, 'redirect' => '/?page=financial/expense-detail&id=' . $id . '&reconciled=1'];
             break;

--- a/src/controllers/financial/mileage_handler.php
+++ b/src/controllers/financial/mileage_handler.php
@@ -18,6 +18,36 @@ require_once __DIR__ . '/../../utils/audit.php';
 $action = $_POST['action'] ?? null;
 $response = ['success' => false, 'message' => ''];
 
+function mileage_handler_is_ajax(): bool
+{
+    return strtolower((string)($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '')) === 'xmlhttprequest'
+        || str_contains(strtolower((string)($_SERVER['HTTP_ACCEPT'] ?? '')), 'application/json');
+}
+
+function mileage_handler_redirect_with_message(string $url, string $key, string $message): void
+{
+    $join = str_contains($url, '?') ? '&' : '?';
+    header('Location: ' . $url . $join . rawurlencode($key) . '=' . rawurlencode($message));
+    exit;
+}
+
+function mileage_handler_finish(array $response, int $status = 200, string $fallback = '/?page=financial/mileage-list'): void
+{
+    if (mileage_handler_is_ajax()) {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo json_encode($response);
+        exit;
+    }
+
+    if (!empty($response['success'])) {
+        header('Location: ' . (string)($response['redirect'] ?? '/?page=financial/mileage-list'));
+        exit;
+    }
+
+    mileage_handler_redirect_with_message($fallback, 'error', (string)($response['message'] ?? 'Mileage request failed'));
+}
+
 // CSRF + auth checks: accept legacy 'csrf' or Symfony '_token'
 $csrfOk = false;
 $submitted = $_POST['_token'] ?? '';
@@ -28,27 +58,20 @@ if (is_string($submitted) && $submitted !== '') {
 }
 if (!$csrfOk) {
     $response['message'] = 'Invalid request (CSRF validation failed)';
-    header('Content-Type: application/json');
-    echo json_encode($response);
-    exit;
+    mileage_handler_finish($response, 400, '/?page=financial/mileage-create');
 }
 
 if (empty($_SESSION['user']['id'])) {
     $response['message'] = 'Authentication required';
-    header('Content-Type: application/json');
-    echo json_encode($response);
-    exit;
+    mileage_handler_finish($response, 401, '/?page=login');
 }
 
 try {
     $userId = (int)$_SESSION['user']['id'];
-    $orgId = get_active_org_id();
+    $orgId = active_or_default_org_id($pdo);
     if ($orgId <= 0 || !user_can($pdo, $userId, 'financial.manage', $orgId)) {
-        http_response_code(403);
         $response['message'] = 'Permission denied';
-        header('Content-Type: application/json');
-        echo json_encode($response);
-        exit;
+        mileage_handler_finish($response, 403, '/?page=financial/mileage-list');
     }
 
     // Make sure mileage_logs table exists
@@ -149,6 +172,7 @@ try {
 
         case 'update':
             $id = (int)($_POST['id'] ?? 0);
+            $fallback = $id > 0 ? '/?page=financial/mileage-create&id=' . $id : '/?page=financial/mileage-create';
             $tripDate = trim($_POST['trip_date'] ?? '');
             $startLocation = trim($_POST['start_location'] ?? '');
             $endLocation = trim($_POST['end_location'] ?? '');
@@ -188,8 +212,9 @@ try {
                 throw new Exception('Mileage rate cannot be negative');
             }
 
-            $stmt = $pdo->prepare('SELECT id FROM mileage_logs WHERE id = ? AND organization_id = ?');
-            $stmt->execute([$id, $orgId]);
+            [$mileageScopeWhere, $mileageScopeParams] = finance_scope_clause($pdo, 'm', $userId, $orgId, 'user_id');
+            $stmt = $pdo->prepare('SELECT m.id FROM mileage_logs m WHERE m.id = ? AND ' . $mileageScopeWhere);
+            $stmt->execute(array_merge([$id], $mileageScopeParams));
             if (!$stmt->fetch()) {
                 throw new Exception('Mileage entry not found');
             }
@@ -241,19 +266,21 @@ try {
 
         case 'delete':
             $id = (int)($_POST['id'] ?? 0);
+            $fallback = $id > 0 ? '/?page=financial/mileage-list' : '/?page=financial/mileage-list';
 
             if ($id <= 0) {
                 throw new Exception('Invalid mileage entry ID');
             }
 
-            $stmt = $pdo->prepare('SELECT id FROM mileage_logs WHERE id = ? AND organization_id = ?');
-            $stmt->execute([$id, $orgId]);
+            [$mileageScopeWhere, $mileageScopeParams] = finance_scope_clause($pdo, 'm', $userId, $orgId, 'user_id');
+            $stmt = $pdo->prepare('SELECT m.id FROM mileage_logs m WHERE m.id = ? AND ' . $mileageScopeWhere);
+            $stmt->execute(array_merge([$id], $mileageScopeParams));
             if (!$stmt->fetch()) {
                 throw new Exception('Mileage entry not found');
             }
 
-            $stmt = $pdo->prepare('DELETE FROM mileage_logs WHERE id = ? AND organization_id = ?');
-            $stmt->execute([$id, $orgId]);
+            $stmt = $pdo->prepare('DELETE m FROM mileage_logs m WHERE m.id = ? AND ' . $mileageScopeWhere);
+            $stmt->execute(array_merge([$id], $mileageScopeParams));
 
             audit_log($pdo, 'mileage.delete', 'mileage_log', $id, [
                 'organization_id' => $orgId,
@@ -272,5 +299,4 @@ try {
     error_log('[mileage_handler] Error: ' . $e->getMessage());
 }
 
-header('Content-Type: application/json');
-echo json_encode($response);
+mileage_handler_finish($response, !empty($response['success']) ? 200 : 400, $fallback ?? '/?page=financial/mileage-list');

--- a/src/controllers/financial/vendor_handler.php
+++ b/src/controllers/financial/vendor_handler.php
@@ -15,24 +15,46 @@ require_once __DIR__ . '/../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/audit.php';
 
-header('Content-Type: application/json');
+function vendor_handler_is_ajax(): bool
+{
+    return strtolower((string)($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '')) === 'xmlhttprequest'
+        || str_contains(strtolower((string)($_SERVER['HTTP_ACCEPT'] ?? '')), 'application/json');
+}
+
+function vendor_handler_finish(array $response, int $status = 200, string $fallback = '/?page=financial/vendor-form'): void
+{
+    if (vendor_handler_is_ajax()) {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo json_encode($response);
+        exit;
+    }
+
+    if (!empty($response['success'])) {
+        $redirect = (string)($response['redirect'] ?? '/?page=financial/expenses-list&tab=vendors');
+        $join = str_contains($redirect, '?') ? '&' : '?';
+        header('Location: ' . $redirect . $join . 'success=' . rawurlencode((string)($response['message'] ?? 'Vendor saved')));
+        exit;
+    }
+
+    $join = str_contains($fallback, '?') ? '&' : '?';
+    header('Location: ' . $fallback . $join . 'error=' . rawurlencode((string)($response['message'] ?? 'Vendor request failed')));
+    exit;
+}
 
 $response = ['success' => false, 'message' => ''];
 
 // Auth required
 if (empty($_SESSION['user']['id'])) {
     $response['message'] = 'Authentication required';
-    echo json_encode($response);
-    exit;
+    vendor_handler_finish($response, 401, '/?page=login');
 }
 
 $userId = (int)$_SESSION['user']['id'];
-$orgId  = get_active_org_id();
+$orgId  = active_or_default_org_id($pdo);
 if ($orgId <= 0 || !user_can($pdo, $userId, 'financial.manage', $orgId)) {
-    http_response_code(403);
     $response['message'] = 'Permission denied';
-    echo json_encode($response);
-    exit;
+    vendor_handler_finish($response, 403, '/?page=financial/expenses-list&tab=vendors');
 }
 
 // CSRF required: accept legacy 'csrf' or Symfony '_token'
@@ -45,15 +67,13 @@ if (is_string($submitted) && $submitted !== '') {
 }
 if (!$csrfOk) {
     $response['message'] = 'Invalid request (CSRF validation failed)';
-    echo json_encode($response);
-    exit;
+    vendor_handler_finish($response, 400, '/?page=financial/vendor-form');
 }
 
 $action = $_POST['action'] ?? '';
 
 function jsonResponse(bool $success, string $message, array $extra = []): void {
-    echo json_encode(array_merge(['success' => $success, 'message' => $message], $extra));
-    exit;
+    vendor_handler_finish(array_merge(['success' => $success, 'message' => $message], $extra), $success ? 200 : 400);
 }
 
 function trimNullable(string $value): ?string {

--- a/src/controllers/receipts_handler.php
+++ b/src/controllers/receipts_handler.php
@@ -11,27 +11,53 @@ ini_set('display_errors', '0');
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../utils/csrf.php';
 require_once __DIR__ . '/../utils/acl.php';
+require_once __DIR__ . '/../utils/upload_validator.php';
 
 $action = $_POST['action'] ?? null;
 $response = ['success' => false, 'message' => ''];
 
+function receipts_handler_is_ajax(): bool
+{
+    return strtolower((string)($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '')) === 'xmlhttprequest'
+        || str_contains(strtolower((string)($_SERVER['HTTP_ACCEPT'] ?? '')), 'application/json');
+}
+
+function receipts_handler_redirect_with_message(string $url, string $key, string $message): void
+{
+    $join = str_contains($url, '?') ? '&' : '?';
+    header('Location: ' . $url . $join . rawurlencode($key) . '=' . rawurlencode($message));
+    exit;
+}
+
+function receipts_handler_finish(array $response, int $status = 200, string $fallback = '/?page=financial/expenses-list&tab=receipts'): void
+{
+    if (receipts_handler_is_ajax()) {
+        http_response_code($status);
+        header('Content-Type: application/json');
+        echo json_encode($response);
+        exit;
+    }
+
+    if (!empty($response['success'])) {
+        header('Location: ' . (string)($response['redirect'] ?? '/?page=financial/expenses-list&tab=receipts'));
+        exit;
+    }
+
+    receipts_handler_redirect_with_message($fallback, 'error', (string)($response['message'] ?? 'Receipt request failed'));
+}
+
 // Validate CSRF token
 if (!csrf_validate()) {
     $response['message'] = 'Invalid request (CSRF validation failed)';
-    header('Content-Type: application/json');
-    echo json_encode($response);
-    exit;
+    receipts_handler_finish($response, 400, '/?page=financial/receipt-upload');
 }
 
 try {
     $userId = (int)($_SESSION['user']['id'] ?? 0);
-    $orgId = get_active_org_id();
+    $orgId = active_or_default_org_id($pdo);
     if ($userId <= 0 || $orgId <= 0 || !user_can($pdo, $userId, 'financial.manage', $orgId)) {
-        http_response_code(403);
         $response['message'] = 'Permission denied';
-        header('Content-Type: application/json');
-        echo json_encode($response);
-        exit;
+        receipts_handler_finish($response, 403, '/?page=financial/expenses-list&tab=receipts');
     }
 
     $resolveStoreId = static function (PDO $pdo, int $orgId, string $storeName): ?int {
@@ -72,7 +98,6 @@ try {
             $file = $_FILES['receipt_file'];
             $allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'application/pdf'];
 
-            require_once __DIR__ . '/../utils/upload_validator.php';
             $uploadErr = validate_upload($file, $allowedTypes, 10 * 1024 * 1024);
             if ($uploadErr !== null) {
                 throw new Exception($uploadErr);
@@ -126,7 +151,7 @@ try {
 
             $response['success'] = true;
             $response['message'] = 'Receipt uploaded successfully';
-            $response['redirect'] = '/?page=financial/receipts-list';
+            $response['redirect'] = '/?page=financial/expenses-list&tab=receipts&created=1';
             break;
 
         case 'delete':
@@ -137,8 +162,9 @@ try {
             }
 
             // Get file path before deleting
-            $stmt = $pdo->prepare('SELECT file_path FROM receipts WHERE id = ? AND organization_id = ?');
-            $stmt->execute([$receiptId, $orgId]);
+            [$receiptScopeWhere, $receiptScopeParams] = finance_scope_clause($pdo, 'r', $userId, $orgId, 'uploaded_by');
+            $stmt = $pdo->prepare('SELECT r.file_path FROM receipts r WHERE r.id = ? AND ' . $receiptScopeWhere);
+            $stmt->execute(array_merge([$receiptId], $receiptScopeParams));
             $receipt = $stmt->fetch();
 
             if (!$receipt) {
@@ -146,8 +172,8 @@ try {
             }
 
             // Delete database record
-            $stmt = $pdo->prepare('DELETE FROM receipts WHERE id = ? AND organization_id = ?');
-            $stmt->execute([$receiptId, $orgId]);
+            $stmt = $pdo->prepare('DELETE r FROM receipts r WHERE r.id = ? AND ' . $receiptScopeWhere);
+            $stmt->execute(array_merge([$receiptId], $receiptScopeParams));
 
             // Delete file
             $filePath = __DIR__ . '/../..' . $receipt['file_path'];
@@ -157,6 +183,7 @@ try {
 
             $response['success'] = true;
             $response['message'] = 'Receipt deleted successfully';
+            $response['redirect'] = '/?page=financial/expenses-list&tab=receipts&deleted=1';
             break;
 
         case 'update':
@@ -172,13 +199,20 @@ try {
 
             $storeId = $resolveStoreId($pdo, $orgId, $storeName);
 
+            [$receiptScopeWhere, $receiptScopeParams] = finance_scope_clause($pdo, 'r', $userId, $orgId, 'uploaded_by');
+            $exists = $pdo->prepare('SELECT 1 FROM receipts r WHERE r.id = ? AND ' . $receiptScopeWhere . ' LIMIT 1');
+            $exists->execute(array_merge([$receiptId], $receiptScopeParams));
+            if (!$exists->fetchColumn()) {
+                throw new Exception('Receipt not found');
+            }
+
             // Update database
             $stmt = $pdo->prepare('
-                UPDATE receipts 
+                UPDATE receipts r
                 SET description = ?, store_id = ?, receipt_date = ?, amount = ?
-                WHERE id = ? AND organization_id = ?
+                WHERE r.id = ? AND ' . $receiptScopeWhere . '
             ');
-            $stmt->execute([$description, $storeId, $receiptDate, $amount, $receiptId, $orgId]);
+            $stmt->execute(array_merge([$description, $storeId, $receiptDate, $amount, $receiptId], $receiptScopeParams));
 
             // Handle new file upload if provided
             if (isset($_FILES['receipt_file']) && $_FILES['receipt_file']['error'] === UPLOAD_ERR_OK) {
@@ -191,8 +225,8 @@ try {
                 }
 
                 // Get old file path
-                $stmt = $pdo->prepare('SELECT file_path FROM receipts WHERE id = ? AND organization_id = ?');
-                $stmt->execute([$receiptId, $orgId]);
+                $stmt = $pdo->prepare('SELECT r.file_path FROM receipts r WHERE r.id = ? AND ' . $receiptScopeWhere);
+                $stmt->execute(array_merge([$receiptId], $receiptScopeParams));
                 $oldReceipt = $stmt->fetch();
 
                 // Upload new file with year/month structure
@@ -235,8 +269,8 @@ try {
                 }
 
                 // Update file path in database
-                $stmt = $pdo->prepare('UPDATE receipts SET file_path = ?, file_name = ?, file_size = ?, mime_type = ?, uploaded_by = ? WHERE id = ? AND organization_id = ?');
-                $stmt->execute([$dbPath, $file['name'], $file['size'], $file['type'], $userId, $receiptId, $orgId]);
+                $stmt = $pdo->prepare('UPDATE receipts r SET file_path = ?, file_name = ?, file_size = ?, mime_type = ?, uploaded_by = ? WHERE r.id = ? AND ' . $receiptScopeWhere);
+                $stmt->execute(array_merge([$dbPath, $file['name'], $file['size'], $file['type'], $userId, $receiptId], $receiptScopeParams));
 
                 // Delete old file
                 if ($oldReceipt) {
@@ -260,5 +294,4 @@ try {
     error_log('[receipts_handler] Error: ' . $e->getMessage());
 }
 
-header('Content-Type: application/json');
-echo json_encode($response);
+receipts_handler_finish($response, !empty($response['success']) ? 200 : 400);

--- a/src/utils/acl.php
+++ b/src/utils/acl.php
@@ -203,6 +203,23 @@ function scope_clause(PDO $pdo, string $tableAlias, int $userId): array
     return ["{$tableAlias}.organization_id = ? AND {$tableAlias}.created_by = ?", [$activeOrgId, $userId]];
 }
 
+function finance_scope_clause(PDO $pdo, string $tableAlias, int $userId, int $orgId, string $ownerColumn = 'created_by'): array
+{
+    $orgId = $orgId > 0 ? $orgId : active_or_default_org_id($pdo);
+    $where = ["{$tableAlias}.organization_id = ?"];
+    $params = [$orgId];
+
+    if (($_SESSION['user']['role'] ?? '') !== 'admin') {
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $ownerColumn)) {
+            $ownerColumn = 'created_by';
+        }
+        $where[] = "{$tableAlias}.{$ownerColumn} = ?";
+        $params[] = $userId;
+    }
+
+    return [implode(' AND ', $where), $params];
+}
+
 function can_access_record(PDO $pdo, string $table, int $recordId, int $userId): bool
 {
     if (($_SESSION['user']['role'] ?? '') === 'admin') {

--- a/src/views/pages/financial/_assets_tab.php
+++ b/src/views/pages/financial/_assets_tab.php
@@ -4,15 +4,17 @@ require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 require_once __DIR__ . '/../../../utils/financial_assets.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 $assetSearch = trim((string)($_GET['asset_search'] ?? ''));
 $assetStatus = (string)($_GET['asset_status'] ?? '');
 $assetType = trim((string)($_GET['asset_type'] ?? ''));
 $assetVendorId = (int)($_GET['asset_vendor_id'] ?? 0);
 
-$where = ['a.organization_id = ?'];
-$params = [$orgId];
+[$assetScopeWhere, $assetScopeParams] = finance_scope_clause($pdo, 'a', $userId, $orgId, 'created_by');
+$where = [$assetScopeWhere];
+$params = $assetScopeParams;
 if ($assetSearch !== '') {
     $where[] = '(a.name LIKE ? OR a.asset_tag LIKE ? OR a.serial_number LIKE ? OR a.location LIKE ?)';
     $like = '%' . $assetSearch . '%';
@@ -46,8 +48,8 @@ $stmt = $pdo->prepare("
 $stmt->execute($params);
 $assets = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$typeStmt = $pdo->prepare('SELECT DISTINCT asset_type FROM financial_assets WHERE organization_id = ? AND asset_type IS NOT NULL AND asset_type <> "" ORDER BY asset_type');
-$typeStmt->execute([$orgId]);
+$typeStmt = $pdo->prepare('SELECT DISTINCT asset_type FROM financial_assets a WHERE ' . $assetScopeWhere . ' AND asset_type IS NOT NULL AND asset_type <> "" ORDER BY asset_type');
+$typeStmt->execute($assetScopeParams);
 $assetTypes = $typeStmt->fetchAll(PDO::FETCH_COLUMN);
 
 $vendorStmt = $pdo->prepare('SELECT id, name FROM vendors WHERE organization_id = ? AND is_active = 1 ORDER BY name');

--- a/src/views/pages/financial/_expenses_tab.php
+++ b/src/views/pages/financial/_expenses_tab.php
@@ -5,7 +5,8 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 $start = $_GET['start'] ?? '';
 $end = $_GET['end'] ?? '';
@@ -15,10 +16,10 @@ $clientId = (int)($_GET['client_id'] ?? 0);
 $billable = $_GET['billable'] ?? '';
 $status = $_GET['status'] ?? '';
 
-[$scopeWhere, $scopeParams] = scope_clause($pdo, 'e', (int)$_SESSION['user']['id']);
+[$scopeWhere, $scopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
 
-$where = ['e.organization_id = ?'];
-$params = [$orgId];
+$where = [$scopeWhere];
+$params = $scopeParams;
 if ($start) { $where[] = 'e.expense_date >= ?'; $params[] = $start; }
 if ($end) { $where[] = 'e.expense_date <= ?'; $params[] = $end; }
 if ($categoryId > 0) { $where[] = 'e.category_id = ?'; $params[] = $categoryId; }
@@ -27,8 +28,6 @@ if ($clientId > 0) { $where[] = 'e.client_id = ?'; $params[] = $clientId; }
 if ($billable === '1') { $where[] = 'e.is_billable = 1'; }
 if ($billable === '0') { $where[] = 'e.is_billable = 0'; }
 if ($status) { $where[] = 'e.status = ?'; $params[] = $status; }
-if ($scopeWhere !== '') { $where[] = ltrim($scopeWhere, ' AND'); }
-
 $whereSQL = implode(' AND ', $where);
 
 $per = (int)($_GET['per_page'] ?? 50);
@@ -37,7 +36,7 @@ $pageN = max(1, (int)($_GET['p'] ?? 1));
 $offset = ($pageN - 1) * $per;
 
 $countStmt = $pdo->prepare("SELECT COUNT(*) FROM expenses e WHERE {$whereSQL}");
-$countStmt->execute(array_merge($params, $scopeParams));
+$countStmt->execute($params);
 $total = (int)$countStmt->fetchColumn();
 
 $sql = "
@@ -51,7 +50,7 @@ $sql = "
     LIMIT $per OFFSET $offset
 ";
 $stmt = $pdo->prepare($sql);
-$stmt->execute(array_merge($params, $scopeParams));
+$stmt->execute($params);
 $expenses = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $sumStmt = $pdo->prepare("
@@ -61,7 +60,7 @@ $sumStmt = $pdo->prepare("
            COALESCE(SUM(CASE WHEN e.is_billable=1 AND e.is_reimbursed=0 THEN e.total_amount ELSE 0 END),0) as unreimbursed_total
     FROM expenses e WHERE {$whereSQL}
 ");
-$sumStmt->execute(array_merge($params, $scopeParams));
+$sumStmt->execute($params);
 $summary = $sumStmt->fetch(PDO::FETCH_ASSOC);
 
 $cats = $pdo->prepare('SELECT id, name FROM expense_categories WHERE organization_id=? ORDER BY name');
@@ -72,7 +71,8 @@ $vendorsQ = $pdo->prepare('SELECT id, name FROM vendors WHERE organization_id=? 
 $vendorsQ->execute([$orgId]);
 $vendors = $vendorsQ->fetchAll(PDO::FETCH_ASSOC);
 
-$clientsQ = $pdo->query('SELECT id, name FROM clients ORDER BY name');
+$clientsQ = $pdo->prepare('SELECT id, name FROM clients WHERE organization_id = ? ORDER BY name');
+$clientsQ->execute([$orgId]);
 $clients = $clientsQ->fetchAll(PDO::FETCH_ASSOC);
 
 $totalPages = max(1, (int)ceil($total / $per));
@@ -274,7 +274,6 @@ $paginationFilters = [
             <td class="text-right">
               <div class="expense-amount">
                 <strong><?php echo expense_tab_money($totalAmount); ?></strong>
-                <?php if ((float)$e['tax_amount'] > 0): ?><span>Tax <?php echo expense_tab_money((float)$e['tax_amount']); ?></span><?php endif; ?>
               </div>
             </td>
             <td><span class="status-pill status-pill--<?php echo expense_tab_status_class($e['status']); ?>"><?php echo htmlspecialchars(ucfirst((string)$e['status'])); ?></span></td>

--- a/src/views/pages/financial/asset-detail.php
+++ b/src/views/pages/financial/asset-detail.php
@@ -6,13 +6,15 @@ require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 require_once __DIR__ . '/../../../utils/financial_assets.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 $id = (int)($_GET['id'] ?? 0);
 if ($id <= 0) {
     header('Location: /?page=financial/expenses-list&tab=assets');
     exit;
 }
 
+[$assetScopeWhere, $assetScopeParams] = finance_scope_clause($pdo, 'a', $userId, $orgId, 'created_by');
 $stmt = $pdo->prepare('
     SELECT a.*, v.name AS vendor_name, ec.name AS category_name,
            e.expense_date AS linked_expense_date, e.total_amount AS linked_expense_total, e.amount AS linked_expense_amount,
@@ -21,9 +23,9 @@ $stmt = $pdo->prepare('
     LEFT JOIN vendors v ON v.id = a.vendor_id
     LEFT JOIN expense_categories ec ON ec.id = a.category_id
     LEFT JOIN expenses e ON e.id = a.expense_id
-    WHERE a.id = ? AND a.organization_id = ?
+    WHERE a.id = ? AND ' . $assetScopeWhere . '
 ');
-$stmt->execute([$id, $orgId]);
+$stmt->execute(array_merge([$id], $assetScopeParams));
 $asset = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$asset) {
     header('Location: /?page=financial/expenses-list&tab=assets');
@@ -157,7 +159,7 @@ $linkedExpenseTotal = (float)($asset['linked_expense_total'] ?? $asset['linked_e
       <?php endif; ?>
 
       <?php if (!in_array((string)$asset['status'], ['disposed', 'lost'], true)): ?>
-        <form id="assetDisposeForm" method="post" action="/?page=financial/asset-handler" class="asset-dispose-form">
+        <form id="assetDisposeForm" method="post" action="/?page=financial/asset-handler" class="asset-dispose-form" onsubmit="return confirm('Mark this asset as disposed?')">
           <input type="hidden" name="_token" value="<?php echo htmlspecialchars(csrf_sf_token('asset')); ?>">
           <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
           <input type="hidden" name="action" value="delete">
@@ -168,25 +170,3 @@ $linkedExpenseTotal = (float)($asset['linked_expense_total'] ?? $asset['linked_e
     </aside>
   </div>
 </div>
-
-<script>
-(function() {
-  const form = document.getElementById('assetDisposeForm');
-  if (!form) return;
-  form.addEventListener('submit', async function(event) {
-    event.preventDefault();
-    if (!confirm('Mark this asset as disposed?')) return;
-    const response = await fetch('/?page=financial/asset-handler', {
-      method: 'POST',
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-      body: new FormData(form)
-    });
-    const data = await response.json();
-    if (data.success && data.redirect) {
-      window.location.href = data.redirect;
-    } else {
-      alert(data.message || 'Failed to update asset');
-    }
-  });
-})();
-</script>

--- a/src/views/pages/financial/asset-form.php
+++ b/src/views/pages/financial/asset-form.php
@@ -5,18 +5,19 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
 $editId = (int)($_GET['id'] ?? 0);
 
 $asset = null;
 if ($editId > 0) {
+    [$assetScopeWhere, $assetScopeParams] = finance_scope_clause($pdo, 'a', (int)($_SESSION['user']['id'] ?? 0), $orgId, 'created_by');
     $stmt = $pdo->prepare('
         SELECT a.*, v.name AS vendor_name
         FROM financial_assets a
         LEFT JOIN vendors v ON v.id = a.vendor_id
-        WHERE a.id = ? AND a.organization_id = ?
+        WHERE a.id = ? AND ' . $assetScopeWhere . '
     ');
-    $stmt->execute([$editId, $orgId]);
+    $stmt->execute(array_merge([$editId], $assetScopeParams));
     $asset = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$asset) {
         header('Location: /?page=financial/expenses-list&tab=assets');
@@ -32,15 +33,16 @@ $categoriesQ = $pdo->prepare('SELECT id, name FROM expense_categories WHERE orga
 $categoriesQ->execute([$orgId]);
 $categories = $categoriesQ->fetchAll(PDO::FETCH_ASSOC);
 
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', (int)($_SESSION['user']['id'] ?? 0), $orgId, 'created_by');
 $expensesQ = $pdo->prepare('
     SELECT e.id, e.expense_date, e.total_amount, e.amount, e.description, v.name AS vendor_name
     FROM expenses e
     LEFT JOIN vendors v ON v.id = e.vendor_id
-    WHERE e.organization_id = ? AND e.status != "void"
+    WHERE ' . $expenseScopeWhere . ' AND e.status != "void"
     ORDER BY e.expense_date DESC, e.id DESC
     LIMIT 200
 ');
-$expensesQ->execute([$orgId]);
+$expensesQ->execute($expenseScopeParams);
 $expenses = $expensesQ->fetchAll(PDO::FETCH_ASSOC);
 
 $typesQ = $pdo->prepare('SELECT DISTINCT asset_type FROM financial_assets WHERE organization_id = ? AND asset_type IS NOT NULL AND asset_type <> "" ORDER BY asset_type');
@@ -73,8 +75,12 @@ $selected = static function (string $key, string $value, string $default = '') u
     <input type="hidden" name="_token" value="<?php echo htmlspecialchars(csrf_sf_token('asset')); ?>">
     <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
     <input type="hidden" name="action" value="<?php echo $editId > 0 ? 'update' : 'create'; ?>">
-    <?php if ($editId > 0): ?><input type="hidden" name="id" value="<?php echo $editId; ?>"><?php endif; ?>
-    <input type="hidden" name="vendor_id" id="assetVendorId" value="<?php echo (int)($asset['vendor_id'] ?? 0); ?>">
+  <?php if ($editId > 0): ?><input type="hidden" name="id" value="<?php echo $editId; ?>"><?php endif; ?>
+  <input type="hidden" name="vendor_id" id="assetVendorId" value="<?php echo (int)($asset['vendor_id'] ?? 0); ?>">
+
+  <?php if (!empty($_GET['error'])): ?>
+    <div class="alert alert-danger"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+  <?php endif; ?>
 
     <section class="card asset-form-section">
       <div class="card-head">
@@ -269,25 +275,8 @@ $selected = static function (string $key, string $value, string $default = '') u
   });
   updateDepreciationEstimate();
 
-  form.addEventListener('submit', async function(event) {
-    event.preventDefault();
+  form.addEventListener('submit', function() {
     updateVendorId();
-    const formData = new FormData(form);
-    try {
-      const response = await fetch('/?page=financial/asset-handler', {
-        method: 'POST',
-        headers: { 'X-Requested-With': 'XMLHttpRequest' },
-        body: formData
-      });
-      const data = await response.json();
-      if (data.success && data.redirect) {
-        window.location.href = data.redirect;
-        return;
-      }
-      alert(data.message || 'Failed to save asset');
-    } catch (error) {
-      alert('Error: ' + error.message);
-    }
   });
 })();
 </script>

--- a/src/views/pages/financial/categories-list.php
+++ b/src/views/pages/financial/categories-list.php
@@ -5,18 +5,20 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
 
 $stmt = $pdo->prepare("
     SELECT c.*, pc.name as parent_name, COUNT(e.id) as expense_count, COALESCE(SUM(e.amount),0) as total_amount
     FROM expense_categories c
     LEFT JOIN expense_categories pc ON c.parent_id = pc.id
-    LEFT JOIN expenses e ON e.category_id = c.id
+    LEFT JOIN expenses e ON e.category_id = c.id AND {$expenseScopeWhere}
     WHERE c.organization_id = ?
     GROUP BY c.id
     ORDER BY c.is_system DESC, c.name
 ");
-$stmt->execute([$orgId]);
+$stmt->execute(array_merge($expenseScopeParams, [$orgId]));
 $categories = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $csrf = csrf_token();

--- a/src/views/pages/financial/csv-import.php
+++ b/src/views/pages/financial/csv-import.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
 // Fetch categories for default category dropdown
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
 $catStmt = $pdo->prepare('SELECT id, name FROM expense_categories WHERE organization_id=? ORDER BY name');
 $catStmt->execute([$orgId]);
 $categories = $catStmt->fetchAll(PDO::FETCH_ASSOC);
@@ -32,14 +32,14 @@ $categories = $catStmt->fetchAll(PDO::FETCH_ASSOC);
           <li>Date: <code>date</code>, <code>transaction date</code>, <code>order date</code></li>
           <li>Amount: <code>amount</code>, <code>debit</code>, <code>withdrawal</code>, <code>purchase price</code></li>
           <li>Vendor: <code>vendor</code>, <code>merchant</code>, <code>payee</code>, <code>seller</code></li>
-          <li>Optional: tax, total, reference/order ID, payment method</li>
+          <li>Optional: total and reference/order ID</li>
           <li>Negative debit amounts are accepted and imported as positive expenses</li>
         </ul>
       </div>
       <div>
         <div class="font-600" style="margin-bottom:6px">Example</div>
-        <pre style="margin:0;padding:10px;border:1px solid #e5e7eb;border-radius:8px;background:#f8fafc;overflow:auto;font-size:12px">date,vendor,description,amount,tax,total,reference,payment_method
-2026-06-01,Acme Supply,Cable clips,42.50,2.34,44.84,INV-1001,Card</pre>
+        <pre style="margin:0;padding:10px;border:1px solid #e5e7eb;border-radius:8px;background:#f8fafc;overflow:auto;font-size:12px">date,vendor,description,amount,total,reference
+2026-06-01,Acme Supply,Cable clips,42.50,42.50,INV-1001</pre>
       </div>
     </div>
   </div>
@@ -159,10 +159,8 @@ function buildMappingTable(headers, suggested, previewRows) {
     'vendor_name': 'Vendor Name',
     'description': 'Description',
     'amount': 'Amount',
-    'tax_amount': 'Tax Amount',
     'total_amount': 'Total Amount',
-    'reference_number': 'Reference Number',
-    'payment_method': 'Payment Method'
+    'reference_number': 'Reference Number'
   };
 
   let html = '<table class="pa-table"><thead><tr><th>Expense Field</th><th>CSV Column</th><th>Preview (first row)</th></tr></thead><tbody>';
@@ -182,7 +180,7 @@ function buildMappingTable(headers, suggested, previewRows) {
 
 async function runImport(dryRun) {
   const mapping = {};
-  ['expense_date', 'vendor_name', 'description', 'amount', 'tax_amount', 'total_amount', 'reference_number', 'payment_method'].forEach(field => {
+  ['expense_date', 'vendor_name', 'description', 'amount', 'total_amount', 'reference_number'].forEach(field => {
     const sel = document.getElementById('map_' + field);
     mapping[field] = sel ? (sel.value !== '' ? parseInt(sel.value) : null) : null;
   });

--- a/src/views/pages/financial/expense-create.php
+++ b/src/views/pages/financial/expense-create.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
 $orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 $editId = (int)($_GET['id'] ?? 0);
 
 // Pre-fill from query params (when coming from receipt)
@@ -24,25 +25,31 @@ $vendorsQ = $pdo->prepare('SELECT id, name FROM vendors WHERE organization_id=? 
 $vendorsQ->execute([$orgId]);
 $vendors = $vendorsQ->fetchAll(PDO::FETCH_ASSOC);
 
-$clientsQ = $pdo->query('SELECT id, name FROM clients ORDER BY name');
+$clientsQ = $pdo->prepare('SELECT id, name FROM clients WHERE organization_id = ? ORDER BY name');
+$clientsQ->execute([$orgId]);
 $clients = $clientsQ->fetchAll(PDO::FETCH_ASSOC);
 
-$projectsQ = $pdo->query('SELECT id, name FROM projects ORDER BY name');
+$projectsQ = $pdo->prepare('SELECT id, name FROM projects WHERE organization_id = ? ORDER BY name');
+$projectsQ->execute([$orgId]);
 $projects = $projectsQ->fetchAll(PDO::FETCH_ASSOC);
 
 // Load existing expense for edit mode
 $expense = null;
 if ($editId > 0) {
-    $stmt = $pdo->prepare('SELECT * FROM expenses WHERE id=? AND organization_id=?');
-    $stmt->execute([$editId, $orgId]);
+    [$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
+    $stmt = $pdo->prepare('
+        SELECT e.*, v.name AS vendor_name
+        FROM expenses e
+        LEFT JOIN vendors v ON v.id = e.vendor_id
+        WHERE e.id = ? AND ' . $expenseScopeWhere . '
+    ');
+    $stmt->execute(array_merge([$editId], $expenseScopeParams));
     $expense = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$expense) {
         header('Location: /?page=financial/expenses-list&tab=expenses');
         exit;
     }
 }
-
-$paymentMethods = [];
 ?>
 
 <div style="max-width:800px;margin:0 auto;padding:24px">
@@ -73,7 +80,7 @@ $paymentMethods = [];
                value="<?php echo htmlspecialchars($expense['vendor_name'] ?? $prefillVendor); ?>"
                placeholder="Start typing or select vendor" class="input">
         <datalist id="vendorList">
-          <?php foreach ($vendors as $v): ?><option value="<?php echo htmlspecialchars($v['name']); ?>" data-id="<?php echo (int)$v['id']; ?>"><?php endforeach; ?>
+          <?php foreach ($vendors as $v): ?><option value="<?php echo htmlspecialchars($v['name']); ?>" data-id="<?php echo (int)$v['id']; ?>"></option><?php endforeach; ?>
         </datalist>
       </div>
 
@@ -97,15 +104,6 @@ $paymentMethods = [];
       <div class="field">
         <label class="label">Expense Date *</label>
         <input type="date" name="expense_date" required value="<?php echo htmlspecialchars($expense['expense_date'] ?? $prefillDate); ?>" class="input">
-      </div>
-      <div class="field" style="display:none">
-        <label class="label">Payment Method</label>
-        <select name="payment_method" class="input">
-          <option value="">— Select —</option>
-          <?php foreach ($paymentMethods as $val => $label): ?>
-            <option value="<?php echo $val; ?>" <?php echo ($expense['payment_method'] ?? '') === $val ? 'selected' : ''; ?>><?php echo $label; ?></option>
-          <?php endforeach; ?>
-        </select>
       </div>
     </div>
 

--- a/src/views/pages/financial/expense-detail.php
+++ b/src/views/pages/financial/expense-detail.php
@@ -5,10 +5,12 @@ require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 $id = (int)($_GET['id'] ?? 0);
 if (!$id) { header('Location: /?page=financial/expenses-list&tab=expenses'); exit; }
 
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
 $stmt = $pdo->prepare('
     SELECT e.*, v.name as vendor_name, ec.name as category_name, c.name as client_name, p.name as project_name,
            r.file_path, r.file_name, r.mime_type
@@ -18,9 +20,9 @@ $stmt = $pdo->prepare('
     LEFT JOIN clients c ON c.id = e.client_id
     LEFT JOIN projects p ON p.id = e.project_id
     LEFT JOIN receipts r ON r.id = e.receipt_id
-    WHERE e.id=? AND e.organization_id=?
+    WHERE e.id=? AND ' . $expenseScopeWhere . '
 ');
-$stmt->execute([$id, $orgId]);
+$stmt->execute(array_merge([$id], $expenseScopeParams));
 $e = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$e) { header('Location: /?page=financial/expenses-list&tab=expenses'); exit; }
 
@@ -31,7 +33,6 @@ if ($hasReceipt) {
     $fileParam = str_replace('/src/uploads/', '', $e['file_path']);
     $fileUrl = '/?page=serve-upload&file=' . urlencode($fileParam);
 }
-$paymentLabels = ['cash' => 'Cash', 'check' => 'Check', 'card' => 'Credit/Debit Card', 'bank_transfer' => 'Bank Transfer', 'paypal' => 'PayPal', 'venmo' => 'Venmo', 'other' => 'Other'];
 ?>
 
 <div style="max-width:1200px;margin:0 auto;padding:24px">
@@ -74,14 +75,10 @@ $paymentLabels = ['cash' => 'Cash', 'check' => 'Check', 'card' => 'Credit/Debit 
       <div class="field"><label class="label-muted">Category</label><div><?php echo htmlspecialchars($e['category_name'] ?? '—'); ?></div></div>
       <div class="field"><label class="label-muted">Description</label><div><?php echo htmlspecialchars($e['description'] ?? '—'); ?></div></div>
 
-      <div class="grid grid-3" style="margin:12px 0">
+      <div class="grid grid-2" style="margin:12px 0">
         <div class="card-tight" style="background:var(--surface-2);border-radius:var(--radius-sm);padding:12px">
           <div class="muted text-sm">Amount</div>
           <div class="font-600" style="font-size:18px">$<?php echo number_format((float)$e['amount'], 2); ?></div>
-        </div>
-        <div class="card-tight" style="background:var(--surface-2);border-radius:var(--radius-sm);padding:12px">
-          <div class="muted text-sm">Tax</div>
-          <div class="font-600" style="font-size:18px"><?php echo $e['tax_amount'] !== null ? '$' . number_format((float)$e['tax_amount'], 2) : '—'; ?></div>
         </div>
         <div class="card-tight" style="background:var(--surface-2);border-radius:var(--radius-sm);padding:12px">
           <div class="muted text-sm">Total</div>
@@ -89,7 +86,6 @@ $paymentLabels = ['cash' => 'Cash', 'check' => 'Check', 'card' => 'Credit/Debit 
         </div>
       </div>
 
-      <div class="field"><label class="label-muted">Payment Method</label><div><?php echo htmlspecialchars($paymentLabels[$e['payment_method']] ?? $e['payment_method'] ?? '—'); ?></div></div>
       <div class="field"><label class="label-muted">Reference Number</label><div><?php echo htmlspecialchars($e['reference_number'] ?? '—'); ?></div></div>
 
       <div class="grid grid-2" style="margin:12px 0">

--- a/src/views/pages/financial/expense-report.php
+++ b/src/views/pages/financial/expense-report.php
@@ -6,7 +6,8 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/format.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id() ?: 0;
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 // Fetch filter options
 $catStmt = $pdo->prepare('SELECT id, name FROM expense_categories WHERE organization_id=? ORDER BY name');
@@ -17,7 +18,8 @@ $vendorStmt = $pdo->prepare('SELECT id, name FROM vendors WHERE organization_id=
 $vendorStmt->execute([$orgId]);
 $vendors = $vendorStmt->fetchAll(PDO::FETCH_ASSOC);
 
-$clientStmt = $pdo->query('SELECT id, name FROM clients ORDER BY name');
+$clientStmt = $pdo->prepare('SELECT id, name FROM clients WHERE organization_id = ? ORDER BY name');
+$clientStmt->execute([$orgId]);
 $clients = $clientStmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Filters
@@ -31,8 +33,9 @@ $taxDeductible = $_GET['tax_deductible'] ?? '';
 $status = $_GET['status'] ?? '';
 $groupBy = $_GET['group_by'] ?? 'none';
 
-$where = ['e.organization_id = ?'];
-$params = [$orgId];
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
+$where = [$expenseScopeWhere];
+$params = $expenseScopeParams;
 
 if ($start) { $where[] = 'e.expense_date >= ?'; $params[] = $start; }
 if ($end) { $where[] = 'e.expense_date <= ?'; $params[] = $end; }
@@ -50,7 +53,6 @@ $whereSQL = implode(' AND ', $where);
 // Summary totals
 $summaryStmt = $pdo->prepare("
     SELECT COALESCE(SUM(e.amount),0) as total_amount,
-           COALESCE(SUM(e.tax_amount),0) as total_tax,
            COALESCE(SUM(e.total_amount),0) as grand_total,
            COALESCE(SUM(CASE WHEN e.is_billable=1 THEN e.total_amount ELSE 0 END),0) as billable_total,
            COALESCE(SUM(CASE WHEN e.is_tax_deductible=1 THEN e.total_amount ELSE 0 END),0) as deductible_total,
@@ -62,14 +64,6 @@ $summary = $summaryStmt->fetch(PDO::FETCH_ASSOC);
 
 // Build query based on group_by
 if ($groupBy === 'category') {
-    $sql = "
-        SELECT ec.name as group_name, COALESCE(SUM(e.total_amount),0) as total, COUNT(e.id) as count
-        FROM expense_categories ec
-        LEFT JOIN expenses e ON e.category_id = ec.id AND " . implode(' AND ', array_map(function($w) { return 'e.' . $w; }, $where)) . "
-        WHERE ec.organization_id = ?
-        GROUP BY ec.id ORDER BY total DESC
-    ";
-    // This approach is complex with the WHERE clause; simpler to do it directly:
     $groupStmt = $pdo->prepare("
         SELECT ec.name as group_name, COALESCE(SUM(e.total_amount),0) as total, COUNT(e.id) as count
         FROM expenses e
@@ -217,15 +211,11 @@ $exportParams = http_build_query(array_filter([
   </div>
 
   <!-- Summary Cards -->
-  <div class="grid grid-4" style="margin-bottom:20px">
+  <div class="grid grid-3" style="margin-bottom:20px">
     <div class="card card-tight">
       <div class="muted text-sm">Total Expenses</div>
       <div class="font-600" style="font-size:20px"><?php echo money_format_total($summary['grand_total']); ?></div>
       <div class="muted-note"><?php echo (int)$summary['count']; ?> expenses</div>
-    </div>
-    <div class="card card-tight">
-      <div class="muted text-sm">Tax Amount</div>
-      <div class="font-600" style="font-size:20px"><?php echo money_format_total($summary['total_tax']); ?></div>
     </div>
     <div class="card card-tight">
       <div class="muted text-sm">Billable</div>
@@ -348,9 +338,7 @@ $exportParams = http_build_query(array_filter([
             <th>Description</th>
             <th>Category</th>
             <th class="text-right">Amount</th>
-            <th class="text-right">Tax</th>
             <th class="text-right">Total</th>
-            <th>Payment</th>
             <th>Billable</th>
             <th>Status</th>
           </tr>
@@ -363,9 +351,7 @@ $exportParams = http_build_query(array_filter([
               <td><?php echo htmlspecialchars(mb_substr($d['description'] ?? '', 0, 40)); ?></td>
               <td><?php echo htmlspecialchars($d['category_name'] ?? '—'); ?></td>
               <td class="text-right"><?php echo htmlspecialchars(money_format_total($d['amount'])); ?></td>
-              <td class="text-right"><?php echo $d['tax_amount'] ? htmlspecialchars(money_format_total($d['tax_amount'])) : '—'; ?></td>
               <td class="text-right font-600"><?php echo htmlspecialchars(money_format_total($d['total_amount'] ?? $d['amount'])); ?></td>
-              <td><?php echo htmlspecialchars($d['payment_method'] ?? '—'); ?></td>
               <td><?php echo $d['is_billable'] ? '<span class="status-pill status-pill--active">Billable</span>' : '<span class="muted">—</span>'; ?></td>
               <td><span class="status-pill status-pill--<?php echo htmlspecialchars(strtolower($d['status'])); ?>"><?php echo htmlspecialchars($d['status']); ?></span></td>
             </tr>

--- a/src/views/pages/financial/expenses-list.php
+++ b/src/views/pages/financial/expenses-list.php
@@ -6,7 +6,8 @@ require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 $csrfToken = csrf_sf_token('expense');
 
 $tabs = [
@@ -33,20 +34,24 @@ $stats = [
 ];
 
 try {
-    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM financial_assets WHERE organization_id=? AND status NOT IN ('disposed','lost')");
-    $countStmt->execute([$orgId]);
+    [$assetScopeWhere, $assetScopeParams] = finance_scope_clause($pdo, 'a', $userId, $orgId, 'created_by');
+    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM financial_assets a WHERE {$assetScopeWhere} AND a.status NOT IN ('disposed','lost')");
+    $countStmt->execute($assetScopeParams);
     $stats['assets'] = (int)$countStmt->fetchColumn();
 
-    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM expenses WHERE organization_id=? AND status != 'void'");
-    $countStmt->execute([$orgId]);
+    [$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
+    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM expenses e WHERE {$expenseScopeWhere} AND e.status != 'void'");
+    $countStmt->execute($expenseScopeParams);
     $stats['expenses'] = (int)$countStmt->fetchColumn();
 
-    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM receipts WHERE organization_id=?");
-    $countStmt->execute([$orgId]);
+    [$receiptScopeWhere, $receiptScopeParams] = finance_scope_clause($pdo, 'r', $userId, $orgId, 'uploaded_by');
+    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM receipts r WHERE {$receiptScopeWhere}");
+    $countStmt->execute($receiptScopeParams);
     $stats['receipts'] = (int)$countStmt->fetchColumn();
 
-    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM mileage_logs WHERE organization_id=?");
-    $countStmt->execute([$orgId]);
+    [$mileageScopeWhere, $mileageScopeParams] = finance_scope_clause($pdo, 'm', $userId, $orgId, 'user_id');
+    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM mileage_logs m WHERE {$mileageScopeWhere}");
+    $countStmt->execute($mileageScopeParams);
     $stats['mileage'] = (int)$countStmt->fetchColumn();
 
     $countStmt = $pdo->prepare("SELECT COUNT(*) FROM vendors WHERE organization_id=? AND is_active=1");

--- a/src/views/pages/financial/financial-dashboard.php
+++ b/src/views/pages/financial/financial-dashboard.php
@@ -3,7 +3,8 @@
 require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 // Date range filter (default: current year)
 $defaultStartDate = date('Y') . '-01-01';
@@ -17,34 +18,38 @@ $incomeStmt = $pdo->prepare("SELECT COALESCE(SUM(GREATEST(p.amount-p.refunded_am
 $incomeStmt->execute([$orgId, $orgId, $start, $end]);
 $totalIncome = (float)$incomeStmt->fetchColumn();
 
-$expenseStmt = $pdo->prepare("SELECT COALESCE(SUM(total_amount),0) as total, COUNT(*) as count FROM expenses WHERE organization_id=? AND status != 'void' AND expense_date BETWEEN ? AND ?");
-$expenseStmt->execute([$orgId, $start, $end]);
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
+[$mileageScopeWhere, $mileageScopeParams] = finance_scope_clause($pdo, 'm', $userId, $orgId, 'user_id');
+[$receiptScopeWhere, $receiptScopeParams] = finance_scope_clause($pdo, 'r', $userId, $orgId, 'uploaded_by');
+
+$expenseStmt = $pdo->prepare("SELECT COALESCE(SUM(e.total_amount),0) as total, COUNT(*) as count FROM expenses e WHERE {$expenseScopeWhere} AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?");
+$expenseStmt->execute(array_merge($expenseScopeParams, [$start, $end]));
 $expenseSummary = $expenseStmt->fetch(PDO::FETCH_ASSOC);
 $totalExpenses = (float)$expenseSummary['total'];
 $expenseCount = (int)$expenseSummary['count'];
 $netProfit = $totalIncome - $totalExpenses;
 
-$mileageStmt = $pdo->prepare("SELECT COALESCE(SUM(miles * mileage_rate),0) as total, COALESCE(SUM(miles),0) as miles, COUNT(*) as trips FROM mileage_logs WHERE organization_id=? AND purpose='business' AND trip_date BETWEEN ? AND ?");
-$mileageStmt->execute([$orgId, $start, $end]);
+$mileageStmt = $pdo->prepare("SELECT COALESCE(SUM(m.miles * m.mileage_rate),0) as total, COALESCE(SUM(m.miles),0) as miles, COUNT(*) as trips FROM mileage_logs m WHERE {$mileageScopeWhere} AND m.purpose='business' AND m.trip_date BETWEEN ? AND ?");
+$mileageStmt->execute(array_merge($mileageScopeParams, [$start, $end]));
 $mileageSummary = $mileageStmt->fetch(PDO::FETCH_ASSOC);
 $totalMileageDeduction = (float)($mileageSummary['total'] ?? 0);
 $totalMiles = (float)($mileageSummary['miles'] ?? 0);
 $totalTrips = (int)($mileageSummary['trips'] ?? 0);
 
-$receiptStmt = $pdo->prepare("SELECT COUNT(*) as count FROM receipts WHERE organization_id=? AND created_at BETWEEN ? AND ?");
-$receiptStmt->execute([$orgId, $start . ' 00:00:00', $end . ' 23:59:59']);
+$receiptStmt = $pdo->prepare("SELECT COUNT(*) as count FROM receipts r WHERE {$receiptScopeWhere} AND r.created_at BETWEEN ? AND ?");
+$receiptStmt->execute(array_merge($receiptScopeParams, [$start . ' 00:00:00', $end . ' 23:59:59']));
 $receiptCount = (int)$receiptStmt->fetchColumn();
 
 $catStmt = $pdo->prepare("
     SELECT ec.name, ec.color, COALESCE(SUM(e.total_amount),0) as total, COUNT(e.id) as count
     FROM expense_categories ec
-    LEFT JOIN expenses e ON e.category_id = ec.id AND e.organization_id = ? AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?
+    LEFT JOIN expenses e ON e.category_id = ec.id AND {$expenseScopeWhere} AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?
     WHERE ec.organization_id = ?
     GROUP BY ec.id
     HAVING total > 0
     ORDER BY total DESC
 ");
-$catStmt->execute([$orgId, $start, $end, $orgId]);
+$catStmt->execute(array_merge($expenseScopeParams, [$start, $end, $orgId]));
 $categories = $catStmt->fetchAll(PDO::FETCH_ASSOC);
 $categoryMax = 0;
 foreach ($categories as $c) $categoryMax = max($categoryMax, (float)$c['total']);
@@ -52,14 +57,14 @@ foreach ($categories as $c) $categoryMax = max($categoryMax, (float)$c['total'])
 $vendorStmt = $pdo->prepare("
     SELECT v.name, COALESCE(SUM(e.total_amount),0) as total, COUNT(e.id) as count
     FROM vendors v
-    LEFT JOIN expenses e ON e.vendor_id = v.id AND e.organization_id = ? AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?
+    LEFT JOIN expenses e ON e.vendor_id = v.id AND {$expenseScopeWhere} AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?
     WHERE v.organization_id = ? AND v.is_active = 1
     GROUP BY v.id
     HAVING total > 0
     ORDER BY total DESC
     LIMIT 8
 ");
-$vendorStmt->execute([$orgId, $start, $end, $orgId]);
+$vendorStmt->execute(array_merge($expenseScopeParams, [$start, $end, $orgId]));
 $vendors = $vendorStmt->fetchAll(PDO::FETCH_ASSOC);
 
 $recentStmt = $pdo->prepare("
@@ -67,21 +72,21 @@ $recentStmt = $pdo->prepare("
     FROM expenses e
     LEFT JOIN expense_categories ec ON ec.id = e.category_id
     LEFT JOIN vendors v ON v.id = e.vendor_id
-    WHERE e.organization_id = ? AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?
+    WHERE {$expenseScopeWhere} AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?
     ORDER BY e.expense_date DESC, e.id DESC
     LIMIT 10
 ");
-$recentStmt->execute([$orgId, $start, $end]);
+$recentStmt->execute(array_merge($expenseScopeParams, [$start, $end]));
 $recentExpenses = $recentStmt->fetchAll(PDO::FETCH_ASSOC);
 
 $statusStmt = $pdo->prepare("
     SELECT status, COUNT(*) as count, COALESCE(SUM(total_amount),0) as total
-    FROM expenses
-    WHERE organization_id = ? AND expense_date BETWEEN ? AND ?
+    FROM expenses e
+    WHERE {$expenseScopeWhere} AND e.expense_date BETWEEN ? AND ?
     GROUP BY status
     ORDER BY total DESC
 ");
-$statusStmt->execute([$orgId, $start, $end]);
+$statusStmt->execute(array_merge($expenseScopeParams, [$start, $end]));
 $statusSummary = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
 
 $incomeTrendStmt = $pdo->prepare("
@@ -97,12 +102,12 @@ foreach ($incomeTrendStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
 }
 
 $expenseTrendStmt = $pdo->prepare("
-    SELECT DATE_FORMAT(expense_date, '%Y-%m') as period, COALESCE(SUM(total_amount),0) as total
-    FROM expenses
-    WHERE organization_id=? AND status != 'void' AND expense_date BETWEEN ? AND ?
+    SELECT DATE_FORMAT(e.expense_date, '%Y-%m') as period, COALESCE(SUM(e.total_amount),0) as total
+    FROM expenses e
+    WHERE {$expenseScopeWhere} AND e.status != 'void' AND e.expense_date BETWEEN ? AND ?
     GROUP BY period
 ");
-$expenseTrendStmt->execute([$orgId, $start, $end]);
+$expenseTrendStmt->execute(array_merge($expenseScopeParams, [$start, $end]));
 $expensesByMonth = [];
 foreach ($expenseTrendStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
     $expensesByMonth[$row['period']] = (float)$row['total'];

--- a/src/views/pages/financial/mileage-create.php
+++ b/src/views/pages/financial/mileage-create.php
@@ -3,6 +3,10 @@
 require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/csrf_sf.php';
+require_once __DIR__ . '/../../../utils/acl.php';
+
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 $editMode = false;
 $log = [
@@ -22,13 +26,14 @@ $log = [
 
 $editId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($editId > 0) {
+    [$mileageScopeWhere, $mileageScopeParams] = finance_scope_clause($pdo, 'm', $userId, $orgId, 'user_id');
     $stmt = $pdo->prepare('
         SELECT m.*, c.name AS client_name
         FROM mileage_logs m
         LEFT JOIN clients c ON m.client_id = c.id
-        WHERE m.id = ? AND m.organization_id = ?
+        WHERE m.id = ? AND ' . $mileageScopeWhere . '
     ');
-    $stmt->execute([$editId, 1]);
+    $stmt->execute(array_merge([$editId], $mileageScopeParams));
     $existing = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($existing) {
         $editMode = true;
@@ -37,7 +42,8 @@ if ($editId > 0) {
 }
 
 // Clients for billable dropdown
-$clientsStmt = $pdo->query('SELECT id, name FROM clients ORDER BY name ASC');
+$clientsStmt = $pdo->prepare('SELECT id, name FROM clients WHERE organization_id = ? ORDER BY name ASC');
+$clientsStmt->execute([$orgId]);
 $clients = $clientsStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
@@ -220,20 +226,5 @@ $clients = $clientsStmt->fetchAll(PDO::FETCH_ASSOC);
   updateCalculations();
   updateBillableFields();
 
-  // AJAX form submission for a smoother UX
-  form.addEventListener('submit', function (e) {
-    e.preventDefault();
-    var data = new FormData(form);
-    fetch(form.action, { method: 'POST', body: data })
-      .then(function (r) { return r.json(); })
-      .then(function (res) {
-        if (res.success && res.redirect) {
-          window.location.href = res.redirect;
-        } else {
-          alert(res.message || 'Failed to save mileage entry');
-        }
-      })
-      .catch(function () { alert('Request failed'); });
-  });
 })();
 </script>

--- a/src/views/pages/financial/mileage-list.php
+++ b/src/views/pages/financial/mileage-list.php
@@ -5,7 +5,8 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 // Filters
 $start = $_GET['start'] ?? '';
@@ -14,8 +15,9 @@ $purpose = $_GET['purpose'] ?? '';
 $clientId = isset($_GET['client_id']) && $_GET['client_id'] !== '' ? (int)$_GET['client_id'] : 0;
 $billable = $_GET['billable'] ?? '';
 
-$where = ['m.organization_id = ?'];
-$params = [$orgId];
+[$mileageScopeWhere, $mileageScopeParams] = finance_scope_clause($pdo, 'm', $userId, $orgId, 'user_id');
+$where = [$mileageScopeWhere];
+$params = $mileageScopeParams;
 
 if ($start !== '') {
     $where[] = 'm.trip_date >= ?';
@@ -75,7 +77,8 @@ foreach ($logs as $log) {
 }
 
 // Clients for filter dropdown
-$clientsStmt = $pdo->query('SELECT id, name FROM clients ORDER BY name ASC');
+$clientsStmt = $pdo->prepare('SELECT id, name FROM clients WHERE organization_id = ? ORDER BY name ASC');
+$clientsStmt->execute([$orgId]);
 $clients = $clientsStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
@@ -224,7 +227,7 @@ $clients = $clientsStmt->fetchAll(PDO::FETCH_ASSOC);
               <td class="text-right">
                 <div class="flex flex-end">
                   <a href="/?page=financial/mileage-create&id=<?php echo (int)$log['id']; ?>" class="btn btn-sm">Edit</a>
-                  <form method="post" action="/?page=financial/mileage-handler" class="inline-form mileage-delete-form" style="display:inline">
+                  <form method="post" action="/?page=financial/mileage-handler" class="inline-form mileage-delete-form" style="display:inline" onsubmit="return confirm('Delete this mileage entry?')">
                     <input type="hidden" name="_token" value="<?php echo htmlspecialchars(csrf_sf_token('mileage')); ?>">
                     <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
                     <input type="hidden" name="action" value="delete">
@@ -240,26 +243,3 @@ $clients = $clientsStmt->fetchAll(PDO::FETCH_ASSOC);
     </table>
   </div>
 </section>
-
-<script>
-  document.querySelectorAll('.mileage-delete-form').forEach(function (form) {
-    form.addEventListener('submit', function (e) {
-      if (!confirm('Delete this mileage entry?')) {
-        e.preventDefault();
-        return false;
-      }
-      e.preventDefault();
-      var data = new FormData(form);
-      fetch(form.action, { method: 'POST', body: data })
-        .then(function (r) { return r.json(); })
-        .then(function (res) {
-          if (res.success && res.redirect) {
-            window.location.href = res.redirect;
-          } else {
-            alert(res.message || 'Failed to delete mileage entry');
-          }
-        })
-        .catch(function () { alert('Request failed'); });
-    });
-  });
-</script>

--- a/src/views/pages/financial/receipt-detail.php
+++ b/src/views/pages/financial/receipt-detail.php
@@ -5,7 +5,8 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
 $receiptId = (int)($_GET['id'] ?? 0);
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 // Get existing stores for edit modal
 $storeStmt = $pdo->prepare('SELECT DISTINCT name FROM vendors WHERE organization_id = ? ORDER BY name');
@@ -18,13 +19,14 @@ if (!$receiptId) {
 }
 
 // Fetch receipt details
+[$receiptScopeWhere, $receiptScopeParams] = finance_scope_clause($pdo, 'r', $userId, $orgId, 'uploaded_by');
 $stmt = $pdo->prepare('
     SELECT r.*, rs.name as store_name
     FROM receipts r
     LEFT JOIN vendors rs ON r.store_id = rs.id
-    WHERE r.id = ? AND r.organization_id = ?
+    WHERE r.id = ? AND ' . $receiptScopeWhere . '
 ');
-$stmt->execute([$receiptId, $orgId]);
+$stmt->execute(array_merge([$receiptId], $receiptScopeParams));
 $receipt = $stmt->fetch(PDO::FETCH_ASSOC);
 
 if (!$receipt) {
@@ -154,7 +156,7 @@ $isPdf = $fileExt === 'pdf';
     <div style="background:#fff;border-radius:12px;padding:24px;max-width:500px;width:90%;max-height:90vh;overflow-y:auto">
         <h3 style="margin:0 0 16px 0">Edit Receipt</h3>
         
-        <form id="editForm" enctype="multipart/form-data">
+        <form id="editForm" method="post" action="/?page=receipts-handler" enctype="multipart/form-data">
             <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
             <input type="hidden" name="action" value="update">
             <input type="hidden" name="receipt_id" value="<?php echo $receiptId; ?>">

--- a/src/views/pages/financial/receipt-upload.php
+++ b/src/views/pages/financial/receipt-upload.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
 
 // Get all existing stores for autocomplete
 $stmt = $pdo->prepare('SELECT DISTINCT name FROM vendors WHERE organization_id = ? ORDER BY name');
@@ -22,7 +22,11 @@ $stores = $stmt->fetchAll(PDO::FETCH_COLUMN);
     <h1 style="margin:0 0 8px 0">Upload Receipt</h1>
     <p style="margin:0 0 24px 0;color:var(--muted)">Upload an image or PDF of your business expense receipt</p>
 
-    <form id="receiptUploadForm" enctype="multipart/form-data" style="background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:24px">
+    <?php if (!empty($_GET['error'])): ?>
+        <div class="alert alert-danger" style="margin-bottom:16px"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+    <?php endif; ?>
+
+    <form id="receiptUploadForm" method="post" action="/?page=receipts-handler" enctype="multipart/form-data" style="background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:24px">
         <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
         <input type="hidden" name="action" value="create">
 

--- a/src/views/pages/financial/receipts-list.php
+++ b/src/views/pages/financial/receipts-list.php
@@ -5,7 +5,8 @@ require_once __DIR__ . '/../../../utils/format.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
 
 // Get filter parameters with defaults to current year/month
 $filterStore = $_GET['store'] ?? '';
@@ -15,8 +16,9 @@ $filterMinAmount = $_GET['min_amount'] ?? '';
 $filterMaxAmount = $_GET['max_amount'] ?? '';
 
 // Build WHERE clause
-$whereClauses = ['r.organization_id = ?'];
-$params = [$orgId];
+[$receiptScopeWhere, $receiptScopeParams] = finance_scope_clause($pdo, 'r', $userId, $orgId, 'uploaded_by');
+$whereClauses = [$receiptScopeWhere];
+$params = $receiptScopeParams;
 
 if (!empty($filterStore)) {
     $whereClauses[] = 'rs.name = ?';
@@ -62,8 +64,8 @@ $storeStmt->execute([$orgId]);
 $stores = $storeStmt->fetchAll(PDO::FETCH_COLUMN);
 
 // Get available years
-$yearStmt = $pdo->prepare('SELECT DISTINCT YEAR(receipt_date) as year FROM receipts WHERE organization_id = ? ORDER BY year DESC');
-$yearStmt->execute([$orgId]);
+$yearStmt = $pdo->prepare('SELECT DISTINCT YEAR(r.receipt_date) as year FROM receipts r WHERE ' . $receiptScopeWhere . ' ORDER BY year DESC');
+$yearStmt->execute($receiptScopeParams);
 $years = $yearStmt->fetchAll(PDO::FETCH_COLUMN);
 
 // Always include current year if not present
@@ -83,6 +85,14 @@ if (!in_array($currentYear, $years)) {
             + Upload Receipt
         </a>
     </div>
+
+    <?php if (!empty($_GET['created'])): ?>
+        <div class="alert alert-success" style="margin-bottom:16px">Receipt uploaded.</div>
+    <?php elseif (!empty($_GET['deleted'])): ?>
+        <div class="alert alert-success" style="margin-bottom:16px">Receipt deleted.</div>
+    <?php elseif (!empty($_GET['error'])): ?>
+        <div class="alert alert-danger" style="margin-bottom:16px"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+    <?php endif; ?>
 
     <!-- Filters -->
     <?php

--- a/src/views/pages/financial/vendor-form.php
+++ b/src/views/pages/financial/vendor-form.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
 
 // Fetch categories for default_category_id dropdown
 $catStmt = $pdo->prepare("

--- a/src/views/pages/financial/vendors-list.php
+++ b/src/views/pages/financial/vendors-list.php
@@ -5,18 +5,20 @@ require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
-$orgId = get_active_org_id();
+$orgId = active_or_default_org_id($pdo);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
 
 $stmt = $pdo->prepare("
     SELECT v.*, ec.name as default_category_name, COUNT(e.id) as expense_count, COALESCE(SUM(e.amount),0) as total_spent
     FROM vendors v
-    LEFT JOIN expenses e ON e.vendor_id = v.id
+    LEFT JOIN expenses e ON e.vendor_id = v.id AND {$expenseScopeWhere}
     LEFT JOIN expense_categories ec ON v.default_category_id = ec.id
     WHERE v.organization_id = ?
     GROUP BY v.id
     ORDER BY v.name
 ");
-$stmt->execute([$orgId]);
+$stmt->execute(array_merge($expenseScopeParams, [$orgId]));
 $vendors = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $totalVendors = count($vendors);

--- a/tests/Security/SecurityHardeningTest.php
+++ b/tests/Security/SecurityHardeningTest.php
@@ -100,9 +100,11 @@ final class SecurityHardeningTest extends TestCase
 
         $csv = $this->read('src/controllers/financial/csv_import.php');
         self::assertStringNotContainsString('$orgId = 1;', $csv);
-        self::assertStringContainsString('get_active_org_id()', $csv);
+        self::assertStringContainsString('active_or_default_org_id($pdo)', $csv);
         self::assertStringContainsString('financial.manage', $csv);
         self::assertStringContainsString('expense_categories WHERE id = ? AND organization_id = ?', $csv);
+        self::assertStringContainsString('$taxAmount = null;', $csv);
+        self::assertStringContainsString('$pm = null;', $csv);
 
         $payments = $this->read('src/controllers/payments_create.php');
         $invoiceLifecycle = $this->read('src/utils/invoice_lifecycle.php');

--- a/tests/Workflows/FinancialAssetsTest.php
+++ b/tests/Workflows/FinancialAssetsTest.php
@@ -93,6 +93,8 @@ final class FinancialAssetsTest extends TestCase
     {
         $form = $this->read('src/views/pages/financial/asset-form.php');
         self::assertStringContainsString("csrf_sf_token('asset')", $form);
+        self::assertStringContainsString('action="/?page=financial/asset-handler"', $form);
+        self::assertStringNotContainsString("fetch('/?page=financial/asset-handler'", $form);
         self::assertStringContainsString('Useful Life (months)', $form);
         self::assertStringContainsString('Estimated Monthly', $form);
         self::assertStringContainsString('Linked Expense', $form);
@@ -102,6 +104,29 @@ final class FinancialAssetsTest extends TestCase
         self::assertStringContainsString('Accumulated Depreciation', $detail);
         self::assertStringContainsString('Linked Expense', $detail);
         self::assertStringContainsString('Mark Disposed', $detail);
+        self::assertStringNotContainsString("fetch('/?page=financial/asset-handler'", $detail);
+
+        $handler = $this->read('src/controllers/financial/asset_handler.php');
+        self::assertStringContainsString('function asset_handler_finish', $handler);
+        self::assertStringContainsString('active_or_default_org_id($pdo)', $handler);
+        self::assertStringContainsString('finance_scope_clause($pdo, \'a\'', $handler);
+    }
+
+    public function testFinancialHubUsesConsistentFinanceScope(): void
+    {
+        $acl = $this->read('src/utils/acl.php');
+        self::assertStringContainsString('function finance_scope_clause', $acl);
+
+        foreach ([
+            'src/views/pages/financial/expenses-list.php',
+            'src/views/pages/financial/_expenses_tab.php',
+            'src/views/pages/financial/_assets_tab.php',
+            'src/views/pages/financial/financial-dashboard.php',
+            'src/views/pages/financial/expense-report.php',
+            'src/controllers/financial/expense_export.php',
+        ] as $path) {
+            self::assertStringContainsString('finance_scope_clause', $this->read($path), $path);
+        }
     }
 
     private function read(string $relativePath): string

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -337,9 +337,9 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('$taxAmount = null;', (string)$expenseHandler);
         self::assertStringContainsString('$paymentMethod = null;', (string)$expenseHandler);
         self::assertStringNotContainsString('id="taxInput"', (string)$expenseCreate);
+        self::assertStringNotContainsString('name="payment_method"', (string)$expenseCreate);
         self::assertStringNotContainsString('fetch(form.action', (string)$expenseCreate);
         self::assertStringContainsString('$_GET[\'error\']', (string)$expenseCreate);
-        self::assertStringContainsString('style="display:none"', (string)$expenseCreate);
         self::assertStringContainsString('#toolbar=0&navpanes=0&scrollbar=0&view=FitH', (string)$formsList);
         self::assertStringContainsString('Open PDF in new tab', (string)$formDetail);
         self::assertStringContainsString('X-Frame-Options: SAMEORIGIN', (string)$securityHeaders);


### PR DESCRIPTION
## Summary
- make assets, expenses, receipts, mileage, vendors, and categories resilient to normal POST redirects as well as AJAX
- apply consistent finance scoping so admins see all records and non-admin finance users see their own records
- clean up expense tax/payment-method UI and import/export/report behavior

## Verification
- php -l on all changed PHP files
- node --check public/assets/js/receipt-upload-logic.js
- node --check public/assets/js/receipt-detail-logic.js
- git diff --check

Note: local PHPUnit is blocked by Composer metadata not registering phpunit/phpunit, even though files exist in vendor.