### PR TITLE
Improve cron and Stripe payment imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ ARG APP_VERSION=dev
 ENV APP_VERSION=${APP_VERSION}
 
 RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends \
-        default-mysql-client cron curl zlib1g-dev libzip-dev \
+        default-mysql-client cron curl tzdata zlib1g-dev libzip-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN docker-php-ext-install -j"$(nproc)" zip pdo_mysql mysqli

--- a/cron/README.md
+++ b/cron/README.md
@@ -1,13 +1,15 @@
 # Project Alpha Cron Service
 
-The cron image runs Project Alpha's scheduled PHP jobs independently from Apache. The current schedule is installed from `cron/crontab` and uses UTC.
+The cron image runs Project Alpha's scheduled PHP jobs independently from Apache. The current schedule is installed from `cron/crontab` and uses the PA system timezone loaded from `app_config.timezone` when the cron container starts.
+
+On container startup, the entrypoint also runs `stripe_reconciliation.php --startup` once before starting cron. This catches recent Stripe payments after downtime, while the normal six-hour schedule continues to reconcile missed webhooks.
 
 ## Installed Schedule
 
-| UTC schedule | Script | Purpose |
+| Local schedule | Script | Purpose |
 |---|---|---|
 | Daily 02:00 | `generate_recurring_invoices.php` | Generate due long-term invoices and catch up missed periods |
-| Daily 02:30 | `backup_database.php` | Create rotating daily, weekly, and monthly backups |
+| Hourly at :30 | `backup_database.php --scheduled` | Creates rotating backups when the configured local backup hour matches |
 | Daily 03:00 | `auto_terminate_contracts.php` | Complete contracts whose configured end date has passed |
 | Daily 04:00 | `link_expiration_checker.php` | Expire public document links |
 | Every 6 hours | `stripe_reconciliation.php` | Recover Stripe payments missed by webhooks or downtime |
@@ -16,6 +18,8 @@ The cron image runs Project Alpha's scheduled PHP jobs independently from Apache
 | Daily 08:00 | `send_invoice_reminders.php` | Send enabled due and overdue reminders |
 
 All output is appended to `/var/www/config/logs/cron/cron.log` in the cron container.
+
+If the PA system timezone is changed in Settings, restart or recreate the cron container so the daemon reloads `/etc/localtime`. Individual PHP jobs also load `config/app.php`, so their date math uses the configured timezone.
 
 ## Runtime
 

--- a/cron/crontab
+++ b/cron/crontab
@@ -7,31 +7,33 @@ SHELL=/bin/bash
 # Unified log file for all cron jobs
 CRON_LOG=/var/www/config/logs/cron/cron.log
 
-# Rotate system and cron logs above 10 MB - daily at 1:15 AM UTC
+# Times are interpreted in the PA system timezone applied by entrypoint.sh.
+
+# Rotate system and cron logs above 10 MB - daily at 1:15 AM
 15 1 * * * root . /etc/environment && php /var/www/src/cron/rotate_logs.php >> $CRON_LOG 2>&1
 
-# Generate recurring invoices - daily at 2:00 AM UTC
+# Generate recurring invoices - daily at 2:00 AM
 0 2 * * * root . /etc/environment && php /var/www/src/cron/generate_recurring_invoices.php >> $CRON_LOG 2>&1
 
 # Check hourly at :30; the script honors the configured UTC backup hour.
 30 * * * * root . /etc/environment && php /var/www/src/cron/backup_database.php --scheduled >> $CRON_LOG 2>&1
 
-# Auto-terminate expired contracts - daily at 3:00 AM UTC
+# Auto-terminate expired contracts - daily at 3:00 AM
 0 3 * * * root . /etc/environment && php /var/www/src/cron/auto_terminate_contracts.php >> $CRON_LOG 2>&1
 
-# Check and expire links - daily at 4:00 AM UTC
+# Check and expire links - daily at 4:00 AM
 0 4 * * * root . /etc/environment && php /var/www/src/cron/link_expiration_checker.php >> $CRON_LOG 2>&1
 
-# Process audit schedules - daily at 6:00 AM UTC
+# Process audit schedules - daily at 6:00 AM
 0 6 * * * root . /etc/environment && php /var/www/src/cron/process_audit_schedules.php >> $CRON_LOG 2>&1
 
-# Send invoice reminders (due-7 and overdue-weekly) - daily at 8:00 AM UTC
+# Send invoice reminders (due-7 and overdue-weekly) - daily at 8:00 AM
 0 8 * * * root . /etc/environment && php /var/www/src/cron/send_invoice_reminders.php >> $CRON_LOG 2>&1
 
 # Stripe payment reconciliation - every 6 hours
 0 */6 * * * root . /etc/environment && php /var/www/src/cron/stripe_reconciliation.php >> $CRON_LOG 2>&1
 
-# Sync actual Stripe merchant rate (non-changeable) - daily at 5:00 AM UTC
+# Sync actual Stripe merchant rate (non-changeable) - daily at 5:00 AM
 0 5 * * * root . /etc/environment && php /var/www/src/cron/sync_merchant_rate.php >> $CRON_LOG 2>&1
 
 # Required blank line at end of crontab

--- a/cron/entrypoint.sh
+++ b/cron/entrypoint.sh
@@ -76,5 +76,37 @@ if [ $counter -ge $RETRIES ]; then
 fi
 
 # ── Start cron in the foreground ──
+APP_TIMEZONE="${APP_TIMEZONE:-}"
+if command -v mysql > /dev/null 2>&1; then
+  APP_TIMEZONE="$(mysql --skip-ssl \
+    -h "${DB_HOST}" -P "${DB_PORT}" \
+    -u"${MYSQL_USER:-root}" \
+    --password="${MYSQL_PASSWORD:-${MYSQL_ROOT_PASSWORD:-rootpass}}" \
+    -D "${MYSQL_DATABASE:-project_alpha}" \
+    --batch --skip-column-names \
+    -e "SELECT config_value FROM app_config WHERE organization_id=0 AND config_key='timezone' LIMIT 1" 2>/dev/null || true)"
+fi
+
+if [ -z "$APP_TIMEZONE" ]; then
+  APP_TIMEZONE="${TZ:-UTC}"
+fi
+
+if [ -f "/usr/share/zoneinfo/${APP_TIMEZONE}" ]; then
+  ln -snf "/usr/share/zoneinfo/${APP_TIMEZONE}" /etc/localtime
+  echo "${APP_TIMEZONE}" > /etc/timezone
+  export TZ="${APP_TIMEZONE}"
+  echo "[cron-entrypoint] Using PA timezone: ${APP_TIMEZONE}"
+else
+  export TZ="UTC"
+  echo "[cron-entrypoint] Timezone '${APP_TIMEZONE}' is unavailable; using UTC."
+fi
+
+grep -v '^TZ=' /etc/environment > /tmp/project-alpha-environment || true
+echo "TZ=\"${TZ}\"" >> /tmp/project-alpha-environment
+mv /tmp/project-alpha-environment /etc/environment
+
+echo "[cron-entrypoint] Running startup Stripe reconciliation..."
+php /var/www/src/cron/stripe_reconciliation.php --startup || echo "[cron-entrypoint] Startup Stripe reconciliation failed; cron will continue."
+
 echo "[cron-entrypoint] Starting cron..."
 exec cron -f

--- a/database/migrations/0018_repair_cron_job_runs_schema.sql
+++ b/database/migrations/0018_repair_cron_job_runs_schema.sql
@@ -1,0 +1,86 @@
+-- Repair cron status tracking for older installs.
+-- Cron jobs and settings pages use this table to display last-run state.
+
+CREATE TABLE IF NOT EXISTS cron_job_runs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    job_name VARCHAR(100) NOT NULL,
+    last_run DATETIME NULL,
+    status ENUM('running','completed','failed','success') NOT NULL DEFAULT 'running',
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP NULL,
+    result TEXT NULL,
+    error_message TEXT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_cron_job_name (job_name),
+    INDEX idx_job_name (job_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @cron_last_run_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'cron_job_runs' AND column_name = 'last_run'
+);
+SET @sql := IF(@cron_last_run_exists = 0, 'ALTER TABLE cron_job_runs ADD COLUMN last_run DATETIME NULL AFTER job_name', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+ALTER TABLE cron_job_runs MODIFY COLUMN status ENUM('running','completed','failed','success') NOT NULL DEFAULT 'running';
+
+SET @cron_started_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'cron_job_runs' AND column_name = 'started_at'
+);
+SET @sql := IF(@cron_started_at_exists = 0, 'ALTER TABLE cron_job_runs ADD COLUMN started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP AFTER status', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @cron_completed_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'cron_job_runs' AND column_name = 'completed_at'
+);
+SET @sql := IF(@cron_completed_at_exists = 0, 'ALTER TABLE cron_job_runs ADD COLUMN completed_at TIMESTAMP NULL AFTER started_at', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @cron_result_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'cron_job_runs' AND column_name = 'result'
+);
+SET @sql := IF(@cron_result_exists = 0, 'ALTER TABLE cron_job_runs ADD COLUMN result TEXT NULL AFTER completed_at', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @cron_error_message_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'cron_job_runs' AND column_name = 'error_message'
+);
+SET @sql := IF(@cron_error_message_exists = 0, 'ALTER TABLE cron_job_runs ADD COLUMN error_message TEXT NULL AFTER result', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @cron_updated_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'cron_job_runs' AND column_name = 'updated_at'
+);
+SET @sql := IF(@cron_updated_at_exists = 0, 'ALTER TABLE cron_job_runs ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER error_message', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @cron_unique_job_name_exists := (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'cron_job_runs'
+      AND column_name = 'job_name'
+      AND non_unique = 0
+);
+SET @sql := IF(@cron_unique_job_name_exists = 0, 'ALTER TABLE cron_job_runs ADD UNIQUE KEY uq_cron_job_name (job_name)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+INSERT IGNORE INTO cron_job_runs (job_name, last_run, status) VALUES
+    ('rotate_logs', NULL, 'success'),
+    ('generate_recurring_invoices', NULL, 'success'),
+    ('backup_database', NULL, 'success'),
+    ('auto_terminate_contracts', NULL, 'success'),
+    ('link_expiration_checker', NULL, 'success'),
+    ('process_audit_schedules', NULL, 'success'),
+    ('send_invoice_reminders', NULL, 'success'),
+    ('stripe_reconciliation', NULL, 'success'),
+    ('sync_merchant_rate', NULL, 'success');
+
+INSERT IGNORE INTO app_config (organization_id, config_key, config_value) VALUES
+    (0, 'backup_hour', '2'),
+    (0, 'backup_retention_days', '10'),
+    (0, 'backup_mode', 'database');

--- a/public/index.php
+++ b/public/index.php
@@ -638,6 +638,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'settings/document-custom-fields-handler',
         'settings/link-test-connection',
         'settings/stripe-net-backfill',
+        'settings/stripe-import-payments',
         'settings/dropbox-oauth',
         'settings/link-resolver-run',
 
@@ -849,6 +850,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     if ($page === 'settings/stripe-net-backfill') {
         require_once __DIR__ . '/../src/controllers/settings/stripe_net_backfill.php';
+        exit;
+    }
+    if ($page === 'settings/stripe-import-payments') {
+        require_once __DIR__ . '/../src/controllers/settings/stripe_import_payments.php';
         exit;
     }
     if ($page === 'settings/custom-fields-handler') {

--- a/src/controllers/api/dashboard_summary.php
+++ b/src/controllers/api/dashboard_summary.php
@@ -2,6 +2,7 @@
 // src/controllers/api/dashboard_summary.php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/app_version.php';
+require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/payment_accounting.php';
 header('Content-Type: application/json');
 
@@ -14,6 +15,13 @@ function _count($pdo, $sql) {
 }
 
 $incomeExpr = payment_accounting_net_income_expr('p');
+$userId = (int)($_SESSION['user']['id'] ?? 0);
+$orgId = request_client_org_id();
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
+$expenseCountStmt = $pdo->prepare("SELECT COUNT(*) FROM expenses e WHERE {$expenseScopeWhere} AND e.status != 'void'");
+$expenseCountStmt->execute($expenseScopeParams);
+$expenseTotalStmt = $pdo->prepare("SELECT COALESCE(SUM(COALESCE(e.total_amount, e.amount, 0)),0) FROM expenses e WHERE {$expenseScopeWhere} AND e.status != 'void'");
+$expenseTotalStmt->execute($expenseScopeParams);
 
 $resp = [
     'generated_at' => gmdate('c'),
@@ -23,7 +31,8 @@ $resp = [
     'quotes'       => _count($pdo, "SELECT COUNT(*) FROM quotes"),
     'contracts'    => _count($pdo, "SELECT COUNT(*) FROM contracts"),
     'invoices'     => _count($pdo, "SELECT COUNT(*) FROM invoices"),
-    'expenses'     => _count($pdo, "SELECT COUNT(*) FROM expenses"),
+    'expenses'     => (int)$expenseCountStmt->fetchColumn(),
+    'expense_total'=> (float)$expenseTotalStmt->fetchColumn(),
     'revenue'      => _scalar($pdo, "SELECT COALESCE(SUM({$incomeExpr}),0) FROM payments p WHERE p.status='succeeded'"),
     'outstanding'  => _scalar($pdo, "SELECT COALESCE(SUM(balance_due),0) FROM invoices WHERE status NOT IN ('paid','cancelled','void')"),
 ];

--- a/src/controllers/api/financial_summary.php
+++ b/src/controllers/api/financial_summary.php
@@ -1,6 +1,7 @@
 <?php
 // src/controllers/api/financial_summary.php
 require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/payment_accounting.php';
 header('Content-Type: application/json');
 
@@ -17,8 +18,11 @@ $stmt = $pdo->prepare("SELECT COALESCE(SUM(total),0) FROM invoices WHERE status=
 $stmt->execute([$start]);
 $invoicedPaid = (float) $stmt->fetchColumn();
 
-$stmt = $pdo->prepare("SELECT COALESCE(SUM(total_amount),0) FROM expenses WHERE DATE(expense_date)>=?");
-$stmt->execute([$start]);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
+$orgId = request_client_org_id();
+[$expenseScopeWhere, $expenseScopeParams] = finance_scope_clause($pdo, 'e', $userId, $orgId, 'created_by');
+$stmt = $pdo->prepare("SELECT COALESCE(SUM(COALESCE(e.total_amount, e.amount, 0)),0) FROM expenses e WHERE {$expenseScopeWhere} AND e.status != 'void' AND DATE(e.expense_date)>=?");
+$stmt->execute(array_merge($expenseScopeParams, [$start]));
 $expenses = (float) $stmt->fetchColumn();
 
 echo json_encode([

--- a/src/controllers/backup_handler.php
+++ b/src/controllers/backup_handler.php
@@ -8,6 +8,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../config/app.php';
 require_once __DIR__ . '/../utils/backup_archive.php';
 
 $action = $_POST['action'] ?? '';
@@ -152,6 +153,10 @@ switch ($action) {
         $retentionDays = (int)($_POST['retention_days'] ?? 10);
         $backupHour = (int)($_POST['backup_hour'] ?? 2);
         $backupMode = ($_POST['backup_mode'] ?? 'database') === 'full' ? 'full' : 'database';
+        $backupTimezone = (string)($appConfig['timezone'] ?? date_default_timezone_get() ?: 'UTC');
+        if (!in_array($backupTimezone, DateTimeZone::listIdentifiers(), true)) {
+            $backupTimezone = 'UTC';
+        }
 
         if ($retentionDays < 0 || $retentionDays > 365) {
             $_SESSION['flash_backup'] = [
@@ -178,7 +183,7 @@ switch ($action) {
 
         $_SESSION['flash_backup'] = [
             'type' => 'success',
-                'message' => "Backup settings saved. Mode: {$backupMode}; retention: {$retentionDays} backups; schedule check: " . str_pad($backupHour, 2, '0', STR_PAD_LEFT) . ":30 UTC."
+            'message' => "Backup settings saved. Mode: {$backupMode}; retention: {$retentionDays} backups; schedule check: " . str_pad($backupHour, 2, '0', STR_PAD_LEFT) . ":30 {$backupTimezone}."
         ];
         header('Location: ' . $settingsUrl);
         exit;

--- a/src/controllers/settings/stripe_import_payments.php
+++ b/src/controllers/settings/stripe_import_payments.php
@@ -1,0 +1,97 @@
+<?php
+declare(strict_types=1);
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../config/app.php';
+require_once __DIR__ . '/../../services/StripeService.php';
+require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/csrf.php';
+require_once __DIR__ . '/../../utils/stripe_reconciliation_import.php';
+
+$redirectBase = '/?page=settings&tab=billing';
+
+function stripe_import_redirect(string $key, string $message): void
+{
+    global $redirectBase;
+    header('Location: ' . $redirectBase . '&' . $key . '=' . rawurlencode($message));
+    exit;
+}
+
+function stripe_import_parse_date(string $value, DateTimeZone $timezone): ?DateTimeImmutable
+{
+    $date = DateTimeImmutable::createFromFormat('!Y-m-d', $value, $timezone);
+    $errors = DateTimeImmutable::getLastErrors();
+    if (!$date || (is_array($errors) && ((int)$errors['warning_count'] > 0 || (int)$errors['error_count'] > 0))) {
+        return null;
+    }
+    return $date;
+}
+
+$userId = (int)($_SESSION['user']['id'] ?? 0);
+if ($userId <= 0 || !user_can($pdo, $userId, 'settings.manage', 0)) {
+    stripe_import_redirect('stripe_import_error', 'Permission denied');
+}
+
+if (!csrf_validate()) {
+    stripe_import_redirect('stripe_import_error', 'Invalid request. Please refresh and try again.');
+}
+
+$stripe = StripeService::fromAppConfig($appConfig ?? []);
+if (!$stripe) {
+    stripe_import_redirect('stripe_import_error', 'Stripe is not configured.');
+}
+
+$timezoneName = trim((string)($appConfig['timezone'] ?? date_default_timezone_get() ?: 'UTC'));
+try {
+    $timezone = new DateTimeZone($timezoneName);
+} catch (Throwable $e) {
+    $timezone = new DateTimeZone('UTC');
+}
+
+$today = new DateTimeImmutable('today', $timezone);
+$defaultStart = $today->modify('-30 days');
+$startDateRaw = trim((string)($_POST['stripe_import_start_date'] ?? $defaultStart->format('Y-m-d')));
+$endDateRaw = trim((string)($_POST['stripe_import_end_date'] ?? $today->format('Y-m-d')));
+
+$startDate = stripe_import_parse_date($startDateRaw, $timezone);
+$endDate = stripe_import_parse_date($endDateRaw, $timezone);
+if (!$startDate || !$endDate) {
+    stripe_import_redirect('stripe_import_error', 'Enter valid start and end dates.');
+}
+
+if ($endDate > $today) {
+    $endDate = $today;
+}
+if ($startDate > $endDate) {
+    stripe_import_redirect('stripe_import_error', 'Start date must be on or before the end date.');
+}
+
+$maxIntents = (int)($_POST['stripe_import_max_intents'] ?? 2000);
+$maxIntents = max(100, min(10000, $maxIntents));
+
+try {
+    $result = stripe_reconcile_payment_intents(
+        $pdo,
+        $stripe,
+        $appConfig ?? [],
+        $startDate->setTime(0, 0, 0)->getTimestamp(),
+        $endDate->setTime(23, 59, 59)->getTimestamp(),
+        $maxIntents,
+        true
+    );
+
+    $message = sprintf(
+        'Stripe payment import complete for %s through %s: %s.',
+        $startDate->format('Y-m-d'),
+        $endDate->format('Y-m-d'),
+        stripe_reconcile_summary($result)
+    );
+    stripe_import_redirect('stripe_import_result', $message);
+} catch (Throwable $e) {
+    @error_log('[stripe_import_payments] Error: ' . $e->getMessage());
+    stripe_import_redirect('stripe_import_error', $e->getMessage());
+}

--- a/src/cron/backup_database.php
+++ b/src/cron/backup_database.php
@@ -6,13 +6,19 @@
  */
 
 require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../config/app.php';
 require_once __DIR__ . '/../utils/cron_state.php';
 require_once __DIR__ . '/../utils/backup_archive.php';
 
 $jobName = 'backup_database';
+$appTimezone = date_default_timezone_get();
 
 $scheduledRun = in_array('--scheduled', $argv ?? [], true);
 if ($scheduledRun) {
+    if (empty($appConfig['cron_enabled'])) {
+        cron_state_mark_success($pdo, $jobName, 'Cron disabled');
+        exit(0);
+    }
     $backupHour = 2;
     try {
         $hourStmt = $pdo->prepare('SELECT config_value FROM app_config WHERE organization_id=0 AND config_key="backup_hour"');
@@ -62,7 +68,7 @@ if (!$gz) {
 
 // Write header
 gzwrite($gz, "-- Project Alpha Database Backup\n");
-gzwrite($gz, "-- Generated: " . date('Y-m-d H:i:s') . " UTC\n");
+gzwrite($gz, "-- Generated: " . date('Y-m-d H:i:s') . " {$appTimezone}\n");
 gzwrite($gz, "-- Database: $db\n\n");
 gzwrite($gz, "SET FOREIGN_KEY_CHECKS=0;\n");
 gzwrite($gz, "SET NAMES utf8mb4;\n\n");

--- a/src/cron/generate_recurring_invoices.php
+++ b/src/cron/generate_recurring_invoices.php
@@ -14,6 +14,7 @@ $jobName = 'generate_recurring_invoices';
 // Check if cron is enabled in settings
 if (empty($appConfig['cron_enabled'])) {
     @error_log("$logPrefix Cron is disabled in settings. Skipping invoice generation.");
+    cron_state_mark_success($pdo, $jobName, 'Cron disabled');
     exit(0);
 }
 

--- a/src/cron/link_expiration_checker.php
+++ b/src/cron/link_expiration_checker.php
@@ -2,10 +2,17 @@
 // src/cron/link_expiration_checker.php
 
 require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../config/app.php';
 require_once __DIR__ . '/../utils/cron_state.php';
 
 $logPrefix = '[LinkExpirationChecker]';
 $jobName = 'link_expiration_checker';
+
+if (empty($appConfig['cron_enabled'])) {
+    echo $logPrefix . " Cron is disabled. Exiting.\n";
+    cron_state_mark_success($pdo, $jobName, 'Cron disabled');
+    exit(0);
+}
 
 /**
  * Link Expiration Checker Cron Job

--- a/src/cron/send_invoice_reminders.php
+++ b/src/cron/send_invoice_reminders.php
@@ -13,6 +13,12 @@ require_once __DIR__ . '/../utils/cron_state.php';
 $logPrefix = '[send_invoice_reminders]';
 $jobName = 'send_invoice_reminders';
 
+if (empty($appConfig['cron_enabled'])) {
+    @error_log("$logPrefix Cron is disabled in settings. Skipping.");
+    cron_state_mark_success($pdo, $jobName, 'Cron disabled');
+    exit(0);
+}
+
 // Check if either reminder is enabled
 $due7Enabled = !empty($appConfig['invoice_auto_send_due_7days']);
 $overdueEnabled = !empty($appConfig['invoice_auto_send_overdue_weekly']);

--- a/src/cron/stripe_reconciliation.php
+++ b/src/cron/stripe_reconciliation.php
@@ -10,9 +10,8 @@
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../config/app.php';
 require_once __DIR__ . '/../services/StripeService.php';
-require_once __DIR__ . '/../services/PaymentProcessorImportService.php';
 require_once __DIR__ . '/../utils/cron_state.php';
-require_once __DIR__ . '/../utils/stripe_financial_events.php';
+require_once __DIR__ . '/../utils/stripe_reconciliation_import.php';
 require_once __DIR__ . '/../utils/stripe_payment_accounting.php';
 
 $logPrefix = '[stripe_reconciliation]';
@@ -21,12 +20,14 @@ $jobName = 'stripe_reconciliation';
 // Check if cron is enabled
 if (empty($appConfig['cron_enabled'])) {
     @error_log("$logPrefix Cron is disabled in settings. Skipping.");
+    cron_state_mark_success($pdo, $jobName, 'Cron disabled');
     exit(0);
 }
 
 // Check if Stripe is configured
 if (!StripeService::isConfigured($appConfig)) {
     @error_log("$logPrefix Stripe is not configured. Skipping.");
+    cron_state_mark_success($pdo, $jobName, 'Stripe not configured');
     exit(0);
 }
 
@@ -47,164 +48,16 @@ try {
     
     @error_log("$logPrefix Fetching Payment Intents since " . date('Y-m-d H:i:s', $since));
     
-    // Fetch Payment Intents from Stripe
-    $paymentIntents = $stripe->listPaymentIntents($since);
-    
-    $reconciled = 0;
-    $skipped = 0;
-    $errors = 0;
-    
-    foreach ($paymentIntents as $pi) {
-        try {
-            // Only process succeeded payments
-            if ($pi['status'] !== 'succeeded') {
-                $skipped++;
-                continue;
-            }
-
-            if (!empty($pi['metadata']['pa_project_invoice_id']) || !empty($pi['metadata']['project_invoice_id'])) {
-                require_once __DIR__ . '/../utils/project_invoice_billing.php';
-                if (project_invoice_record_stripe_payment($pdo, $pi)) {
-                    $reconciled++;
-                } else {
-                    $errors++;
-                }
-                continue;
-            }
-            
-            // Get invoice ID from metadata
-            $invoiceId = $pi['metadata']['pa_invoice_id'] ?? $pi['metadata']['invoice_id'] ?? null;
-            if (!$invoiceId) {
-                $result = PaymentProcessorImportService::importStandalone(
-                    $pdo,
-                    $appConfig,
-                    $stripe->normalizePaymentIntentForImport($pi)
-                );
-                if (in_array($result['status'] ?? '', ['imported', 'duplicate'], true)) {
-                    $reconciled++;
-                } elseif (($result['status'] ?? '') === 'failed') {
-                    $errors++;
-                } else {
-                    $skipped++;
-                }
-                continue;
-            }
-            
-            $invoiceId = (int)$invoiceId;
-            $piId = $pi['id'];
-            $amount = ($pi['amount'] ?? 0) / 100; // Convert cents to dollars
-            $paymentAmount = isset($pi['metadata']['original_amount']) ? (float)$pi['metadata']['original_amount'] : $amount;
-            $surchargeAmount = isset($pi['metadata']['surcharge_amount']) ? (float)$pi['metadata']['surcharge_amount'] : max(0, $amount - $paymentAmount);
-            $processorTx = $stripe->normalizePaymentIntentForImport($pi);
-            
-            // Check if this payment is already recorded
-            $existsStmt = $pdo->prepare('SELECT id FROM payments WHERE stripe_payment_intent_id = ?');
-            $existsStmt->execute([$piId]);
-            $existingPaymentId = (int)($existsStmt->fetchColumn() ?: 0);
-            if ($existingPaymentId > 0) {
-                stripe_update_payment_processor_fields($pdo, $existingPaymentId, $processorTx, $appConfig);
-                $reconciled++;
-                continue;
-            }
-            
-            // Check if invoice exists
-            $invStmt = $pdo->prepare('SELECT id, total, status, client_id FROM invoices WHERE id = ?');
-            $invStmt->execute([$invoiceId]);
-            $invoice = $invStmt->fetch(PDO::FETCH_ASSOC);
-            
-            if (!$invoice) {
-                @error_log("$logPrefix Invoice $invoiceId not found for PI $piId");
-                $skipped++;
-                continue;
-            }
-            
-            // Skip if already paid
-            if ($invoice['status'] === 'paid') {
-                $skipped++;
-                continue;
-            }
-            
-            // Record the payment
-            $pdo->beginTransaction();
-            
-            $isAutoPay = 0;
-            $processorFields = stripe_processor_fields_from_normalized($processorTx, $appConfig, $paymentAmount, $surchargeAmount);
-            $pdo->prepare('
-                INSERT INTO payments
-                    (client_id, invoice_id, amount, surcharge_paid, payment_method, stripe_payment_intent_id, auto_pay_attempt,
-                     processor_provider, processor_payment_id, processor_gross_amount, processor_fee_amount, processor_net_amount,
-                     processor_fee_policy, processor_fee_source, status, payment_date, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURDATE(), NOW())
-            ')->execute([
-                (int)$invoice['client_id'], $invoiceId, $paymentAmount, $surchargeAmount, 'stripe', $piId, $isAutoPay,
-                $processorFields['processor_provider'], $processorFields['processor_payment_id'] ?: null,
-                $processorFields['processor_gross_amount'], $processorFields['processor_fee_amount'], $processorFields['processor_net_amount'],
-                $processorFields['processor_fee_policy'], $processorFields['processor_fee_source'], 'succeeded'
-            ]);
-            $paymentId = (int)$pdo->lastInsertId();
-            stripe_link_pending_financial_events($pdo, $paymentId, $piId);
-            
-            // Update invoice status
-            $sumStmt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount,0)), 0) FROM payments WHERE invoice_id = ? AND status = "succeeded"');
-            $sumStmt->execute([$invoiceId]);
-            $totalPaid = (float)$sumStmt->fetchColumn();
-            
-            $invoiceTotal = (float)$invoice['total'];
-            $newStatus = ($totalPaid >= $invoiceTotal) ? 'paid' : 'partial';
-            
-            // Update invoice (with graceful handling of amount_paid column)
-            try {
-                $pdo->prepare('UPDATE invoices SET status=?,amount_paid=?,balance_due=GREATEST(total-?,0),stripe_session_id=NULL,stripe_checkout_expires_at=NULL WHERE id=?')
-                    ->execute([$newStatus, $totalPaid, $totalPaid, $invoiceId]);
-            } catch (Throwable $e) {
-                $pdo->prepare('UPDATE invoices SET status = ? WHERE id = ?')
-                    ->execute([$newStatus, $invoiceId]);
-            }
-            
-            // If fully paid, handle contract completion and public link revocation
-            if ($newStatus === 'paid') {
-                // Revoke public links
-                try {
-                    $pdo->prepare('UPDATE public_links SET revoked = 1, redirect = ? WHERE document_type = "invoice" AND document_id = ? AND revoked = 0')
-                        ->execute(['/?page=public-redirect&type=invoice&reason=paid', $invoiceId]);
-                } catch (Throwable $e) { /* ignore */ }
-                
-                // Mark linked contract as completed
-                $coStmt = $pdo->prepare('SELECT contract_id FROM invoices WHERE id = ?');
-                $coStmt->execute([$invoiceId]);
-                $contractId = (int)$coStmt->fetchColumn();
-                if ($contractId > 0) {
-                    $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')->execute(['completed', $contractId]);
-                }
-            }
-            
-            $pdo->commit();
-            $reconciled++;
-
-            try {
-                require_once __DIR__ . '/../utils/payment_receipts.php';
-                payment_receipt_issue($pdo, $paymentId, $appConfig);
-            } catch (Throwable $receiptError) {
-                @error_log("$logPrefix Receipt issue failed for payment $paymentId: " . $receiptError->getMessage());
-            }
-            
-            @error_log("$logPrefix Reconciled payment $piId for invoice $invoiceId: \$$paymentAmount");
-            
-        } catch (Throwable $e) {
-            if ($pdo->inTransaction()) $pdo->rollBack();
-            $errors++;
-            @error_log("$logPrefix Error processing PI {$pi['id']}: " . $e->getMessage());
-        }
-    }
+    $result = stripe_reconcile_payment_intents($pdo, $stripe, $appConfig, $since, null, 1000, false);
 
     $backfill = stripe_backfill_net_income($pdo, $stripe, $appConfig, 100);
-    $reconciled += (int)$backfill['updated'] + (int)$backfill['estimated'];
-    $skipped += (int)$backfill['unknown'] + (int)$backfill['skipped'];
-    $errors += (int)$backfill['failed'];
+    $result['reconciled'] += (int)$backfill['updated'] + (int)$backfill['estimated'];
+    $result['skipped'] += (int)$backfill['unknown'] + (int)$backfill['skipped'];
+    $result['errors'] += (int)$backfill['failed'];
     
-    cron_state_mark_success($pdo, $jobName, "{$reconciled} reconciled; {$skipped} skipped; {$errors} errors");
+    cron_state_mark_success($pdo, $jobName, stripe_reconcile_summary($result));
     
-    @error_log("$logPrefix Completed: $reconciled reconciled, $skipped skipped, $errors errors");
+    @error_log("$logPrefix Completed: " . stripe_reconcile_summary($result));
     
 } catch (Throwable $e) {
     @error_log("$logPrefix Fatal error: " . $e->getMessage());

--- a/src/cron/sync_merchant_rate.php
+++ b/src/cron/sync_merchant_rate.php
@@ -23,6 +23,12 @@ require_once __DIR__ . '/../utils/cron_state.php';
 $logPrefix = '[sync_merchant_rate]';
 $jobName = 'sync_merchant_rate';
 
+if (empty($appConfig['cron_enabled'])) {
+    @error_log("$logPrefix Cron is disabled in settings. Skipping.");
+    cron_state_mark_success($pdo, $jobName, 'Cron disabled');
+    exit(0);
+}
+
 // Initialize Stripe service
 $stripe = StripeService::fromAppConfig($appConfig);
 if (!$stripe) {

--- a/src/services/StripeService.php
+++ b/src/services/StripeService.php
@@ -355,19 +355,35 @@ class StripeService {
      * @return array List of Payment Intent objects
      */
     public function listPaymentIntents($since) {
+        return $this->listPaymentIntentsBetween((int)$since, null, 1000);
+    }
+
+    /**
+     * List Payment Intents created within a timestamp range.
+     *
+     * @param int $since Unix timestamp, inclusive.
+     * @param int|null $until Unix timestamp, inclusive.
+     * @param int $maxItems Safety cap for large historical imports.
+     * @return array List of Payment Intent objects
+     */
+    public function listPaymentIntentsBetween(int $since, ?int $until = null, int $maxItems = 1000): array {
         try {
             $allIntents = [];
             $hasMore = true;
             $startingAfter = null;
+            $maxItems = max(1, min(10000, $maxItems));
             
             while ($hasMore) {
                 $params = [
-                    'limit' => 100,
+                    'limit' => min(100, $maxItems - count($allIntents)),
                     'created[gte]' => $since,
                     'expand[0]' => 'charges.data',
                     'expand[1]' => 'charges.data.balance_transaction',
                     'expand[2]' => 'latest_charge.balance_transaction'
                 ];
+                if ($until !== null) {
+                    $params['created[lte]'] = $until;
+                }
                 if ($startingAfter) {
                     $params['starting_after'] = $startingAfter;
                 }
@@ -383,7 +399,7 @@ class StripeService {
                 $hasMore = !empty($response['has_more']);
                 
                 // Safety limit
-                if (count($allIntents) >= 1000) {
+                if (count($allIntents) >= $maxItems) {
                     break;
                 }
             }

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -43,6 +43,7 @@ function page_permission_map(): array
         'settings/permissions-handler'         => 'settings.manage',
         'settings/link-test-connection'      => 'settings.manage',
         'settings/stripe-net-backfill'       => 'settings.manage',
+        'settings/stripe-import-payments'    => 'settings.manage',
         'settings/tax-import-handler'        => 'settings.manage',
         'settings/tax-rates-handler'         => 'settings.manage',
 

--- a/src/utils/cron_state.php
+++ b/src/utils/cron_state.php
@@ -2,8 +2,97 @@
 // src/utils/cron_state.php
 // Shared helpers for recording cron run status and looking up catch-up windows.
 
+function cron_state_now(): string {
+    return date('Y-m-d H:i:s');
+}
+
+function cron_state_ensure_schema(PDO $pdo): void {
+    static $ensured = false;
+    if ($ensured) {
+        return;
+    }
+
+    try {
+        $pdo->exec(
+            "CREATE TABLE IF NOT EXISTS cron_job_runs (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                job_name VARCHAR(100) NOT NULL,
+                last_run DATETIME NULL,
+                status ENUM('running','completed','failed','success') NOT NULL DEFAULT 'running',
+                started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                completed_at TIMESTAMP NULL,
+                result TEXT NULL,
+                error_message TEXT NULL,
+                updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                UNIQUE KEY uq_cron_job_name (job_name),
+                INDEX idx_job_name (job_name)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"
+        );
+
+        $columns = [
+            'last_run' => 'DATETIME NULL AFTER job_name',
+            'started_at' => 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP AFTER status',
+            'completed_at' => 'TIMESTAMP NULL AFTER started_at',
+            'result' => 'TEXT NULL AFTER completed_at',
+            'error_message' => 'TEXT NULL AFTER result',
+            'updated_at' => 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER error_message',
+        ];
+        $check = $pdo->prepare(
+            'SELECT 1 FROM information_schema.columns
+             WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?
+             LIMIT 1'
+        );
+        foreach ($columns as $name => $definition) {
+            $check->execute(['cron_job_runs', $name]);
+            if ($check->fetchColumn() === false) {
+                $pdo->exec("ALTER TABLE cron_job_runs ADD COLUMN {$name} {$definition}");
+            }
+        }
+
+        try {
+            $pdo->exec("ALTER TABLE cron_job_runs MODIFY COLUMN status ENUM('running','completed','failed','success') NOT NULL DEFAULT 'running'");
+        } catch (Throwable $ignored) {
+        }
+
+        $index = $pdo->prepare(
+            'SELECT 1 FROM information_schema.statistics
+             WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ? AND non_unique = 0
+             LIMIT 1'
+        );
+        $index->execute(['cron_job_runs', 'job_name']);
+        if ($index->fetchColumn() === false) {
+            $pdo->exec('ALTER TABLE cron_job_runs ADD UNIQUE KEY uq_cron_job_name (job_name)');
+        }
+
+        $jobs = [
+            'rotate_logs',
+            'generate_recurring_invoices',
+            'backup_database',
+            'auto_terminate_contracts',
+            'link_expiration_checker',
+            'process_audit_schedules',
+            'send_invoice_reminders',
+            'stripe_reconciliation',
+            'sync_merchant_rate',
+        ];
+        $seed = $pdo->prepare('
+            INSERT INTO cron_job_runs (job_name, last_run, status)
+            SELECT ?, NULL, "success"
+            WHERE NOT EXISTS (SELECT 1 FROM cron_job_runs WHERE job_name = ?)
+        ');
+        foreach ($jobs as $job) {
+            $seed->execute([$job, $job]);
+        }
+    } catch (Throwable $e) {
+        @error_log('[cron_state] Failed to ensure cron_job_runs schema: ' . $e->getMessage());
+    }
+
+    $ensured = true;
+}
+
 function cron_state_last_run(PDO $pdo, string $jobName): ?string {
     try {
+        cron_state_ensure_schema($pdo);
         $stmt = $pdo->prepare('SELECT last_run FROM cron_job_runs WHERE job_name = ?');
         $stmt->execute([$jobName]);
         $lastRun = $stmt->fetchColumn();
@@ -16,17 +105,19 @@ function cron_state_last_run(PDO $pdo, string $jobName): ?string {
 
 function cron_state_mark_success(PDO $pdo, string $jobName, ?string $result = null): void {
     try {
+        cron_state_ensure_schema($pdo);
+        $now = cron_state_now();
         $stmt = $pdo->prepare('
             INSERT INTO cron_job_runs (job_name, last_run, status, completed_at, result, error_message)
-            VALUES (?, NOW(), "success", NOW(), ?, NULL)
+            VALUES (?, ?, "success", ?, ?, NULL)
             ON DUPLICATE KEY UPDATE
-                last_run = NOW(),
+                last_run = VALUES(last_run),
                 status = "success",
-                completed_at = NOW(),
+                completed_at = VALUES(completed_at),
                 result = VALUES(result),
                 error_message = NULL
         ');
-        $stmt->execute([$jobName, $result]);
+        $stmt->execute([$jobName, $now, $now, $result]);
     } catch (Throwable $e) {
         @error_log("[cron_state] Failed to mark success for {$jobName}: " . $e->getMessage());
     }
@@ -34,17 +125,19 @@ function cron_state_mark_success(PDO $pdo, string $jobName, ?string $result = nu
 
 function cron_state_mark_failure(PDO $pdo, string $jobName, Throwable $error): void {
     try {
+        cron_state_ensure_schema($pdo);
         $message = substr($error->getMessage(), 0, 1000);
+        $now = cron_state_now();
         $stmt = $pdo->prepare('
             INSERT INTO cron_job_runs (job_name, last_run, status, completed_at, error_message)
-            VALUES (?, NOW(), "failed", NOW(), ?)
+            VALUES (?, ?, "failed", ?, ?)
             ON DUPLICATE KEY UPDATE
-                last_run = NOW(),
+                last_run = VALUES(last_run),
                 status = "failed",
-                completed_at = NOW(),
+                completed_at = VALUES(completed_at),
                 error_message = VALUES(error_message)
         ');
-        $stmt->execute([$jobName, $message]);
+        $stmt->execute([$jobName, $now, $now, $message]);
     } catch (Throwable $e) {
         @error_log("[cron_state] Failed to mark failure for {$jobName}: " . $e->getMessage());
     }

--- a/src/utils/stripe_reconciliation_import.php
+++ b/src/utils/stripe_reconciliation_import.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../services/StripeService.php';
+require_once __DIR__ . '/../services/PaymentProcessorImportService.php';
+require_once __DIR__ . '/stripe_financial_events.php';
+require_once __DIR__ . '/stripe_payment_accounting.php';
+
+function stripe_reconcile_payment_intents(
+    PDO $pdo,
+    StripeService $stripe,
+    array $appConfig,
+    int $since,
+    ?int $until = null,
+    int $maxIntents = 1000,
+    bool $forceStandaloneImport = false
+): array {
+    $paymentIntents = $stripe->listPaymentIntentsBetween($since, $until, $maxIntents);
+    $result = [
+        'checked' => count($paymentIntents),
+        'reconciled' => 0,
+        'imported' => 0,
+        'duplicates' => 0,
+        'skipped' => 0,
+        'errors' => 0,
+    ];
+
+    $importConfig = $appConfig;
+    if ($forceStandaloneImport) {
+        $importConfig['processor_import_standalone_income'] = 1;
+    }
+
+    foreach ($paymentIntents as $pi) {
+        try {
+            if (($pi['status'] ?? '') !== 'succeeded') {
+                $result['skipped']++;
+                continue;
+            }
+
+            if (!empty($pi['metadata']['pa_project_invoice_id']) || !empty($pi['metadata']['project_invoice_id'])) {
+                require_once __DIR__ . '/project_invoice_billing.php';
+                if (project_invoice_record_stripe_payment($pdo, $pi)) {
+                    $result['reconciled']++;
+                } else {
+                    $result['errors']++;
+                }
+                continue;
+            }
+
+            $invoiceId = $pi['metadata']['pa_invoice_id'] ?? $pi['metadata']['invoice_id'] ?? null;
+            if (!$invoiceId) {
+                $standalone = PaymentProcessorImportService::importStandalone(
+                    $pdo,
+                    $importConfig,
+                    $stripe->normalizePaymentIntentForImport($pi)
+                );
+                if (($standalone['status'] ?? '') === 'imported') {
+                    $result['imported']++;
+                    $result['reconciled']++;
+                } elseif (($standalone['status'] ?? '') === 'duplicate') {
+                    $result['duplicates']++;
+                    $result['reconciled']++;
+                } elseif (($standalone['status'] ?? '') === 'failed') {
+                    $result['errors']++;
+                } else {
+                    $result['skipped']++;
+                }
+                continue;
+            }
+
+            $invoiceId = (int)$invoiceId;
+            $piId = (string)($pi['id'] ?? '');
+            $amount = ((int)($pi['amount'] ?? 0)) / 100;
+            $paymentAmount = isset($pi['metadata']['original_amount']) ? (float)$pi['metadata']['original_amount'] : $amount;
+            $surchargeAmount = isset($pi['metadata']['surcharge_amount']) ? (float)$pi['metadata']['surcharge_amount'] : max(0, $amount - $paymentAmount);
+            $processorTx = $stripe->normalizePaymentIntentForImport($pi);
+
+            $existsStmt = $pdo->prepare('SELECT id FROM payments WHERE stripe_payment_intent_id = ?');
+            $existsStmt->execute([$piId]);
+            $existingPaymentId = (int)($existsStmt->fetchColumn() ?: 0);
+            if ($existingPaymentId > 0) {
+                stripe_update_payment_processor_fields($pdo, $existingPaymentId, $processorTx, $appConfig);
+                $result['duplicates']++;
+                $result['reconciled']++;
+                continue;
+            }
+
+            $invStmt = $pdo->prepare('SELECT id, total, status, client_id FROM invoices WHERE id = ?');
+            $invStmt->execute([$invoiceId]);
+            $invoice = $invStmt->fetch(PDO::FETCH_ASSOC);
+            if (!$invoice) {
+                @error_log("[stripe_reconciliation] Invoice {$invoiceId} not found for PI {$piId}");
+                $result['skipped']++;
+                continue;
+            }
+
+            if (($invoice['status'] ?? '') === 'paid') {
+                $result['skipped']++;
+                continue;
+            }
+
+            $pdo->beginTransaction();
+            $processorFields = stripe_processor_fields_from_normalized($processorTx, $appConfig, $paymentAmount, $surchargeAmount);
+            $pdo->prepare('
+                INSERT INTO payments
+                    (client_id, invoice_id, amount, surcharge_paid, payment_method, stripe_payment_intent_id, auto_pay_attempt,
+                     processor_provider, processor_payment_id, processor_gross_amount, processor_fee_amount, processor_net_amount,
+                     processor_fee_policy, processor_fee_source, status, payment_date, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURDATE(), NOW())
+            ')->execute([
+                (int)$invoice['client_id'], $invoiceId, $paymentAmount, $surchargeAmount, 'stripe', $piId, 0,
+                $processorFields['processor_provider'], $processorFields['processor_payment_id'] ?: null,
+                $processorFields['processor_gross_amount'], $processorFields['processor_fee_amount'], $processorFields['processor_net_amount'],
+                $processorFields['processor_fee_policy'], $processorFields['processor_fee_source'], 'succeeded'
+            ]);
+            $paymentId = (int)$pdo->lastInsertId();
+            stripe_link_pending_financial_events($pdo, $paymentId, $piId);
+
+            $sumStmt = $pdo->prepare('SELECT COALESCE(SUM(GREATEST(amount-refunded_amount,0)), 0) FROM payments WHERE invoice_id = ? AND status = "succeeded"');
+            $sumStmt->execute([$invoiceId]);
+            $totalPaid = (float)$sumStmt->fetchColumn();
+
+            $invoiceTotal = (float)$invoice['total'];
+            $newStatus = ($totalPaid >= $invoiceTotal) ? 'paid' : 'partial';
+
+            try {
+                $pdo->prepare('UPDATE invoices SET status=?,amount_paid=?,balance_due=GREATEST(total-?,0),stripe_session_id=NULL,stripe_checkout_expires_at=NULL WHERE id=?')
+                    ->execute([$newStatus, $totalPaid, $totalPaid, $invoiceId]);
+            } catch (Throwable $e) {
+                $pdo->prepare('UPDATE invoices SET status = ? WHERE id = ?')->execute([$newStatus, $invoiceId]);
+            }
+
+            if ($newStatus === 'paid') {
+                try {
+                    $pdo->prepare('UPDATE public_links SET revoked = 1, redirect = ? WHERE document_type = "invoice" AND document_id = ? AND revoked = 0')
+                        ->execute(['/?page=public-redirect&type=invoice&reason=paid', $invoiceId]);
+                } catch (Throwable $e) {
+                }
+
+                $coStmt = $pdo->prepare('SELECT contract_id FROM invoices WHERE id = ?');
+                $coStmt->execute([$invoiceId]);
+                $contractId = (int)$coStmt->fetchColumn();
+                if ($contractId > 0) {
+                    $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')->execute(['completed', $contractId]);
+                }
+            }
+
+            $pdo->commit();
+            $result['imported']++;
+            $result['reconciled']++;
+
+            try {
+                require_once __DIR__ . '/payment_receipts.php';
+                payment_receipt_issue($pdo, $paymentId, $appConfig);
+            } catch (Throwable $receiptError) {
+                @error_log("[stripe_reconciliation] Receipt issue failed for payment {$paymentId}: " . $receiptError->getMessage());
+            }
+        } catch (Throwable $e) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            $result['errors']++;
+            @error_log('[stripe_reconciliation] Error processing PI ' . (string)($pi['id'] ?? 'unknown') . ': ' . $e->getMessage());
+        }
+    }
+
+    return $result;
+}
+
+function stripe_reconcile_summary(array $result): string {
+    return sprintf(
+        '%d checked; %d reconciled; %d imported; %d duplicates; %d skipped; %d errors',
+        (int)($result['checked'] ?? 0),
+        (int)($result['reconciled'] ?? 0),
+        (int)($result['imported'] ?? 0),
+        (int)($result['duplicates'] ?? 0),
+        (int)($result['skipped'] ?? 0),
+        (int)($result['errors'] ?? 0)
+    );
+}

--- a/src/views/pages/home.php
+++ b/src/views/pages/home.php
@@ -8,20 +8,51 @@ require_once __DIR__ . '/../../utils/payment_accounting.php';
 // Data queries
 // ------------------------------------------------------------------
 $dashboard_income_expr = payment_accounting_net_income_expr('p');
+$db_error = false;
+$pending_quotes = $active_contracts = $unpaid_invoices = $total_clients = $total_users = 0;
+$income_30 = $expenses_30 = $net_30 = 0.0;
+$overdue_invoices = $receipts_30 = 0;
+$income_monthly = [];
+$quote_status = $contract_status = $invoice_status = [];
+$clients_recent = $payments_recent = $login_recent = [];
+$failed_logins_24h = 0;
+$db_status = 'Connected';
+$php_version = PHP_VERSION;
+$sys_mem_total = $sys_mem_avail = $sys_mem_used = 0;
+$disk_free = $disk_total = false;
+$uptime = '';
+$dashboard_finance_period_start = date('Y') . '-01-01';
+$dashboard_finance_subtitle = date('Y') . ' finance summary';
+$dashboard_actionable_invoice_where = "
+    status IN ('partial','overdue')
+    OR (
+      status = 'unpaid'
+      AND (
+        due_date IS NULL
+        OR due_date <= CURDATE()
+        OR invoice_type != 'long_term'
+      )
+    )
+";
+
 try {
   $dashboard_user_id = (int)($_SESSION['user']['id'] ?? 0);
   $dashboard_org_id = request_client_org_id();
   [$dashboard_expense_scope_where, $dashboard_expense_scope_params] = finance_scope_clause($pdo, 'e', $dashboard_user_id, $dashboard_org_id, 'created_by');
 
+  // Financial snapshot first, so unrelated dashboard widget failures do not hide expenses.
+  $incomeStmt         = $pdo->prepare("SELECT COALESCE(SUM({$dashboard_income_expr}),0) FROM payments p WHERE p.payment_date >= ? AND p.status='succeeded'");
+  $incomeStmt->execute([$dashboard_finance_period_start]);
+  $income_30          = (float)$incomeStmt->fetchColumn();
+  $expensesStmt       = $pdo->prepare("SELECT COALESCE(SUM(COALESCE(e.total_amount, e.amount, 0)),0) FROM expenses e WHERE {$dashboard_expense_scope_where} AND e.status != 'void' AND e.expense_date >= ?");
+  $expensesStmt->execute(array_merge($dashboard_expense_scope_params, [$dashboard_finance_period_start]));
+  $expenses_30        = (float)$expensesStmt->fetchColumn();
+  $net_30             = $income_30 - $expenses_30;
+
   // Core stats
   $pending_quotes     = (int)$pdo->query("SELECT COUNT(*) FROM quotes WHERE status='pending'")->fetchColumn();
   $active_contracts   = (int)$pdo->query("SELECT COUNT(*) FROM contracts WHERE status IN ('draft','active')")->fetchColumn();
-  $unpaid_invoices    = (int)$pdo->query("SELECT COUNT(*) FROM invoices WHERE status IN ('unpaid','partial')")->fetchColumn();
-  $income_30          = (float)$pdo->query("SELECT COALESCE(SUM({$dashboard_income_expr}),0) FROM payments p WHERE p.payment_date >= CURDATE() - INTERVAL 29 DAY AND p.status='succeeded'")->fetchColumn();
-  $expensesStmt       = $pdo->prepare("SELECT COALESCE(SUM(COALESCE(e.total_amount, e.amount, 0)),0) FROM expenses e WHERE {$dashboard_expense_scope_where} AND e.status != 'void' AND e.expense_date >= CURDATE() - INTERVAL 29 DAY");
-  $expensesStmt->execute($dashboard_expense_scope_params);
-  $expenses_30        = (float)$expensesStmt->fetchColumn();
-  $net_30             = $income_30 - $expenses_30;
+  $unpaid_invoices    = (int)$pdo->query("SELECT COUNT(*) FROM invoices WHERE {$dashboard_actionable_invoice_where}")->fetchColumn();
   $overdue_invoices   = (int)$pdo->query("SELECT COUNT(*) FROM invoices WHERE status IN ('unpaid','partial','overdue') AND due_date IS NOT NULL AND due_date < CURDATE()")->fetchColumn();
   $receipts_30        = (int)$pdo->query("SELECT COUNT(*) FROM receipts WHERE created_at >= NOW() - INTERVAL 30 DAY")->fetchColumn();
   $total_clients      = (int)$pdo->query("SELECT COUNT(*) FROM clients WHERE archived=0 AND deleted_at IS NULL")->fetchColumn();
@@ -41,7 +72,17 @@ try {
   // Status breakdowns
   $quote_status = $pdo->query("SELECT status, COUNT(*) AS cnt FROM quotes GROUP BY status")->fetchAll(PDO::FETCH_KEY_PAIR);
   $contract_status = $pdo->query("SELECT status, COUNT(*) AS cnt FROM contracts GROUP BY status")->fetchAll(PDO::FETCH_KEY_PAIR);
-  $invoice_status = $pdo->query("SELECT status, COUNT(*) AS cnt FROM invoices GROUP BY status")->fetchAll(PDO::FETCH_KEY_PAIR);
+  $invoice_status = $pdo->query("
+    SELECT dashboard_status, COUNT(*) AS cnt
+    FROM (
+      SELECT CASE
+        WHEN {$dashboard_actionable_invoice_where} THEN 'actionable_unpaid'
+        ELSE status
+      END AS dashboard_status
+      FROM invoices
+    ) invoice_dashboard_statuses
+    GROUP BY dashboard_status
+  ")->fetchAll(PDO::FETCH_KEY_PAIR);
 
   // Recent lists
   $clients_recent = $pdo->query("SELECT id,name,created_at FROM clients WHERE deleted_at IS NULL ORDER BY created_at DESC LIMIT 6")->fetchAll();
@@ -88,18 +129,9 @@ try {
   }
 } catch (PDOException $e) {
   $db_error = true;
-  $pending_quotes = $active_contracts = $unpaid_invoices = $total_clients = $total_users = 0;
-  $income_30 = $expenses_30 = $net_30 = 0;
-  $overdue_invoices = $receipts_30 = 0;
-  $income_monthly = [];
-  $quote_status = $contract_status = $invoice_status = [];
-  $clients_recent = $payments_recent = $login_recent = [];
-  $failed_logins_24h = 0;
+  error_log('[Dashboard] Failed to load dashboard data: ' . $e->getMessage());
   $db_status = 'Disconnected';
   $php_version = PHP_VERSION;
-  $sys_mem_total = $sys_mem_avail = $sys_mem_used = 0;
-  $disk_free = $disk_total = false;
-  $uptime = '';
 }
 
 // Build chart-ready arrays
@@ -208,12 +240,12 @@ function svg_line_chart(array $labels, array $values, int $w = 720, int $h = 220
 $status_rows = [
   ['Pending Quotes',   (int)($quote_status['pending'] ?? 0),  '#f59e0b'],
   ['Active Contracts', (int)($contract_status['active'] ?? 0), '#10b981'],
-  ['Unpaid Invoices',  (int)($invoice_status['unpaid'] ?? 0) + (int)($invoice_status['partial'] ?? 0), '#ef4444'],
+  ['Unpaid Invoices',  (int)($invoice_status['actionable_unpaid'] ?? 0), '#ef4444'],
   ['Paid Invoices',    (int)($invoice_status['paid'] ?? 0),   '#22c55e'],
   ['Draft / Other',
     (int)($quote_status['draft'] ?? 0) + (int)($quote_status['approved'] ?? 0) + (int)($quote_status['denied'] ?? 0) + (int)($quote_status['rejected'] ?? 0) + (int)($quote_status['expired'] ?? 0) +
     (int)($contract_status['draft'] ?? 0) + (int)($contract_status['pending'] ?? 0) + (int)($contract_status['paused'] ?? 0) + (int)($contract_status['completed'] ?? 0) + (int)($contract_status['cancelled'] ?? 0) + (int)($contract_status['denied'] ?? 0) + (int)($contract_status['void'] ?? 0) +
-    (int)($invoice_status['draft'] ?? 0) + (int)($invoice_status['sent'] ?? 0) + (int)($invoice_status['overdue'] ?? 0) + (int)($invoice_status['cancelled'] ?? 0) + (int)($invoice_status['void'] ?? 0),
+    (int)($invoice_status['draft'] ?? 0) + (int)($invoice_status['sent'] ?? 0) + (int)($invoice_status['unpaid'] ?? 0) + (int)($invoice_status['partial'] ?? 0) + (int)($invoice_status['overdue'] ?? 0) + (int)($invoice_status['cancelled'] ?? 0) + (int)($invoice_status['void'] ?? 0),
     '#9ca3af'],
 ];
 $status_max = max(1, max(array_column($status_rows, 1)));
@@ -256,7 +288,7 @@ if ($disk_total !== false && $disk_total > 0) {
         </svg>
       </div>
       <div>
-        <div class="dash-card__label">Income (30d)</div>
+        <div class="dash-card__label">Income (YTD)</div>
         <div class="dash-card__value">$<?php echo number_format($income_30, 2); ?></div>
       </div>
     </article>
@@ -337,7 +369,7 @@ if ($disk_total !== false && $disk_total > 0) {
     <div class="dash-panel__head">
       <div>
         <h3 class="dash-panel__title">Financial Snapshot</h3>
-        <p class="dash-finance-snapshot__sub">30-day cash flow summary</p>
+        <p class="dash-finance-snapshot__sub"><?php echo htmlspecialchars($dashboard_finance_subtitle); ?></p>
       </div>
       <a class="dash-panel__link" href="/?page=financial/financial-dashboard">Open financial dashboard</a>
     </div>

--- a/src/views/pages/settings/backup.php
+++ b/src/views/pages/settings/backup.php
@@ -3,7 +3,9 @@
 // Database backup settings page
 
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../config/app.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
+require_once __DIR__ . '/../../../utils/cron_state.php';
 
 // Get existing database-only and full backups.
 $backupsDir = '/var/www/backups';
@@ -13,7 +15,7 @@ $backupEncryptionEnabled = trim((string)(getenv('BACKUP_ENCRYPTION_KEY') ?: ''))
 // Read retention from env (matches backup_database.php)
 $retentionDays = (int)(getenv('BACKUP_RETENTION_DAYS') ?: '10');
 
-// Read backup hour from app_config (default 2 = 2:00 AM UTC)
+// Read backup hour from app_config (default 2 = 2:30 AM in the configured PA timezone)
 $backupHour = 2;
 try {
     $cfgStmt = $pdo->prepare("SELECT config_value FROM app_config WHERE organization_id = 0 AND config_key = 'backup_hour'");
@@ -27,6 +29,11 @@ try {
     $modeStmt->execute();
     $backupMode = $modeStmt->fetchColumn() === 'full' ? 'full' : 'database';
 } catch (Throwable $e) {}
+$backupTimezone = (string)($appConfig['timezone'] ?? date_default_timezone_get() ?: 'UTC');
+if (!in_array($backupTimezone, DateTimeZone::listIdentifiers(), true)) {
+    $backupTimezone = 'UTC';
+}
+$backupTimeZoneObj = new DateTimeZone($backupTimezone);
 
 // Also check if retention is overridden in app_config
 try {
@@ -85,6 +92,7 @@ $backupCount = count($backups);
 $cronStatus = null;
 $cronStatusError = '';
 try {
+    cron_state_ensure_schema($pdo);
     $cronStmt = $pdo->prepare('SELECT job_name, last_run, status, started_at, completed_at, result, error_message, updated_at FROM cron_job_runs WHERE job_name = ? LIMIT 1');
     $cronStmt->execute(['backup_database']);
     $cronStatus = $cronStmt->fetch(PDO::FETCH_ASSOC) ?: null;
@@ -92,11 +100,12 @@ try {
     $cronStatusError = 'Cron status unavailable: ' . $e->getMessage();
 }
 
-$nowUtc = new DateTimeImmutable('now', new DateTimeZone('UTC'));
-$nextExpectedUtc = $nowUtc->setTime($backupHour, 30);
-if ($nextExpectedUtc <= $nowUtc) {
-    $nextExpectedUtc = $nextExpectedUtc->modify('+1 day');
+$nowLocal = new DateTimeImmutable('now', $backupTimeZoneObj);
+$nextExpectedLocal = $nowLocal->setTime($backupHour, 30);
+if ($nextExpectedLocal <= $nowLocal) {
+    $nextExpectedLocal = $nextExpectedLocal->modify('+1 day');
 }
+$nextExpectedUtc = $nextExpectedLocal->setTimezone(new DateTimeZone('UTC'));
 
 $backupDirChecks = [];
 foreach ([
@@ -136,7 +145,7 @@ if ($backupCount === 0) {
     } elseif (($cronStatus['status'] ?? '') === 'running') {
         $zeroBackupDiagnostics[] = 'The backup cron is currently marked running.';
     }
-    $zeroBackupDiagnostics[] = 'Next expected scheduled run: ' . $nextExpectedUtc->format('Y-m-d H:i') . ' UTC.';
+    $zeroBackupDiagnostics[] = 'Next expected scheduled run: ' . $nextExpectedLocal->format('Y-m-d H:i') . ' ' . $backupTimezone . ' (' . $nextExpectedUtc->format('Y-m-d H:i') . ' UTC).';
 }
 
 // Handle flash messages
@@ -169,11 +178,11 @@ unset($_SESSION['flash_backup']);
         </div>
         <div class="status-item">
             <span class="status-label">Schedule:</span>
-            <span class="status-value">Daily at <?php echo str_pad((string)$backupHour, 2, '0', STR_PAD_LEFT); ?>:30 UTC</span>
+            <span class="status-value">Daily at <?php echo str_pad((string)$backupHour, 2, '0', STR_PAD_LEFT); ?>:30 <?php echo htmlspecialchars($backupTimezone); ?></span>
         </div>
         <div class="status-item">
             <span class="status-label">Next Expected Run:</span>
-            <span class="status-value"><?php echo htmlspecialchars($nextExpectedUtc->format('Y-m-d H:i')); ?> UTC</span>
+            <span class="status-value"><?php echo htmlspecialchars($nextExpectedLocal->format('Y-m-d H:i')); ?> <?php echo htmlspecialchars($backupTimezone); ?></span>
         </div>
         <div class="status-item">
             <span class="status-label">Encryption:</span>
@@ -263,15 +272,15 @@ unset($_SESSION['flash_backup']);
             </div>
 
             <div class="form-group" style="margin:0;">
-                <label for="backup_hour" style="font-size:0.85rem; color:#6c757d; margin-bottom:0.35rem; display:block;">Backup Time (UTC)</label>
+                <label for="backup_hour" style="font-size:0.85rem; color:#6c757d; margin-bottom:0.35rem; display:block;">Backup Time (<?php echo htmlspecialchars($backupTimezone); ?>)</label>
                 <select name="backup_hour" id="backup_hour" class="input" style="width:100%; padding:0.5rem; border:1px solid #ddd; border-radius:6px; font-size:0.95rem;">
                     <?php for ($h = 0; $h < 24; $h++): ?>
                     <option value="<?php echo $h; ?>" <?php echo ($h == $backupHour) ? 'selected' : ''; ?>>
-                        <?php echo str_pad($h, 2, '0', STR_PAD_LEFT); ?>:00 UTC
+                        <?php echo str_pad($h, 2, '0', STR_PAD_LEFT); ?>:30 <?php echo htmlspecialchars($backupTimezone); ?>
                     </option>
                     <?php endfor; ?>
                 </select>
-                <span class="help-text" style="display:block; margin-top:0.35rem; font-size:0.8rem;">The cron service checks this setting hourly at :30.</span>
+                <span class="help-text" style="display:block; margin-top:0.35rem; font-size:0.8rem;">The cron service checks this setting hourly at :30 using the PA system timezone.</span>
             </div>
         </div>
 

--- a/src/views/pages/settings/billing.php
+++ b/src/views/pages/settings/billing.php
@@ -7,6 +7,8 @@ require_once __DIR__ . '/../../../services/StripeService.php';
 $stripeSecretConfigured = StripeService::hasSecretKey($appConfig ?? []);
 $stripeWebhookConfigured = !empty($appConfig['_stripe_webhook_secret']) || !empty($appConfig['stripe_webhook_secret_enc']);
 $stripePanelConfigured = $stripeSecretConfigured || $stripeWebhookConfigured || !empty($appConfig['stripe_publishable_key']);
+$stripeImportEndDefault = date('Y-m-d');
+$stripeImportStartDefault = date('Y-m-d', strtotime('-30 days'));
 ?>
 
 <fieldset style="border:1px solid #eee;border-radius:8px;padding:12px">
@@ -48,12 +50,27 @@ $stripePanelConfigured = $stripeSecretConfigured || $stripeWebhookConfigured || 
 </fieldset>
 
 <fieldset style="border:1px solid #eee;border-radius:8px;padding:12px;margin-top:16px">
+  <legend style="padding:0 6px;color:var(--muted)">Review Request</legend>
+  <label>
+    <div style="margin-bottom:4px">Review Link <span style="color:#666;font-weight:normal">(Optional)</span></div>
+    <input type="url" name="review_link" value="<?php echo htmlspecialchars($appConfig['review_link'] ?? ''); ?>" placeholder="https://g.page/your-business/review" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+    <div style="font-size:0.85em;color:#666;margin-top:4px">If set, this link will appear on invoices to encourage clients to leave a review.</div>
+  </label>
+</fieldset>
+
+<fieldset style="border:1px solid #eee;border-radius:8px;padding:12px;margin-top:16px">
   <legend style="padding:0 6px;color:var(--muted)">Processor Imports</legend>
   <?php if (!empty($_GET['stripe_net_backfill'])): ?>
     <div style="margin-bottom:12px;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0"><?php echo htmlspecialchars((string)$_GET['stripe_net_backfill']); ?></div>
   <?php endif; ?>
   <?php if (!empty($_GET['stripe_net_error'])): ?>
     <div style="margin-bottom:12px;padding:10px 12px;border-radius:8px;background:#fff1f2;color:#881337;border:1px solid #fca5a5"><?php echo htmlspecialchars((string)$_GET['stripe_net_error']); ?></div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['stripe_import_result'])): ?>
+    <div style="margin-bottom:12px;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0"><?php echo htmlspecialchars((string)$_GET['stripe_import_result']); ?></div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['stripe_import_error'])): ?>
+    <div style="margin-bottom:12px;padding:10px 12px;border-radius:8px;background:#fff1f2;color:#881337;border:1px solid #fca5a5"><?php echo htmlspecialchars((string)$_GET['stripe_import_error']); ?></div>
   <?php endif; ?>
   <label style="display:flex;align-items:flex-start;gap:8px;margin-bottom:12px">
     <input type="checkbox" name="processor_import_standalone_income" value="1" <?php echo !empty($appConfig['processor_import_standalone_income']) ? 'checked' : ''; ?> style="margin-top:3px">
@@ -71,6 +88,24 @@ $stripePanelConfigured = $stripeSecretConfigured || $stripeWebhookConfigured || 
   </label>
   <div style="margin-top:14px;padding-top:12px;border-top:1px solid #eee;display:grid;gap:8px">
     <div>
+      <strong>Import old Stripe payments</strong>
+      <div style="font-size:13px;color:var(--muted);margin-top:2px">Pull successful Stripe payments for a selected date range, including standalone income not linked to PA invoices. Defaults to the last 30 days through today.</div>
+    </div>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+      <label style="display:grid;gap:4px;font-size:13px;color:var(--muted)">Start
+        <input type="date" name="stripe_import_start_date" value="<?php echo htmlspecialchars($stripeImportStartDefault); ?>" max="<?php echo htmlspecialchars($stripeImportEndDefault); ?>" style="padding:7px;border-radius:8px;border:1px solid #ddd">
+      </label>
+      <label style="display:grid;gap:4px;font-size:13px;color:var(--muted)">End
+        <input type="date" name="stripe_import_end_date" value="<?php echo htmlspecialchars($stripeImportEndDefault); ?>" max="<?php echo htmlspecialchars($stripeImportEndDefault); ?>" style="padding:7px;border-radius:8px;border:1px solid #ddd">
+      </label>
+      <label style="display:grid;gap:4px;font-size:13px;color:var(--muted)">Limit
+        <input type="number" name="stripe_import_max_intents" value="2000" min="100" max="10000" step="100" style="width:100px;padding:7px;border-radius:8px;border:1px solid #ddd">
+      </label>
+      <button type="submit" formaction="/?page=settings/stripe-import-payments" formmethod="post" style="padding:8px 10px;border-radius:8px;border:1px solid #ddd;background:#fff;font-weight:600">Import Stripe Payments</button>
+    </div>
+  </div>
+  <div style="margin-top:14px;padding-top:12px;border-top:1px solid #eee;display:grid;gap:8px">
+    <div>
       <strong>Stripe net income backfill</strong>
       <div style="font-size:13px;color:var(--muted);margin-top:2px">Fetch actual Stripe balance transaction fees for older Stripe-paid invoices without changing invoice paid status.</div>
     </div>
@@ -83,19 +118,10 @@ $stripePanelConfigured = $stripeSecretConfigured || $stripeWebhookConfigured || 
   </div>
 </fieldset>
 
-<fieldset style="border:1px solid #eee;border-radius:8px;padding:12px;margin-top:16px">
-  <legend style="padding:0 6px;color:var(--muted)">Review Request</legend>
-  <label>
-    <div style="margin-bottom:4px">Review Link <span style="color:#666;font-weight:normal">(Optional)</span></div>
-    <input type="url" name="review_link" value="<?php echo htmlspecialchars($appConfig['review_link'] ?? ''); ?>" placeholder="https://g.page/your-business/review" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
-    <div style="font-size:0.85em;color:#666;margin-top:4px">If set, this link will appear on invoices to encourage clients to leave a review.</div>
-  </label>
-</fieldset>
-
-<div style="margin-top:20px;padding:16px;background:#f0f9ff;border:1px solid #bae6fd;border-radius:8px;font-size:14px">
+<!-- <div style="margin-top:20px;padding:16px;background:#f0f9ff;border:1px solid #bae6fd;border-radius:8px;font-size:14px">
   <strong>💡 Looking for Tax Rates?</strong>
   <div style="margin-top:8px;color:#1e40af">Tax rate management has been moved to the <a href="/?page=settings&tab=taxes" style="color:var(--nav-accent);font-weight:600">Taxes</a> tab for better organization.</div>
-</div>
+</div> -->
 
 <fieldset id="stripeConfig" data-configured="<?php echo $stripePanelConfigured ? '1' : '0'; ?>" style="border:1px solid #eee;border-radius:8px;padding:12px;margin-top:16px;display:none">
   <legend style="padding:0 6px;color:var(--muted)">Stripe Configuration</legend>

--- a/tests/Payments/ProcessorImportTest.php
+++ b/tests/Payments/ProcessorImportTest.php
@@ -62,11 +62,15 @@ final class ProcessorImportTest extends TestCase
     public function testStripeReconciliationUsesGenericStandaloneImportFallback(): void
     {
         $cron = $this->read('src/cron/stripe_reconciliation.php');
+        $importHelper = $this->read('src/utils/stripe_reconciliation_import.php');
         $stripe = $this->read('src/services/StripeService.php');
         $webhook = $this->read('src/controllers/webhook/stripe_payment_succeeded.php');
 
-        self::assertStringContainsString('PaymentProcessorImportService::importStandalone', $cron);
+        self::assertStringContainsString('stripe_reconcile_payment_intents', $cron);
+        self::assertStringContainsString('PaymentProcessorImportService::importStandalone', $importHelper);
+        self::assertStringContainsString('forceStandaloneImport', $importHelper);
         self::assertStringContainsString('normalizePaymentIntentForImport', $stripe);
+        self::assertStringContainsString('listPaymentIntentsBetween', $stripe);
         self::assertStringContainsString('charges.data.balance_transaction', $stripe);
         self::assertStringContainsString('getPaymentIntentWithBalanceTransaction', $stripe);
         self::assertStringContainsString('PaymentProcessorImportService::importStandalone', $webhook);
@@ -81,6 +85,7 @@ final class ProcessorImportTest extends TestCase
         $checkout = $this->read('src/controllers/stripe/stripe_checkout.php');
         $settings = $this->read('src/views/pages/settings/billing.php');
         $controller = $this->read('src/controllers/settings/stripe_net_backfill.php');
+        $importController = $this->read('src/controllers/settings/stripe_import_payments.php');
         $front = $this->read('public/index.php');
         $acl = $this->read('src/utils/acl_middleware.php');
 
@@ -92,9 +97,14 @@ final class ProcessorImportTest extends TestCase
         self::assertStringContainsString('stripe_update_project_payment_processor_fields', $helper);
         self::assertStringContainsString('pa_fee_policy', $checkout);
         self::assertStringContainsString('Backfill Stripe Net Income', $settings);
+        self::assertStringContainsString('Import old Stripe payments', $settings);
         self::assertStringContainsString('stripe_backfill_net_income', $controller);
+        self::assertStringContainsString('stripe_reconcile_payment_intents', $importController);
+        self::assertStringContainsString('stripe_import_start_date', $importController);
         self::assertStringContainsString('settings/stripe-net-backfill', $front);
+        self::assertStringContainsString('settings/stripe-import-payments', $front);
         self::assertStringContainsString("'settings/stripe-net-backfill'", $acl);
+        self::assertStringContainsString("'settings/stripe-import-payments'", $acl);
     }
 
     public function testDashboardsAndPaymentsListUseNetIncomeAccounting(): void

--- a/tests/Workflows/FinancialAssetsTest.php
+++ b/tests/Workflows/FinancialAssetsTest.php
@@ -129,6 +129,25 @@ final class FinancialAssetsTest extends TestCase
         self::assertStringContainsString('COALESCE(e.total_amount, e.amount, 0)', $dashboard);
         self::assertStringContainsString('display_total', $dashboard);
         self::assertStringContainsString('COALESCE(e.total_amount, e.amount, 0)', $expensesTab);
+        self::assertStringContainsString("\$dashboard_finance_period_start = date('Y') . '-01-01'", $home);
+        self::assertStringContainsString('dashboard_finance_subtitle', $home);
+        self::assertStringContainsString('dashboard_actionable_invoice_where', $home);
+        self::assertStringContainsString("invoice_type != 'long_term'", $home);
+        self::assertStringContainsString('actionable_unpaid', $home);
+    }
+
+    public function testDashboardExpenseApisUseScopedActiveTotals(): void
+    {
+        $financialApi = $this->read('src/controllers/api/financial_summary.php');
+        $dashboardApi = $this->read('src/controllers/api/dashboard_summary.php');
+
+        foreach ([$financialApi, $dashboardApi] as $source) {
+            self::assertStringContainsString('finance_scope_clause', $source);
+            self::assertStringContainsString("e.status != 'void'", $source);
+            self::assertStringContainsString('COALESCE(e.total_amount, e.amount, 0)', $source);
+        }
+
+        self::assertStringContainsString("'expense_total'", $dashboardApi);
     }
 
     public function testFinancialHubUsesConsistentFinanceScope(): void

--- a/tests/Workflows/FinancialSchedulingTest.php
+++ b/tests/Workflows/FinancialSchedulingTest.php
@@ -37,6 +37,24 @@ final class FinancialSchedulingTest extends TestCase
         self::assertStringContainsString('Expense Report', (string)$cron);
     }
 
+    public function testCronStatusSchemaSelfRepairsAndUsesConfiguredTimezone(): void
+    {
+        $migration = file_get_contents($this->root . '/database/migrations/0018_repair_cron_job_runs_schema.sql');
+        $state = file_get_contents($this->root . '/src/utils/cron_state.php');
+        $backup = file_get_contents($this->root . '/src/cron/backup_database.php');
+        $backupPage = file_get_contents($this->root . '/src/views/pages/settings/backup.php');
+        $entrypoint = file_get_contents($this->root . '/cron/entrypoint.sh');
+
+        self::assertStringContainsString('ADD COLUMN updated_at', (string)$migration);
+        self::assertStringContainsString('cron_state_ensure_schema', (string)$state);
+        self::assertStringContainsString('cron_state_ensure_schema($pdo)', (string)$backupPage);
+        self::assertStringContainsString("require_once __DIR__ . '/../config/app.php';", (string)$backup);
+        self::assertStringContainsString('cron_state_mark_success($pdo, $jobName, \'Cron disabled\')', (string)$backup);
+        self::assertStringContainsString("config_key='timezone'", (string)$entrypoint);
+        self::assertStringContainsString('/etc/localtime', (string)$entrypoint);
+        self::assertStringContainsString('stripe_reconciliation.php --startup', (string)$entrypoint);
+    }
+
     public function testAuditAndOrganizationScriptsInitializeAfterAjaxNavigation(): void
     {
         $audit = file_get_contents($this->root . '/public/assets/js/audit-logic.js');


### PR DESCRIPTION
## Summary
- Repair cron status schema handling and align cron scheduling/timezone behavior with PA settings
- Update dashboard expense and pipeline financial snapshots
- Add Stripe historical payment import from Billing settings and reuse shared Stripe reconciliation logic for cron/startup/manual runs
- Run Stripe reconciliation once on cron container startup to catch payments after downtime

## Validation
- php -l on changed PHP controllers/helpers/views/tests
- php src\\migrations\\run_migrations.php --validate-files
- git diff --check

## Notes
- Local PHPUnit remains blocked by the existing vendor issue: Class PHPUnit\\TextUI\\Application not found.
- Startup/scheduled reconciliation honors the standalone processor import setting; the manual historical import button intentionally forces standalone import for the selected range.