### PR TITLE
Add manual payments and refund handling

### DIFF
--- a/database/baseline.sql
+++ b/database/baseline.sql
@@ -1851,7 +1851,10 @@ INSERT INTO app_config (config_key, config_value) VALUES
     ('invoice_missing_content_links_behavior', 'warn'),
     ('invoice_auto_send_due_7days', '1'),
     ('invoice_auto_send_overdue_weekly', '1'),
-    ('invoice_auto_email_on_generate', '1')
+    ('invoice_auto_email_on_generate', '1'),
+    ('payment_receipts_enabled', '1'),
+    ('email_no_reply_notice_enabled', '0'),
+    ('email_no_reply_notice_text', 'This is an automated message. Please do not reply to this email.')
 ON DUPLICATE KEY UPDATE config_value = VALUES(config_value);
 
 -- ============================================================================

--- a/database/migrations/0014_payment_receipt_email_settings.sql
+++ b/database/migrations/0014_payment_receipt_email_settings.sql
@@ -1,0 +1,8 @@
+-- Add defaults for payment receipt and automated email notice settings.
+
+INSERT INTO app_config (organization_id, config_key, config_value)
+VALUES
+    (0, 'payment_receipts_enabled', '1'),
+    (0, 'email_no_reply_notice_enabled', '0'),
+    (0, 'email_no_reply_notice_text', 'This is an automated message. Please do not reply to this email.')
+ON DUPLICATE KEY UPDATE config_value = config_value;

--- a/public/assets/js/invoices-edit-logic.js
+++ b/public/assets/js/invoices-edit-logic.js
@@ -65,6 +65,8 @@ function addExtraCharge() {
 }
 
 function recalcInv() {
+  var totalsEl = document.getElementById('totalsInv');
+  var baseSubtotal = totalsEl ? (parseFloat(totalsEl.dataset.baseSubtotal) || 0) : 0;
   // Recalculate totals from extra charges if visible
   var extraQtys = Array.from(document.querySelectorAll('[name="extra_qty[]"]')).map(e => parseFloat(e.value) || 0);
   var extraPrices = Array.from(document.querySelectorAll('[name="extra_price[]"]')).map(e => parseFloat(e.value) || 0);
@@ -79,18 +81,19 @@ function recalcInv() {
   var dval = parseFloat(document.getElementById('discountValueInv').value) || 0;
   var taxp = parseFloat(document.getElementById('taxPercentInv').value) || 0;
 
+  var subtotal = baseSubtotal + extraSubtotal;
   var discount = 0;
   if (dtype === 'percent') {
-    discount = Math.max(0, Math.min(100, dval)) * extraSubtotal / 100;
+    discount = Math.max(0, Math.min(100, dval)) * subtotal / 100;
   } else if (dtype === 'fixed') {
     discount = Math.max(0, dval);
   }
 
-  var taxable = Math.max(0, extraSubtotal - discount);
+  var taxable = Math.max(0, subtotal - discount);
   var tax = Math.max(0, taxp) * taxable / 100;
   var total = Math.max(0, taxable + tax);
 
-  document.getElementById('subtotalValInv').textContent = money(extraSubtotal);
+  document.getElementById('subtotalValInv').textContent = money(subtotal);
   document.getElementById('discountValInv').textContent = money(discount);
   document.getElementById('taxValInv').textContent = money(tax);
   document.getElementById('totalValInv').textContent = money(total);
@@ -155,7 +158,7 @@ if (window.ProjectAlpha && typeof window.ProjectAlpha.registerPage === 'function
 
 var items = document.querySelectorAll("#item");
 var descriptions = document.querySelectorAll("#description");
-var quantities = document.querySelectorAll("#qunatity");
+var quantities = document.querySelectorAll('[name="extra_qty[]"]');
 var prices = document.querySelectorAll("#price");
 
 var confirmButton = document.getElementById("confirm");

--- a/public/assets/js/payments-create-logic.js
+++ b/public/assets/js/payments-create-logic.js
@@ -1,5 +1,16 @@
 var sel = document.getElementById('invoiceSelect');
 var amt = document.getElementById('amountInput');
+var invoiceFields = document.getElementById('invoicePaymentFields');
+var manualFields = document.getElementById('manualPaymentFields');
+var manualClientSelect = document.getElementById('manualClientSelect');
+var scopeInputs = Array.from(document.querySelectorAll('input[name="payment_scope"]'));
+var sendReceiptInput = document.getElementById('sendReceiptInput');
+
+function selectedScope() {
+    var checked = scopeInputs.find(function (input) { return input.checked; });
+    return checked ? checked.value : 'invoice';
+}
+
 function update() {
     if (!sel || !amt) return;
     var opt = sel.options[sel.selectedIndex];
@@ -22,6 +33,7 @@ var referenceLabel = document.getElementById('referenceLabel');
 function togglePaymentFields() {
     if (!methodSelect || !checkField || !checkInput) return;
     var method = methodSelect.value.toLowerCase();
+    var scope = selectedScope();
     // Check field
     if (method === 'check' || method === 'bank_transfer') {
         checkField.style.display = 'block';
@@ -38,11 +50,39 @@ function togglePaymentFields() {
     }
     // Stripe notice
     if (stripeNotice) {
-        stripeNotice.style.display = method === 'stripe' ? 'block' : 'none';
+        stripeNotice.style.display = method === 'stripe' && scope === 'invoice' ? 'block' : 'none';
     }
+}
+
+function togglePaymentScope() {
+    var scope = selectedScope();
+    var isManual = scope === 'manual';
+    if (invoiceFields) invoiceFields.style.display = isManual ? 'none' : 'grid';
+    if (manualFields) manualFields.style.display = isManual ? 'grid' : 'none';
+    if (sel) sel.required = !isManual;
+    if (manualClientSelect) manualClientSelect.required = isManual;
+    if (sendReceiptInput) sendReceiptInput.checked = !isManual;
+
+    if (methodSelect) {
+        Array.from(methodSelect.options).forEach(function (option) {
+            if (option.value.toLowerCase() === 'stripe') {
+                option.disabled = isManual;
+                if (isManual && option.selected) {
+                    methodSelect.value = methodSelect.options[0] ? methodSelect.options[0].value : '';
+                }
+            }
+        });
+    }
+
+    togglePaymentFields();
 }
 
 if (methodSelect) {
     methodSelect.addEventListener('change', togglePaymentFields);
     togglePaymentFields();
 }
+
+scopeInputs.forEach(function (input) {
+    input.addEventListener('change', togglePaymentScope);
+});
+togglePaymentScope();

--- a/public/index.php
+++ b/public/index.php
@@ -1070,6 +1070,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/../src/controllers/payments_create.php';
         exit;
     }
+    if ($page === 'payments/payment-refund') {
+        require_once __DIR__ . '/../src/controllers/payments_refund.php';
+        exit;
+    }
     if ($page === 'quote/quotes-update' || $page === 'quotes-update') {
         require_once __DIR__ . '/../src/controllers/quote/quotes_update.php';
         exit;

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -37,6 +37,9 @@ $appConfig = [
     'invoice_auto_send_overdue_weekly' => 1,
     'invoice_auto_email_on_generate' => 1,
     'invoice_auto_email_on_contract_complete' => 1,
+    'payment_receipts_enabled' => 1,
+    'email_no_reply_notice_enabled' => 0,
+    'email_no_reply_notice_text' => 'This is an automated message. Please do not reply to this email.',
     // Link resolver / invoice content links are intentionally opt-in.
     'link_resolver_enabled' => 0,
     'org_level_links_only' => 0,
@@ -177,6 +180,7 @@ try {
             'quote_auto_create_contract', 'quote_auto_create_invoice', 'quotes_show_terms',
             'invoice_auto_send_due_7days', 'invoice_auto_send_overdue_weekly', 'invoice_auto_email_on_generate',
             'invoice_auto_email_on_contract_complete',
+            'payment_receipts_enabled', 'email_no_reply_notice_enabled', 'email_no_reply_notice_text',
             'auto_terminate_contracts', 'link_expiration_checker',
             'contract_expiring_warning', 'contract_expiring_days', 'contract_expired_alert',
             'payment_failure_alert',

--- a/src/controllers/api/dashboard_summary.php
+++ b/src/controllers/api/dashboard_summary.php
@@ -21,7 +21,7 @@ $resp = [
     'contracts'    => _count($pdo, "SELECT COUNT(*) FROM contracts"),
     'invoices'     => _count($pdo, "SELECT COUNT(*) FROM invoices"),
     'expenses'     => _count($pdo, "SELECT COUNT(*) FROM expenses"),
-    'revenue'      => _scalar($pdo, "SELECT COALESCE(SUM(amount),0) FROM payments WHERE status='succeeded'"),
+    'revenue'      => _scalar($pdo, "SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) FROM payments WHERE status='succeeded'"),
     'outstanding'  => _scalar($pdo, "SELECT COALESCE(SUM(balance_due),0) FROM invoices WHERE status NOT IN ('paid','cancelled','void')"),
 ];
 

--- a/src/controllers/api/financial_summary.php
+++ b/src/controllers/api/financial_summary.php
@@ -7,7 +7,7 @@ $period = (int)($_GET['days'] ?? 30);
 if ($period < 1 || $period > 365) $period = 30;
 $start = gmdate('Y-m-d', strtotime("-$period days"));
 
-$stmt = $pdo->prepare("SELECT COALESCE(SUM(amount),0) FROM payments WHERE status='succeeded' AND DATE(payment_date)>=?");
+$stmt = $pdo->prepare("SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) FROM payments WHERE status='succeeded' AND DATE(payment_date)>=?");
 $stmt->execute([$start]);
 $revenue = (float) $stmt->fetchColumn();
 

--- a/src/controllers/financial/expense_export.php
+++ b/src/controllers/financial/expense_export.php
@@ -43,7 +43,14 @@ if ($billable === '1') { $where[] = 'e.is_billable = 1'; }
 if ($billable === '0') { $where[] = 'e.is_billable = 0'; }
 if ($taxDeductible === '1') { $where[] = 'e.is_tax_deductible = 1'; }
 if ($taxDeductible === '0') { $where[] = 'e.is_tax_deductible = 0'; }
-if ($status) { $where[] = 'e.status = ?'; $params[] = $status; }
+if ($status === 'all') {
+    // Explicit audit export, including voided expenses.
+} elseif ($status !== '') {
+    $where[] = 'e.status = ?';
+    $params[] = $status;
+} else {
+    $where[] = "e.status != 'void'";
+}
 
 $whereSQL = implode(' AND ', $where);
 

--- a/src/controllers/invoice/invoices_mark_paid.php
+++ b/src/controllers/invoice/invoices_mark_paid.php
@@ -14,7 +14,7 @@ if ($totalValue === false) {
   exit;
 }
 $total = (float)$totalValue;
-$paidStmt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount,0)),0) FROM payments WHERE invoice_id=? AND status="succeeded"');
+$paidStmt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) FROM payments WHERE invoice_id=? AND status="succeeded"');
 $paidStmt->execute([$id]);
 $paid = (float)$paidStmt->fetchColumn();
 $outstanding = max(0.0, $total - $paid);

--- a/src/controllers/invoice/invoices_update.php
+++ b/src/controllers/invoice/invoices_update.php
@@ -5,12 +5,20 @@ require_once __DIR__ . '/../../config/app.php';
 require_once __DIR__ . '/../../utils/document_fields.php';
 require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/acl_middleware.php';
+require_once __DIR__ . '/../../utils/invoice_lifecycle.php';
 $id = (int)($_POST['id'] ?? 0);
 require_record_ownership($pdo, 'invoices', $id);
-$statusStmt = $pdo->prepare('SELECT status FROM invoices WHERE id=?');
+$statusStmt = $pdo->prepare('SELECT status, finalized_at FROM invoices WHERE id=?');
 $statusStmt->execute([$id]);
-if (strtolower((string)$statusStmt->fetchColumn()) !== 'draft') {
-  header('Location: /?page=invoice/invoice-details&id=' . $id . '&error=' . urlencode('Reopen the invoice as a draft before editing it.'));
+$invoiceState = $statusStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+$invoiceStatus = strtolower((string)($invoiceState['status'] ?? ''));
+$isDraft = $invoiceStatus === 'draft';
+if (in_array($invoiceStatus, ['paid', 'partial', 'void', 'cancelled'], true)) {
+  header('Location: /?page=invoice/invoice-details&id=' . $id . '&error=' . urlencode('This invoice status cannot be edited.'));
+  exit;
+}
+if (!$isDraft && invoice_effective_paid_total($pdo, $id) > 0.005) {
+  header('Location: /?page=invoice/invoice-details&id=' . $id . '&error=' . urlencode('Invoices with payment activity cannot be edited.'));
   exit;
 }
 $client_id = (int)($_POST['client_id'] ?? 0);
@@ -78,12 +86,15 @@ for ($i = 0; $i < count($extraItems); $i++) {
 }
 
 // Fetch all existing items to calculate subtotal including contract items
-$allExistingItems = $pdo->prepare('SELECT description, quantity, unit_price FROM invoice_items WHERE invoice_id=?');
+$allExistingItems = $hasExtraChargeCol
+  ? $pdo->prepare('SELECT description, quantity, unit_price, is_extra_charge FROM invoice_items WHERE invoice_id=?')
+  : $pdo->prepare('SELECT description, quantity, unit_price, 0 AS is_extra_charge FROM invoice_items WHERE invoice_id=?');
 $allExistingItems->execute([$id]);
 $contractSubtotal = 0.0;
 foreach ($allExistingItems->fetchAll(PDO::FETCH_ASSOC) as $item) {
-  // Only count non-extra charge items (contract items)
-  $contractSubtotal += (float)$item['quantity'] * (float)$item['unit_price'];
+  if ((int)($item['is_extra_charge'] ?? 0) === 0) {
+    $contractSubtotal += (float)$item['quantity'] * (float)$item['unit_price'];
+  }
 }
 $subtotal = $contractSubtotal; // Reset and add extras
 
@@ -134,6 +145,10 @@ try {
     foreach ($extraItemsArr as $it) {
       $ii->execute([$id, $it['i'], $it['d'], $it['q'], $it['p'], $it['t'], $it['u']]);
     }
+  }
+
+  if (!$isDraft && !empty($invoiceState['finalized_at'])) {
+    invoice_refresh_payment_totals($pdo, $id, false);
   }
   
   $pdo->commit();

--- a/src/controllers/payments_create.php
+++ b/src/controllers/payments_create.php
@@ -4,16 +4,33 @@ require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../config/app.php';
 require_once __DIR__ . '/../utils/acl.php';
 require_once __DIR__ . '/../utils/audit.php';
+require_once __DIR__ . '/../utils/csrf.php';
 require_once __DIR__ . '/../utils/invoice_lifecycle.php';
 
+csrf_verify_post_or_redirect('payments/payments-create');
+
+$payment_scope = ($_POST['payment_scope'] ?? 'invoice') === 'manual' ? 'manual' : 'invoice';
 $invoice_id = (int)($_POST['invoice_id'] ?? 0);
+$client_id_input = (int)($_POST['client_id'] ?? 0);
 $amount = (float)($_POST['amount'] ?? 0);
 $method = trim((string)($_POST['method'] ?? 'card'));
 $check_number = trim((string)($_POST['reference_number'] ?? $_POST['check_number'] ?? ''));
+$notes = trim((string)($_POST['notes'] ?? ''));
+$payment_date = trim((string)($_POST['payment_date'] ?? date('Y-m-d')));
 $paid_in_advance = !empty($_POST['paid_in_advance']);
+$send_receipt = !empty($_POST['send_receipt']);
+
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $payment_date)) {
+  header('Location: /?page=payments/payments-create&error=' . urlencode('Invalid payment date'));
+  exit;
+}
 
 // If Stripe is selected, redirect to Stripe checkout
 if (strtolower($method) === 'stripe') {
+  if ($payment_scope === 'manual') {
+    header('Location: /?page=payments/payments-create&error=' . urlencode('Stripe payments must be tied to an invoice.'));
+    exit;
+  }
   if ($invoice_id <= 0) {
     header('Location: /?page=payments/payments-create&error=Please%20select%20an%20invoice');
     exit;
@@ -26,7 +43,72 @@ if (strtolower($method) === 'stripe') {
   exit;
 }
 
-if ($invoice_id <= 0 || $amount <= 0) {
+if ($amount <= 0) {
+  header('Location: /?page=payments/payments-create&error=Invalid%20input');
+  exit;
+}
+
+if ($payment_scope === 'manual') {
+  if ($client_id_input <= 0) {
+    header('Location: /?page=payments/payments-create&error=' . urlencode('Select a client for manual payments.'));
+    exit;
+  }
+  if (!can_access_record($pdo, 'clients', $client_id_input, (int)($_SESSION['user']['id'] ?? 0))) {
+    header('Location: /?page=payments/payments-create&error=' . urlencode('Permission denied'));
+    exit;
+  }
+  if (strtolower($method) === 'check' && empty($check_number)) {
+    header('Location: /?page=payments/payments-create&error=Check%20number%20is%20required');
+    exit;
+  }
+
+  $clientStmt = $pdo->prepare('SELECT organization_id FROM clients WHERE id=?');
+  $clientStmt->execute([$client_id_input]);
+  $organization_id = (int)($clientStmt->fetchColumn() ?: 0) ?: null;
+  invoice_ensure_payments_schema($pdo);
+
+  $pdo->beginTransaction();
+  try {
+    $insert = $pdo->prepare('
+      INSERT INTO payments
+        (client_id, invoice_id, contract_id, organization_id, amount, payment_method, reference_number, notes, status, payment_date)
+      VALUES (?, NULL, NULL, ?, ?, ?, ?, ?, "succeeded", ?)
+    ');
+    $insert->execute([
+      $client_id_input,
+      $organization_id,
+      $amount,
+      $method ?: 'cash',
+      $check_number ?: null,
+      $notes !== '' ? $notes : 'Manual payment not tied to an invoice',
+      $payment_date,
+    ]);
+    $paymentId = (int)$pdo->lastInsertId();
+    $pdo->commit();
+
+    audit_log($pdo, 'payment.manual_recorded', 'payment', $paymentId, ['amount' => $amount, 'method' => $method, 'client_id' => $client_id_input]);
+
+    if (!empty($appConfig['payment_receipts_enabled'])) {
+      try {
+        require_once __DIR__ . '/../utils/payment_receipts.php';
+        payment_receipt_issue($pdo, $paymentId, $appConfig ?? [], $send_receipt);
+      } catch (Throwable $receiptError) {
+        @error_log('[PaymentsCreate] Manual receipt issue failed: ' . $receiptError->getMessage());
+      }
+    }
+  } catch (Throwable $e) {
+    $pdo->rollBack();
+    @error_log('[PaymentsCreate] Manual payment error: ' . $e->getMessage());
+    $message = trim($e->getMessage()) !== '' ? substr($e->getMessage(), 0, 180) : 'Failed to save payment';
+    header('Location: /?page=payments/payments-create&error=' . urlencode($message));
+    exit;
+  }
+
+  header('Location: /?page=payments/payments-list&saved=1');
+  exit;
+}
+
+if ($invoice_id <= 0) {
   header('Location: /?page=payments/payments-create&error=Invalid%20input');
   exit;
 }
@@ -85,6 +167,7 @@ try {
           'organization_id' => $organization_id,
           'complete_contract_when_paid' => !$paid_in_advance,
           'source' => 'manual_payment',
+          'payment_date' => $payment_date,
       ]
   );
   $paymentId = (int)$result['payment_id'];
@@ -96,7 +179,7 @@ try {
 
   try {
     require_once __DIR__ . '/../utils/payment_receipts.php';
-    payment_receipt_issue($pdo, $paymentId, $appConfig ?? []);
+    payment_receipt_issue($pdo, $paymentId, $appConfig ?? [], $send_receipt);
   } catch (Throwable $receiptError) {
     @error_log('[PaymentsCreate] Receipt issue failed: ' . $receiptError->getMessage());
   }

--- a/src/controllers/payments_refund.php
+++ b/src/controllers/payments_refund.php
@@ -1,0 +1,68 @@
+<?php
+
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../utils/acl.php';
+require_once __DIR__ . '/../utils/audit.php';
+require_once __DIR__ . '/../utils/csrf.php';
+require_once __DIR__ . '/../utils/invoice_lifecycle.php';
+
+csrf_verify_post_or_redirect('payments-list');
+
+$paymentId = (int)($_POST['payment_id'] ?? 0);
+$amount = (float)($_POST['amount'] ?? 0);
+if ($paymentId <= 0 || $amount <= 0) {
+    header('Location: /?page=payments-list&error=' . urlencode('Invalid refund amount.'));
+    exit;
+}
+
+if (!can_access_record($pdo, 'payments', $paymentId, (int)($_SESSION['user']['id'] ?? 0))) {
+    header('Location: /?page=payments-list&error=' . urlencode('Permission denied'));
+    exit;
+}
+
+$pdo->beginTransaction();
+try {
+    invoice_ensure_payments_schema($pdo);
+    $stmt = $pdo->prepare('
+        SELECT id, invoice_id, amount, refunded_amount, disputed_amount, status
+        FROM payments
+        WHERE id=?
+        FOR UPDATE
+    ');
+    $stmt->execute([$paymentId]);
+    $payment = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$payment || strtolower((string)$payment['status']) !== 'succeeded') {
+        throw new RuntimeException('Only successful payments can be refunded.');
+    }
+
+    $paidAmount = (float)$payment['amount'];
+    $refunded = (float)$payment['refunded_amount'];
+    $disputed = (float)$payment['disputed_amount'];
+    $remaining = max(0.0, $paidAmount - $refunded - $disputed);
+    if ($amount > $remaining + 0.005) {
+        throw new RuntimeException('Refund cannot exceed the remaining payment amount.');
+    }
+
+    $pdo->prepare('UPDATE payments SET refunded_amount = refunded_amount + ? WHERE id=?')
+        ->execute([$amount, $paymentId]);
+
+    $totals = null;
+    if (!empty($payment['invoice_id'])) {
+        $totals = invoice_refresh_payment_totals($pdo, (int)$payment['invoice_id']);
+    }
+
+    $pdo->commit();
+    audit_log($pdo, 'payment.refund_recorded', 'payment', $paymentId, [
+        'amount' => $amount,
+        'invoice_id' => !empty($payment['invoice_id']) ? (int)$payment['invoice_id'] : null,
+        'invoice_status' => $totals['status'] ?? null,
+    ]);
+    $GLOBALS['__audit_logged'] = true;
+    header('Location: /?page=payments-list&refunded=1');
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    header('Location: /?page=payments-list&error=' . urlencode($e->getMessage()));
+}
+exit;

--- a/src/controllers/settings_handler.php
+++ b/src/controllers/settings_handler.php
@@ -94,6 +94,9 @@ $settings = [
     'invoice_auto_send_overdue_weekly' => 1,
     'invoice_auto_email_on_generate' => 1,
     'invoice_auto_email_on_contract_complete' => 1,
+    'payment_receipts_enabled' => 1,
+    'email_no_reply_notice_enabled' => 0,
+    'email_no_reply_notice_text' => 'This is an automated message. Please do not reply to this email.',
     // SMTP configuration (optional)
     'smtp_host' => null,
     'smtp_port' => 587,
@@ -370,6 +373,7 @@ $generalConfigKeys = [
     'quote_auto_create_contract', 'quote_auto_create_invoice', 'quotes_show_terms',
     'invoice_auto_send_due_7days', 'invoice_auto_send_overdue_weekly', 'invoice_auto_email_on_generate',
     'invoice_auto_email_on_contract_complete',
+    'payment_receipts_enabled', 'email_no_reply_notice_enabled', 'email_no_reply_notice_text',
     'auto_terminate_contracts', 'link_expiration_checker',
     'contract_expiring_warning', 'contract_expiring_days', 'contract_expired_alert',
     'payment_failure_alert',
@@ -458,6 +462,18 @@ if ($isNotificationsTab || isset($_POST['contract_expired_alert'])) {
 // Payment notification settings
 if ($isNotificationsTab || isset($_POST['payment_failure_alert'])) {
     $settings['payment_failure_alert'] = !empty($_POST['payment_failure_alert']) ? 1 : 0;
+}
+if ($isNotificationsTab || isset($_POST['payment_receipts_enabled'])) {
+    $settings['payment_receipts_enabled'] = !empty($_POST['payment_receipts_enabled']) ? 1 : 0;
+}
+if ($isNotificationsTab || isset($_POST['email_no_reply_notice_enabled'])) {
+    $settings['email_no_reply_notice_enabled'] = !empty($_POST['email_no_reply_notice_enabled']) ? 1 : 0;
+}
+if (isset($_POST['email_no_reply_notice_text'])) {
+    $notice = trim((string)$_POST['email_no_reply_notice_text']);
+    $settings['email_no_reply_notice_text'] = $notice !== ''
+        ? mb_substr($notice, 0, 500)
+        : 'This is an automated message. Please do not reply to this email.';
 }
 // Link expiration warning settings
 if ($isNotificationsTab || isset($_POST['link_expiration_warning'])) {

--- a/src/services/EmailService.php
+++ b/src/services/EmailService.php
@@ -78,6 +78,27 @@ class EmailService {
         return $name;
     }
 
+    public static function applyAutomatedNotice(string $body, bool $isHtml, array $appConfig): string {
+        if (empty($appConfig['email_no_reply_notice_enabled'])) {
+            return $body;
+        }
+
+        $notice = trim((string)($appConfig['email_no_reply_notice_text'] ?? ''));
+        if ($notice === '') {
+            $notice = 'This is an automated message. Please do not reply to this email.';
+        }
+
+        if ($isHtml) {
+            return $body
+                . '<hr style="border:0;border-top:1px solid #e5e7eb;margin:24px 0 12px">'
+                . '<p style="color:#6b7280;font-size:12px;margin:0">'
+                . htmlspecialchars($notice, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                . '</p>';
+        }
+
+        return rtrim($body) . "\n\n" . $notice;
+    }
+
     /**
      * Send an HTML email using the configured SMTP server.
      *
@@ -107,6 +128,7 @@ class EmailService {
         $envelope   = trim((string)($options['envelope_from'] ?? ($cfg['username'] ?: $fromEmail)));
         $attachments = is_array($options['attachments'] ?? null) ? $options['attachments'] : [];
         $isHtml     = (bool)($options['is_html'] ?? true);
+        $body       = self::applyAutomatedNotice($body, $isHtml, $appConfig);
 
         $sent = false;
         $err  = '';

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -144,6 +144,7 @@ function page_permission_map(): array
         'payments/payments-list'    => 'payments.view',
         'payments-list'             => 'payments.view',
         'payments/payments-create'  => 'invoices.mark_paid',
+        'payments/payment-refund'   => 'invoices.mark_paid',
 
         // Clients module
         'client/clients-list'    => 'clients.view',

--- a/src/utils/audit_middleware.php
+++ b/src/utils/audit_middleware.php
@@ -61,6 +61,7 @@ function audit_sensitive_map(): array
             'stripe-webhook'                 => ['payment.stripe_webhook', 'payment'],
             'stripe-webhook-legacy'          => ['payment.stripe_webhook', 'payment'],
             'payments-create'                => ['payment.create', 'payment'],
+            'payments/payment-refund'        => ['payment.refund', 'payment'],
             'invoice/invoices-mark-paid'     => ['invoice.mark_paid', 'invoice'],
             'invoices-mark-paid'             => ['invoice.mark_paid', 'invoice'],
 

--- a/src/utils/invoice_lifecycle.php
+++ b/src/utils/invoice_lifecycle.php
@@ -148,7 +148,7 @@ function invoice_refresh_payment_totals(PDO $pdo, int $invoiceId, bool $revokePa
 
     $paidAtSql = $status === 'paid'
         ? ', paid_at = COALESCE(paid_at, NOW())'
-        : '';
+        : ', paid_at = NULL';
     $pdo->prepare("UPDATE invoices SET status = ?, amount_paid = ?, balance_due = ?{$paidAtSql} WHERE id = ?")
         ->execute([$status, $storedPaid, $balanceDue, $invoiceId]);
 
@@ -187,6 +187,10 @@ function invoice_record_locked_payment(
     $completeContractWhenPaid = (bool)($options['complete_contract_when_paid'] ?? false);
     $allowUnfinalized = (bool)($options['allow_unfinalized'] ?? false);
     $source = substr((string)($options['source'] ?? 'manual'), 0, 50);
+    $paymentDate = trim((string)($options['payment_date'] ?? date('Y-m-d')));
+    if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $paymentDate)) {
+        $paymentDate = date('Y-m-d');
+    }
 
     $ownsTransaction = !$pdo->inTransaction();
     if ($ownsTransaction) {
@@ -229,7 +233,7 @@ function invoice_record_locked_payment(
         $insert = $pdo->prepare('
             INSERT INTO payments
                 (client_id, invoice_id, contract_id, organization_id, amount, payment_method, reference_number, notes, status, payment_date)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, "succeeded", CURDATE())
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, "succeeded", ?)
         ');
         $insert->execute([
             (int)$invoice['client_id'],
@@ -240,6 +244,7 @@ function invoice_record_locked_payment(
             $method !== '' ? $method : 'cash',
             $reference !== '' ? $reference : null,
             $notes !== '' ? $notes : null,
+            $paymentDate,
         ]);
         $paymentId = (int)$pdo->lastInsertId();
 

--- a/src/utils/payment_receipts.php
+++ b/src/utils/payment_receipts.php
@@ -6,8 +6,12 @@ require_once __DIR__ . '/invoice_lifecycle.php';
 /**
  * Create and email one durable Project Alpha receipt per payment.
  */
-function payment_receipt_issue(PDO $pdo, int $paymentId, array $appConfig): ?array
+function payment_receipt_issue(PDO $pdo, int $paymentId, array $appConfig, bool $sendEmail = true): ?array
 {
+    if (array_key_exists('payment_receipts_enabled', $appConfig) && empty($appConfig['payment_receipts_enabled'])) {
+        return null;
+    }
+
     $stmt = $pdo->prepare(
         'SELECT p.id,p.invoice_id,p.amount,p.payment_date,p.payment_method,p.reference_number,
                 i.doc_number,c.name AS client_name,c.email
@@ -44,7 +48,7 @@ function payment_receipt_issue(PDO $pdo, int $paymentId, array $appConfig): ?arr
         $receipt = $existing->fetch(PDO::FETCH_ASSOC);
     }
 
-    if (!$receipt || !empty($receipt['emailed_at']) || empty($receipt['email_to'])) {
+    if (!$sendEmail || !$receipt || !empty($receipt['emailed_at']) || empty($receipt['email_to'])) {
         return $receipt ?: null;
     }
 

--- a/src/views/pages/financial/_expenses_tab.php
+++ b/src/views/pages/financial/_expenses_tab.php
@@ -27,7 +27,14 @@ if ($vendorId > 0) { $where[] = 'e.vendor_id = ?'; $params[] = $vendorId; }
 if ($clientId > 0) { $where[] = 'e.client_id = ?'; $params[] = $clientId; }
 if ($billable === '1') { $where[] = 'e.is_billable = 1'; }
 if ($billable === '0') { $where[] = 'e.is_billable = 0'; }
-if ($status) { $where[] = 'e.status = ?'; $params[] = $status; }
+if ($status === 'all') {
+    // Explicit audit view, including voided expenses.
+} elseif ($status !== '') {
+    $where[] = 'e.status = ?';
+    $params[] = $status;
+} else {
+    $where[] = "e.status != 'void'";
+}
 $whereSQL = implode(' AND ', $where);
 
 $per = (int)($_GET['per_page'] ?? 50);
@@ -203,7 +210,8 @@ $paginationFilters = [
       <label>
         <span class="label-muted">Status</span>
         <select name="status" class="input">
-          <option value="">All statuses</option>
+          <option value="">Active statuses</option>
+          <option value="all" <?php echo $status==='all'?'selected':''; ?>>All statuses including void</option>
           <option value="confirmed" <?php echo $status==='confirmed'?'selected':''; ?>>Confirmed</option>
           <option value="pending" <?php echo $status==='pending'?'selected':''; ?>>Pending</option>
           <option value="reimbursed" <?php echo $status==='reimbursed'?'selected':''; ?>>Reimbursed</option>

--- a/src/views/pages/financial/expense-report.php
+++ b/src/views/pages/financial/expense-report.php
@@ -46,7 +46,14 @@ if ($billable === '1') { $where[] = 'e.is_billable = 1'; }
 if ($billable === '0') { $where[] = 'e.is_billable = 0'; }
 if ($taxDeductible === '1') { $where[] = 'e.is_tax_deductible = 1'; }
 if ($taxDeductible === '0') { $where[] = 'e.is_tax_deductible = 0'; }
-if ($status) { $where[] = 'e.status = ?'; $params[] = $status; }
+if ($status === 'all') {
+    // Explicit audit view, including voided expenses.
+} elseif ($status !== '') {
+    $where[] = 'e.status = ?';
+    $params[] = $status;
+} else {
+    $where[] = "e.status != 'void'";
+}
 
 $whereSQL = implode(' AND ', $where);
 
@@ -189,7 +196,8 @@ $exportParams = http_build_query(array_filter([
       <div class="field">
         <label class="label-muted">Status</label>
         <select name="status" class="input">
-          <option value="">All statuses</option>
+          <option value="">Active statuses</option>
+          <option value="all" <?php echo $status === 'all' ? 'selected' : ''; ?>>All statuses including void</option>
           <?php foreach (['pending' => 'Pending', 'confirmed' => 'Confirmed', 'reimbursed' => 'Reimbursed', 'void' => 'Void'] as $value => $label): ?>
             <option value="<?php echo $value; ?>" <?php echo $status === $value ? 'selected' : ''; ?>><?php echo $label; ?></option>
           <?php endforeach; ?>

--- a/src/views/pages/home.php
+++ b/src/views/pages/home.php
@@ -1,17 +1,24 @@
 <?php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/escaper.php';
+require_once __DIR__ . '/../../utils/acl.php';
 
 // ------------------------------------------------------------------
 // Data queries
 // ------------------------------------------------------------------
 try {
+  $dashboard_user_id = (int)($_SESSION['user']['id'] ?? 0);
+  $dashboard_org_id = active_or_default_org_id($pdo);
+  [$dashboard_expense_scope_where, $dashboard_expense_scope_params] = finance_scope_clause($pdo, 'e', $dashboard_user_id, $dashboard_org_id, 'created_by');
+
   // Core stats
   $pending_quotes     = (int)$pdo->query("SELECT COUNT(*) FROM quotes WHERE status='pending'")->fetchColumn();
   $active_contracts   = (int)$pdo->query("SELECT COUNT(*) FROM contracts WHERE status IN ('draft','active')")->fetchColumn();
   $unpaid_invoices    = (int)$pdo->query("SELECT COUNT(*) FROM invoices WHERE status IN ('unpaid','partial')")->fetchColumn();
-  $income_30          = (float)$pdo->query("SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) FROM payments WHERE created_at >= NOW() - INTERVAL 30 DAY AND status='succeeded'")->fetchColumn();
-  $expenses_30        = (float)$pdo->query("SELECT COALESCE(SUM(total_amount),0) FROM expenses WHERE status != 'void' AND expense_date >= CURDATE() - INTERVAL 29 DAY")->fetchColumn();
+  $income_30          = (float)$pdo->query("SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) FROM payments WHERE payment_date >= CURDATE() - INTERVAL 29 DAY AND status='succeeded'")->fetchColumn();
+  $expensesStmt       = $pdo->prepare("SELECT COALESCE(SUM(e.total_amount),0) FROM expenses e WHERE {$dashboard_expense_scope_where} AND e.status != 'void' AND e.expense_date >= CURDATE() - INTERVAL 29 DAY");
+  $expensesStmt->execute($dashboard_expense_scope_params);
+  $expenses_30        = (float)$expensesStmt->fetchColumn();
   $net_30             = $income_30 - $expenses_30;
   $overdue_invoices   = (int)$pdo->query("SELECT COUNT(*) FROM invoices WHERE status IN ('unpaid','partial','overdue') AND due_date IS NOT NULL AND due_date < CURDATE()")->fetchColumn();
   $receipts_30        = (int)$pdo->query("SELECT COUNT(*) FROM receipts WHERE created_at >= NOW() - INTERVAL 30 DAY")->fetchColumn();
@@ -20,10 +27,10 @@ try {
 
   // Charts data — monthly income last 6 months
   $income_monthly = $pdo->query("
-    SELECT DATE_FORMAT(created_at, '%Y-%m') AS month,
+    SELECT DATE_FORMAT(payment_date, '%Y-%m') AS month,
            COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) AS total
     FROM payments
-    WHERE created_at >= DATE_FORMAT(NOW() - INTERVAL 5 MONTH, '%Y-%m-01')
+    WHERE payment_date >= DATE_FORMAT(NOW() - INTERVAL 5 MONTH, '%Y-%m-01')
       AND status='succeeded'
     GROUP BY month
     ORDER BY month
@@ -132,9 +139,9 @@ $daily_labels = [];
 $daily_values = [];
 try {
   $income_daily_rows = $pdo->query("
-    SELECT DATE(created_at) AS d, COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) AS total
+    SELECT payment_date AS d, COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)),0) AS total
     FROM payments
-    WHERE created_at >= CURDATE() - INTERVAL 29 DAY
+    WHERE payment_date >= CURDATE() - INTERVAL 29 DAY
       AND status='succeeded'
     GROUP BY d
     ORDER BY d

--- a/src/views/pages/invoice/invoice-details.php
+++ b/src/views/pages/invoice/invoice-details.php
@@ -82,18 +82,19 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
     <a href="javascript:history.back()" class="btn btn-sm">Back</a>
     <a href="/?page=invoice/invoice-pdf&id=<?php echo (int)$id; ?>" target="_blank" rel="noopener" class="btn btn-sm">View PDF</a>
     <a href="/?page=invoice/invoice-pdf&id=<?php echo (int)$id; ?>" download="invoice-<?php echo htmlspecialchars($inv['doc_number'] ?? $inv['id']); ?>.pdf" class="btn btn-sm">Download</a>
-    <?php if (strtolower((string)$inv['status']) === 'draft'): ?>
+    <?php
+      $actionStatus = strtolower((string)$inv['status']);
+      $canEditInvoice = $actionStatus === 'draft'
+        || (in_array($actionStatus, ['sent','unpaid','overdue'], true) && (float)($inv['amount_paid'] ?? 0) <= 0.005);
+    ?>
+    <?php if ($canEditInvoice): ?>
       <a href="/?page=invoice/invoices-edit&id=<?php echo (int)$id; ?>" class="btn btn-sm">Edit</a>
+    <?php endif; ?>
+    <?php if (strtolower((string)$inv['status']) === 'draft'): ?>
       <form method="post" action="/?page=invoice/invoice-finalize" style="display:inline" onsubmit="return confirm('Finalize this invoice and email it to the client?');">
         <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
         <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
         <button type="submit" class="btn btn-sm btn-success">Finalize &amp; Send</button>
-      </form>
-    <?php elseif (in_array(strtolower((string)$inv['status']), ['sent','unpaid','overdue'], true)): ?>
-      <form method="post" action="/?page=invoice/invoice-reopen" style="display:inline" onsubmit="return confirm('Reopen this invoice as a draft? Existing public links will be revoked.');">
-        <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
-        <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
-        <button type="submit" class="btn btn-sm">Reopen Draft</button>
       </form>
     <?php endif; ?>
     <?php if (!empty($inv['status']) && in_array(strtolower((string)$inv['status']), ['sent','unpaid','partial','overdue'], true) && $invoiceCollectionMode === 'direct'): ?>
@@ -389,10 +390,10 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
   <?php
     $invoiceTotal = (float)($inv['total'] ?? 0);
     // Calculate amount_paid from payments table for accuracy
-    $paidStmt = $pdo->prepare('SELECT COALESCE(SUM(amount), 0) FROM payments WHERE invoice_id = ? AND status = "succeeded"');
+    $paidStmt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)), 0) FROM payments WHERE invoice_id = ? AND status = "succeeded"');
     $paidStmt->execute([$id]);
     $amountPaid = (float)$paidStmt->fetchColumn();
-    $amountDue = $invoiceTotal - $amountPaid;
+    $amountDue = max(0, $invoiceTotal - $amountPaid);
     $invStatus = strtolower($inv['status'] ?? 'unpaid');
     $isPartial = $invStatus === 'partial';
     $isPaid = $invStatus === 'paid';

--- a/src/views/pages/invoice/invoices-edit.php
+++ b/src/views/pages/invoice/invoices-edit.php
@@ -185,7 +185,7 @@ foreach ($clients as $c) {
                 <input id="quantity" type="number" step="0.01" min="0" name="extra_qty[]" value="<?php echo htmlspecialchars($it['quantity']); ?>" placeholder="Qty" style="padding:8px;border-radius:4px;border:1px solid #ddd">
                 <input id="price" type="number" step="0.01" min="0" name="extra_price[]" value="<?php echo htmlspecialchars($it['unit_price']); ?>" placeholder="Price" style="padding:8px;border-radius:4px;border:1px solid #ddd">
                 <input type="hidden" name="extra_id[]" value="<?php echo htmlspecialchars($it['id']); ?>">
-                <button id="confirm" type="button" onclick="" style="border:0;background:#fee2e2;color:#991b1b;border-radius:4px;padding:8px 10px;cursor:pointer">Remove</button>
+                <button type="button" onclick="if(confirm('Remove this extra charge?')){this.parentElement.remove();recalcInv();}" style="border:0;background:#fee2e2;color:#991b1b;border-radius:4px;padding:8px 10px;cursor:pointer">Remove</button>
               </div>
             <?php endforeach; ?>
           </div>
@@ -216,8 +216,16 @@ foreach ($clients as $c) {
     <?php
     // Calculate totals from database items (contract + extra charges)
     $subtotal = 0;
+    $contractSubtotalForTotals = 0;
+    $extraSubtotalForTotals = 0;
     foreach ($items as $it) {
-      $subtotal += (float)$it['quantity'] * (float)$it['unit_price'];
+      $lineTotal = (float)$it['quantity'] * (float)$it['unit_price'];
+      $subtotal += $lineTotal;
+      if ((int)($it['is_extra_charge'] ?? 0) === 1) {
+        $extraSubtotalForTotals += $lineTotal;
+      } else {
+        $contractSubtotalForTotals += $lineTotal;
+      }
     }
     $dtype = $inv['discount_type'] ?? 'none';
     $dval = (float)($inv['discount_value'] ?? 0);
@@ -232,7 +240,7 @@ foreach ($clients as $c) {
     $tax = max(0, $taxpct) * $taxable / 100;
     $total = max(0, $taxable + $tax);
     ?>
-    <div id="totalsInv" style="margin-top:8px;display:grid;gap:6px;justify-content:end">
+    <div id="totalsInv" data-base-subtotal="<?php echo htmlspecialchars(number_format($contractSubtotalForTotals, 2, '.', '')); ?>" style="margin-top:8px;display:grid;gap:6px;justify-content:end">
       <div style="display:flex;gap:16px;justify-content:flex-end">
         <div style="min-width:140px;text-align:right;color:var(--muted)">Subtotal</div>
         <div id="subtotalValInv" style="min-width:120px;text-align:right">$<?php echo number_format($subtotal, 2); ?></div>

--- a/src/views/pages/payments/payments-create.php
+++ b/src/views/pages/payments/payments-create.php
@@ -1,15 +1,38 @@
 <?php
 // src/views/pages/payments-create.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../config/app.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
-$invoices = $pdo->query("SELECT i.id, i.total, COALESCE(p.paid,0) AS paid, i.status, c.name client FROM invoices i JOIN clients c ON c.id=i.client_id LEFT JOIN (SELECT invoice_id, SUM(amount) AS paid FROM payments WHERE status='succeeded' GROUP BY invoice_id) p ON p.invoice_id=i.id WHERE i.status IN ('unpaid','partial') ORDER BY i.created_at DESC LIMIT 200")->fetchAll();
+
+$invoices = $pdo->query("
+  SELECT i.id, i.total, COALESCE(p.paid,0) AS paid, i.status, c.name client
+  FROM invoices i
+  JOIN clients c ON c.id=i.client_id
+  LEFT JOIN (
+    SELECT invoice_id, SUM(GREATEST(amount-refunded_amount-disputed_amount,0)) AS paid
+    FROM payments
+    WHERE status='succeeded'
+    GROUP BY invoice_id
+  ) p ON p.invoice_id=i.id
+  WHERE i.status IN ('unpaid','partial')
+  ORDER BY i.created_at DESC
+  LIMIT 200
+")->fetchAll(PDO::FETCH_ASSOC);
+$clients = $pdo->query('SELECT id,name,email FROM clients ORDER BY name ASC LIMIT 500')->fetchAll(PDO::FETCH_ASSOC);
 $pref = (int)($_GET['invoice_id'] ?? 0);
 $prefAmount = '';
 if ($pref > 0) {
-  // compute remaining amount
-  $st = $pdo->prepare("SELECT i.total, COALESCE(p.paid,0) AS paid FROM invoices i LEFT JOIN (
-      SELECT invoice_id, SUM(amount) AS paid FROM payments WHERE status='succeeded' GROUP BY invoice_id
-    ) p ON p.invoice_id=i.id WHERE i.id=?");
+  $st = $pdo->prepare("
+    SELECT i.total, COALESCE(p.paid,0) AS paid
+    FROM invoices i
+    LEFT JOIN (
+      SELECT invoice_id, SUM(GREATEST(amount-refunded_amount-disputed_amount,0)) AS paid
+      FROM payments
+      WHERE status='succeeded'
+      GROUP BY invoice_id
+    ) p ON p.invoice_id=i.id
+    WHERE i.id=?
+  ");
   $st->execute([$pref]);
   if ($row = $st->fetch(PDO::FETCH_ASSOC)) {
     $remain = max(0, (float)$row['total'] - (float)$row['paid']);
@@ -19,52 +42,104 @@ if ($pref > 0) {
 ?>
 <section>
   <h2>Record Payment</h2>
-  <form method="post" action="/?page=payments/payments-create" style="display:grid;gap:12px;max-width:520px">
+  <form method="post" action="/?page=payments/payments-create" style="display:grid;gap:12px;max-width:560px">
     <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+
+    <div style="display:grid;gap:8px">
+      <div style="font-weight:600">Payment Type</div>
+      <label style="display:flex;gap:8px;align-items:center">
+        <input type="radio" name="payment_scope" value="invoice" checked>
+        <span>Apply to an invoice</span>
+      </label>
+      <label style="display:flex;gap:8px;align-items:center">
+        <input type="radio" name="payment_scope" value="manual">
+        <span>Manual payment not tied to an invoice</span>
+      </label>
+    </div>
+
+    <div id="invoicePaymentFields" style="display:grid;gap:12px">
+      <label>
+        <div>Invoice</div>
+        <select required name="invoice_id" id="invoiceSelect" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+          <option value="">Select invoice...</option>
+          <?php foreach ($invoices as $i): $remain = max(0, (float)$i['total'] - (float)$i['paid']); ?>
+            <option value="<?php echo (int)$i['id']; ?>" data-remaining="<?php echo number_format($remain,2,'.',''); ?>" <?php echo $pref===(int)$i['id']?'selected':''; ?>>
+              #<?php echo (int)$i['id']; ?> - <?php echo htmlspecialchars($i['client']); ?> - $<?php echo number_format((float)$i['total'],2); ?> (<?php echo htmlspecialchars($i['status']); ?>)
+            </option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+    </div>
+
+    <div id="manualPaymentFields" style="display:none;gap:12px">
+      <label>
+        <div>Client</div>
+        <select name="client_id" id="manualClientSelect" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+          <option value="">Select client...</option>
+          <?php foreach ($clients as $client): ?>
+            <option value="<?php echo (int)$client['id']; ?>">
+              <?php echo htmlspecialchars($client['name']); ?><?php echo !empty($client['email']) ? ' - ' . htmlspecialchars($client['email']) : ''; ?>
+            </option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+    </div>
+
     <label>
-      <div>Invoice</div>
-      <select required name="invoice_id" id="invoiceSelect" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
-        <option value="">Select invoice...</option>
-        <?php foreach ($invoices as $i): $remain = max(0, (float)$i['total'] - (float)$i['paid']); ?>
-          <option value="<?php echo (int)$i['id']; ?>" data-remaining="<?php echo number_format($remain,2,'.',''); ?>" <?php echo $pref===(int)$i['id']?'selected':''; ?>>#<?php echo (int)$i['id']; ?> · <?php echo htmlspecialchars($i['client']); ?> · $<?php echo number_format((float)$i['total'],2); ?> (<?php echo htmlspecialchars($i['status']); ?>)</option>
-        <?php endforeach; ?>
-      </select>
+      <div>Payment Date</div>
+      <input required type="date" name="payment_date" value="<?php echo htmlspecialchars($_GET['payment_date'] ?? date('Y-m-d')); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
     </label>
+
     <label>
       <div>Amount ($)</div>
       <input required type="number" step="0.01" name="amount" id="amountInput" placeholder="0.00" value="<?php echo htmlspecialchars($prefAmount); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
     </label>
+
     <label>
       <div>Method</div>
-    <?php require_once __DIR__ . '/../../../config/app.php';
-         require_once __DIR__ . '/../../../services/StripeService.php';
-         require_once __DIR__ . '/../../../utils/payment_methods.php';
-         $methods = pa_payment_methods_from_config($appConfig);
-         $stripeConfigured = StripeService::isConfigured($appConfig);
-    ?>
+      <?php
+        require_once __DIR__ . '/../../../services/StripeService.php';
+        require_once __DIR__ . '/../../../utils/payment_methods.php';
+        $methods = pa_payment_methods_from_config($appConfig);
+        $stripeConfigured = StripeService::isConfigured($appConfig);
+      ?>
       <select name="method" id="paymentMethod" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
         <?php foreach ($methods as $m): ?>
           <?php if (($m['key'] ?? '') === 'stripe') { continue; } ?>
           <option value="<?php echo htmlspecialchars($m['key']); ?>"><?php echo htmlspecialchars($m['label']); ?></option>
         <?php endforeach; ?>
         <?php if ($stripeConfigured && pa_payment_methods_has($appConfig, 'stripe')): ?>
-          <option value="stripe">💳 Credit Card (Stripe)</option>
+          <option value="stripe">Credit Card (Stripe)</option>
         <?php endif; ?>
       </select>
     </label>
+
     <div id="stripeNotice" style="display:none;padding:12px;background:#e6f4ff;border:1px solid #0284c7;border-radius:8px;font-size:14px">
       <strong>Stripe Checkout:</strong> You will be redirected to Stripe to collect the card payment.
     </div>
+
     <div id="checkNumberField" style="display:none">
       <label>
         <div id="referenceLabel">Check Number</div>
         <input type="text" name="reference_number" id="checkNumberInput" placeholder="Enter check number" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
       </label>
     </div>
+
     <label>
       <div>Notes</div>
       <textarea name="notes" rows="3" placeholder="Optional payment notes" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd"></textarea>
     </label>
+
+    <?php if (!array_key_exists('payment_receipts_enabled', $appConfig) || !empty($appConfig['payment_receipts_enabled'])): ?>
+      <label style="display:flex;align-items:start;gap:8px">
+        <input type="checkbox" name="send_receipt" value="1" id="sendReceiptInput" style="margin-top:3px">
+        <span>
+          <span style="font-weight:600">Email receipt</span><br>
+          <span style="font-size:13px;color:var(--muted)">Invoice payments default on. Manual legacy payments default off.</span>
+        </span>
+      </label>
+    <?php endif; ?>
+
     <button type="submit" style="padding:10px 14px;border-radius:8px;border:0;background:var(--nav-accent);color:#fff;font-weight:600">Save Payment</button>
   </form>
 </section>

--- a/src/views/pages/payments/payments-list.php
+++ b/src/views/pages/payments/payments-list.php
@@ -2,6 +2,8 @@
 // src/views/pages/payments-list.php
 require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/acl.php';
+require_once __DIR__ . '/../../../utils/csrf.php';
+
 $client_id = isset($_GET['client_id']) ? (int)$_GET['client_id'] : 0;
 $client_name = trim($_GET['client'] ?? '');
 $start = $_GET['start'] ?? '';
@@ -9,10 +11,10 @@ $end = $_GET['end'] ?? '';
 $where=[];$p=[];
 if($client_id>0){$where[]='c.id=?';$p[]=$client_id;}
 elseif($client_name!==''){ $where[]='c.name LIKE ?'; $p[]='%'.$client_name.'%'; }
-if($start!==''){$where[]='p.created_at>=?';$p[]=$start.' 00:00:00';}
-if($end!==''){$where[]='p.created_at<=?';$p[]=$end.' 23:59:59';}
+if($start!==''){$where[]='p.payment_date>=?';$p[]=$start;}
+if($end!==''){$where[]='p.payment_date<=?';$p[]=$end;}
 
-[$scopeWhere, $scopeParams] = scope_clause($pdo, 'i', (int)$_SESSION['user']['id']);
+[$scopeWhere, $scopeParams] = scope_clause($pdo, 'p', (int)$_SESSION['user']['id']);
 if ($scopeWhere) {
     $where[] = $scopeWhere;
     $p = array_merge($p, $scopeParams);
@@ -22,16 +24,30 @@ $per = (int)($_GET['per_page'] ?? 50); if(!in_array($per,[50,100],true)) $per=50
 $pageN = max(1, (int)($_GET['p'] ?? 1));
 $offset = ($pageN - 1) * $per;
 
-$sqlCount = 'SELECT COUNT(*) FROM payments p JOIN invoices i ON i.id=p.invoice_id JOIN clients c ON c.id=i.client_id';
+$fromSql = ' FROM payments p JOIN clients c ON c.id=p.client_id LEFT JOIN invoices i ON i.id=p.invoice_id';
+$sqlCount = 'SELECT COUNT(*)' . $fromSql;
 if($where){$sqlCount.=' WHERE '.implode(' AND ',$where);} $stc=$pdo->prepare($sqlCount);$stc->execute($p);$total=(int)$stc->fetchColumn();
 
-$sql = 'SELECT p.id, p.amount, p.status, p.created_at, i.id AS invoice_id, c.name AS client FROM payments p JOIN invoices i ON i.id=p.invoice_id JOIN clients c ON c.id=i.client_id';
-if($where){$sql.=' WHERE '.implode(' AND ',$where);} $sql.=" ORDER BY p.created_at DESC LIMIT $per OFFSET $offset";
-$rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll();
-$clients=$pdo->query('SELECT id,name FROM clients ORDER BY name')->fetchAll();
+$sql = 'SELECT p.id, p.amount, p.refunded_amount, p.disputed_amount, p.status, p.payment_date, p.created_at,
+               p.payment_method, p.reference_number, i.id AS invoice_id, i.doc_number, c.name AS client
+        ' . $fromSql;
+if($where){$sql.=' WHERE '.implode(' AND ',$where);} $sql.=" ORDER BY p.payment_date DESC, p.created_at DESC LIMIT $per OFFSET $offset";
+$rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <section>
-  <h2>Payments</h2>
+  <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap">
+    <h2 style="margin:0">Payments</h2>
+    <a href="/?page=payments/payments-create" style="padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff;display:inline-block;font-size:small">Record Payment</a>
+  </div>
+  <?php if (!empty($_GET['saved'])): ?>
+    <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0">Payment saved.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['refunded'])): ?>
+    <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0">Refund recorded.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['error'])): ?>
+    <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#fff1f2;color:#881337;border:1px solid #fca5a5"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+  <?php endif; ?>
   <form method="get" action="/" style="display:grid;grid-template-columns:1fr 1fr 1fr auto auto;gap:8px;align-items:end;margin:12px 0;position:relative">
     <input type="hidden" name="page" value="payments-list">
     <input type="hidden" name="client_id" id="clientIdPL" value="<?php echo (int)$client_id; ?>">
@@ -41,8 +57,8 @@ $clients=$pdo->query('SELECT id,name FROM clients ORDER BY name')->fetchAll();
     </label>
     <label><div>Start</div><input type="date" name="start" value="<?php echo htmlspecialchars($start); ?>" style="padding:8px;border-radius:8px;border:1px solid #ddd"></label>
     <label><div>End</div><input type="date" name="end" value="<?php echo htmlspecialchars($end); ?>" style="padding:8px;border-radius:8px;border:1px solid #ddd"></label>
-    <button type="submit" style="padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff; font-size: small;">Filter</button>
-    <a href="/?page=payments-list" style="padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff;display:inline-block; font-size: small;">Reset</a>
+    <button type="submit" style="padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff;font-size:small">Filter</button>
+    <a href="/?page=payments-list" style="padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff;display:inline-block;font-size:small">Reset</a>
   </form>
   <script>
     (function(){
@@ -52,7 +68,7 @@ $clients=$pdo->query('SELECT id,name FROM clients ORDER BY name')->fetchAll();
       input.addEventListener('input', function(){
         hid.value='';
         var t=this.value.trim(); if(!t){sug.style.display='none';sug.innerHTML='';return;}
-  fetch('/?page=clients-search&term='+encodeURIComponent(t)).then(r=>r.json()).then(list=>{
+        fetch('/?page=clients-search&term='+encodeURIComponent(t)).then(r=>r.json()).then(list=>{
           if(!Array.isArray(list)||list.length===0){sug.style.display='none';sug.innerHTML='';return;}
           sug.innerHTML = list.map(x=>`<div data-id="${x.id}" data-name="${x.name}" style=\"padding:8px 10px;cursor:pointer\">${x.name}</div>`).join('');
           Array.from(sug.children).forEach(el=>{ el.addEventListener('click', function(){ input.value=this.dataset.name; hid.value=this.dataset.id; sug.style.display='none'; }); });
@@ -69,20 +85,51 @@ $clients=$pdo->query('SELECT id,name FROM clients ORDER BY name')->fetchAll();
           <th style="padding:10px">ID</th>
           <th style="padding:10px">Invoice</th>
           <th style="padding:10px">Client</th>
-          <th style="padding:10px">Amount</th>
+          <th style="padding:10px">Method</th>
+          <th style="padding:10px;text-align:right">Amount</th>
+          <th style="padding:10px;text-align:right">Refunded</th>
+          <th style="padding:10px;text-align:right">Net</th>
           <th style="padding:10px">Status</th>
-          <th style="padding:10px">Created</th>
+          <th style="padding:10px">Payment Date</th>
+          <th style="padding:10px">Actions</th>
         </tr>
       </thead>
       <tbody>
-        <?php foreach ($rows as $r): ?>
+        <?php foreach ($rows as $r):
+          $amount = (float)$r['amount'];
+          $refunded = (float)$r['refunded_amount'];
+          $disputed = (float)$r['disputed_amount'];
+          $net = max(0, $amount - $refunded - $disputed);
+          $canRefund = strtolower((string)$r['status']) === 'succeeded' && $net > 0.005;
+        ?>
           <tr style="border-top:1px solid #f3f4f6">
             <td style="padding:10px">#<?php echo (int)$r['id']; ?></td>
-            <td style="padding:10px">Invoice #<?php echo (int)$r['invoice_id']; ?></td>
+            <td style="padding:10px">
+              <?php if (!empty($r['invoice_id'])): ?>
+                Invoice #<?php echo htmlspecialchars((string)($r['doc_number'] ?: $r['invoice_id'])); ?>
+              <?php else: ?>
+                Manual
+              <?php endif; ?>
+            </td>
             <td style="padding:10px"><?php echo htmlspecialchars($r['client']); ?></td>
-            <td style="padding:10px">$<?php echo number_format((float)$r['amount'], 2); ?></td>
+            <td style="padding:10px;text-transform:capitalize"><?php echo htmlspecialchars(str_replace('_', ' ', (string)$r['payment_method'])); ?></td>
+            <td style="padding:10px;text-align:right">$<?php echo number_format($amount, 2); ?></td>
+            <td style="padding:10px;text-align:right">$<?php echo number_format($refunded + $disputed, 2); ?></td>
+            <td style="padding:10px;text-align:right;font-weight:600">$<?php echo number_format($net, 2); ?></td>
             <td style="padding:10px;text-transform:capitalize"><?php echo htmlspecialchars($r['status']); ?></td>
-            <td style="padding:10px"><?php echo $r['created_at'] ? date('m/d/Y', strtotime($r['created_at'])) : ''; ?></td>
+            <td style="padding:10px"><?php echo $r['payment_date'] ? date('m/d/Y', strtotime($r['payment_date'])) : ''; ?></td>
+            <td style="padding:10px">
+              <?php if ($canRefund): ?>
+                <form method="post" action="/?page=payments/payment-refund" style="display:flex;gap:6px;align-items:center" onsubmit="return confirm('Record this refund? This changes income and invoice balance.');">
+                  <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+                  <input type="hidden" name="payment_id" value="<?php echo (int)$r['id']; ?>">
+                  <input type="number" name="amount" step="0.01" min="0.01" max="<?php echo htmlspecialchars(number_format($net, 2, '.', '')); ?>" placeholder="0.00" style="width:92px;padding:6px;border-radius:6px;border:1px solid #ddd">
+                  <button type="submit" style="padding:6px 9px;border-radius:6px;border:1px solid #fecaca;background:#fff1f2;color:#991b1b">Refund</button>
+                </form>
+              <?php else: ?>
+                <span style="color:var(--muted);font-size:13px">-</span>
+              <?php endif; ?>
+            </td>
           </tr>
         <?php endforeach; ?>
       </tbody>

--- a/src/views/pages/settings/notifications.php
+++ b/src/views/pages/settings/notifications.php
@@ -95,6 +95,34 @@
   
   <fieldset style="border:1px solid #eee;border-radius:8px;padding:16px">
     <legend style="padding:0 8px;font-weight:600">Email Notifications</legend>
+
+    <div style="margin-bottom:16px">
+      <h3 style="margin:0 0 12px 0;font-size:15px">Payment Receipts</h3>
+
+      <label style="display:flex;align-items:start;gap:10px;margin-bottom:12px">
+        <input type="checkbox" name="payment_receipts_enabled" value="1" <?php echo !array_key_exists('payment_receipts_enabled', $appConfig) || !empty($appConfig['payment_receipts_enabled']) ? 'checked' : ''; ?> style="margin-top:3px">
+        <div>
+          <div class="font-600">Enable payment receipts</div>
+          <div style="font-size:13px;color:var(--muted)">Create receipts for successful payments and email them when selected.</div>
+        </div>
+      </label>
+    </div>
+
+    <div style="padding-top:16px;border-top:1px solid #eee;margin-bottom:16px">
+      <h3 style="margin:0 0 12px 0;font-size:15px">Automated Email Notice</h3>
+
+      <label style="display:flex;align-items:start;gap:10px;margin-bottom:12px">
+        <input type="checkbox" name="email_no_reply_notice_enabled" value="1" <?php echo !empty($appConfig['email_no_reply_notice_enabled']) ? 'checked' : ''; ?> style="margin-top:3px">
+        <div>
+          <div class="font-600">Add automated-message notice to outgoing emails</div>
+          <div style="font-size:13px;color:var(--muted)">Adds a short footer to system emails sent from PA.</div>
+        </div>
+      </label>
+      <label style="display:block">
+        <div style="margin-bottom:4px;font-weight:500">Notice text</div>
+        <input type="text" name="email_no_reply_notice_text" value="<?php echo htmlspecialchars($appConfig['email_no_reply_notice_text'] ?? 'This is an automated message. Please do not reply to this email.'); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+      </label>
+    </div>
     
     <!-- Invoice Reminders -->
     <div style="margin-bottom:16px">

--- a/src/views/public/doc-wrapper.php
+++ b/src/views/public/doc-wrapper.php
@@ -56,14 +56,14 @@ if (in_array($type, ['invoice', 'project_invoice'], true)) {
             if ($type === 'project_invoice') {
                 $amountPaid = (float)($invoiceData['amount_paid'] ?? 0);
             } else {
-                $paidSt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount,0)), 0) FROM payments WHERE invoice_id = ? AND status = "succeeded"');
+                $paidSt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount-disputed_amount,0)), 0) FROM payments WHERE invoice_id = ? AND status = "succeeded"');
                 $paidSt->execute([$rid]);
                 $amountPaid = (float)$paidSt->fetchColumn();
             }
             $invoiceData['amount_paid'] = $amountPaid;
             
             $invStatus = strtolower($invoiceData['status'] ?? '');
-            $calculatedAmountDue = (float)($invoiceData['total'] ?? 0) - $amountPaid;
+            $calculatedAmountDue = max(0, (float)($invoiceData['total'] ?? 0) - $amountPaid);
             $collectionMode = trim((string)($invoiceData['collection_mode'] ?? ''));
             if ($collectionMode === '') {
                 $collectionMode = 'direct';


### PR DESCRIPTION
Summary
- Add manual payments not tied to invoices, with manual payment dates for backfilled income.
- Add refund recording from the payments list and recalculate invoice balances/status from net payments.
- Add receipt and automated email notice settings, plus invoice editing improvements for unpaid invoices.

Validation
- PHP syntax checks passed for changed PHP files.
- PHPUnit payment suite could not run because the local vendor tree is missing PHPUnit\TextUI\Application.