### PR TITLE
Polish API keys and client workflows

### DIFF
--- a/database/baseline.sql
+++ b/database/baseline.sql
@@ -360,6 +360,7 @@ CREATE TABLE IF NOT EXISTS client_onboarding_invitations (
     client_id INT NULL,
     invited_email VARCHAR(255) NULL,
     token_hash CHAR(64) NOT NULL,
+    token_enc TEXT NULL,
     status ENUM('pending','verified','submitted','approved','rejected','revoked','expired') NOT NULL DEFAULT 'pending',
     expires_at DATETIME NOT NULL,
     verification_code_hash VARCHAR(255) NULL,

--- a/database/migrations/0020_client_onboarding_recoverable_links.sql
+++ b/database/migrations/0020_client_onboarding_recoverable_links.sql
@@ -1,0 +1,22 @@
+SET @client_onboarding_token_enc_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'client_onboarding_invitations'
+      AND column_name = 'token_enc'
+);
+
+SET @client_onboarding_token_enc_sql := IF(
+    @client_onboarding_token_enc_exists = 0,
+    'ALTER TABLE client_onboarding_invitations ADD COLUMN token_enc TEXT NULL AFTER token_hash',
+    'SELECT 1'
+);
+
+PREPARE client_onboarding_token_enc_stmt FROM @client_onboarding_token_enc_sql;
+EXECUTE client_onboarding_token_enc_stmt;
+DEALLOCATE PREPARE client_onboarding_token_enc_stmt;
+
+UPDATE client_onboarding_invitations
+SET status = 'revoked', consumed_at = COALESCE(consumed_at, NOW())
+WHERE status IN ('pending','verified')
+  AND created_at < DATE_SUB(NOW(), INTERVAL 14 DAY);

--- a/public/assets/js/contracts-edit-logic.js
+++ b/public/assets/js/contracts-edit-logic.js
@@ -5,6 +5,124 @@ itemData.forEach(item => {
     addItemCo(item.item, item.description, Number(item.quantity), Number(item.unit_price), item.billing_unit || 'each');
 });
 
+function escapeHtmlCo(text) {
+    var div = document.createElement('div');
+    div.textContent = text == null ? '' : String(text);
+    return div.innerHTML;
+}
+
+function initContractEditClientSearch() {
+    var form = document.getElementById('coEditForm');
+    var input = document.getElementById('contractEditClientSearch');
+    var hidden = document.getElementById('contractEditClientId');
+    var suggestions = document.getElementById('contractEditClientSuggest');
+    var projectSelect = document.getElementById('contractEditProjectSelect');
+    if (!form || !input || !hidden || !suggestions) return;
+    if (input.dataset.contractEditClientReady === '1') return;
+    input.dataset.contractEditClientReady = '1';
+    var originalClientId = hidden.value || '';
+    var originalProjectId = projectSelect ? (projectSelect.getAttribute('data-selected-project-id') || '') : '';
+
+    function hideSuggestions() {
+        suggestions.style.display = 'none';
+        suggestions.innerHTML = '';
+    }
+
+    function setValidity() {
+        if (hidden.value) {
+            input.setCustomValidity('');
+            return;
+        }
+        input.setCustomValidity('Choose a client from the search results.');
+    }
+
+    function renderProjects(projects, selectedProjectId) {
+        if (!projectSelect) return;
+        var selected = selectedProjectId || '';
+        projectSelect.innerHTML = '<option value="">No project</option>';
+        if (!Array.isArray(projects)) return;
+        projects.forEach(function (project) {
+            var option = document.createElement('option');
+            option.value = project.id;
+            option.textContent = project.name + ' - ' + String(project.status || '').replace('_', ' ');
+            if (String(project.id) === String(selected)) option.selected = true;
+            projectSelect.appendChild(option);
+        });
+    }
+
+    function loadProjects(clientId, selectedProjectId) {
+        if (!projectSelect) return;
+        if (!clientId) {
+            renderProjects([], '');
+            return;
+        }
+        fetch('/?page=projects-search&client_id=' + encodeURIComponent(clientId))
+            .then(function (response) { return response.json(); })
+            .then(function (projects) { renderProjects(projects, selectedProjectId || ''); })
+            .catch(function () { renderProjects([], ''); });
+    }
+
+    function renderSuggestions(list) {
+        if (!Array.isArray(list) || list.length === 0) {
+            hideSuggestions();
+            return;
+        }
+        suggestions.innerHTML = list.map(function (client) {
+            var meta = [];
+            if (client.email) meta.push(client.email);
+            if (client.org_name) meta.push(client.org_name);
+            return '<button type="button" data-client-id="' + escapeHtmlCo(client.id) + '" data-client-name="' + escapeHtmlCo(client.name) + '" style="display:block;width:100%;text-align:left;padding:9px 10px;border:0;border-bottom:1px solid #eef2f7;background:#fff;cursor:pointer">' +
+                '<strong>' + escapeHtmlCo(client.name) + '</strong>' +
+                (meta.length ? '<span style="display:block;margin-top:2px;color:#6b7280;font-size:12px">' + escapeHtmlCo(meta.join(' - ')) + '</span>' : '') +
+                '</button>';
+        }).join('');
+        suggestions.style.display = 'block';
+    }
+
+    var searchTimer = null;
+    input.addEventListener('input', function () {
+        hidden.value = '';
+        setValidity();
+        var term = input.value.trim();
+        clearTimeout(searchTimer);
+        if (!term) {
+            hideSuggestions();
+            loadProjects('', '');
+            return;
+        }
+        searchTimer = setTimeout(function () {
+            fetch('/?page=clients-search&term=' + encodeURIComponent(term))
+                .then(function (response) { return response.json(); })
+                .then(renderSuggestions)
+                .catch(hideSuggestions);
+        }, 160);
+    });
+
+    suggestions.addEventListener('click', function (event) {
+        var option = event.target.closest('[data-client-id]');
+        if (!option) return;
+        hidden.value = option.getAttribute('data-client-id') || '';
+        input.value = option.getAttribute('data-client-name') || '';
+        input.setCustomValidity('');
+        hideSuggestions();
+        loadProjects(hidden.value, String(hidden.value) === String(originalClientId) ? originalProjectId : '');
+    });
+
+    document.addEventListener('click', function (event) {
+        if (!suggestions.contains(event.target) && event.target !== input) {
+            hideSuggestions();
+        }
+    });
+
+    form.addEventListener('submit', function (event) {
+        setValidity();
+        if (!input.checkValidity()) {
+            event.preventDefault();
+            input.reportValidity();
+        }
+    });
+}
+
 function getItemData() {
     const element = document.getElementById("contract-items-data");
     if (!element) {
@@ -128,3 +246,5 @@ if (addItemBtn) addItemBtn.addEventListener('click', function(e) {addItemCo();})
 });
 
 ['discountTypeCo', 'discountValueCo', 'taxPercentCo'].forEach(id => document.getElementById(id).addEventListener('input', recalcCo));
+
+initContractEditClientSearch();

--- a/public/assets/js/payments-create-logic.js
+++ b/public/assets/js/payments-create-logic.js
@@ -1,14 +1,23 @@
 var sel = document.getElementById('invoiceSelect');
 var amt = document.getElementById('amountInput');
+var recordPaymentForm = document.getElementById('recordPaymentForm');
 var invoiceFields = document.getElementById('invoicePaymentFields');
 var manualFields = document.getElementById('manualPaymentFields');
-var manualClientSelect = document.getElementById('manualClientSelect');
+var manualClientId = document.getElementById('manualClientId');
+var manualClientSearch = document.getElementById('manualClientSearch');
+var manualClientSuggest = document.getElementById('manualClientSuggest');
 var scopeInputs = Array.from(document.querySelectorAll('input[name="payment_scope"]'));
 var sendReceiptInput = document.getElementById('sendReceiptInput');
 
 function selectedScope() {
     var checked = scopeInputs.find(function (input) { return input.checked; });
     return checked ? checked.value : 'invoice';
+}
+
+function escapeHtml(text) {
+    var div = document.createElement('div');
+    div.textContent = text == null ? '' : String(text);
+    return div.innerHTML;
 }
 
 function update() {
@@ -60,7 +69,12 @@ function togglePaymentScope() {
     if (invoiceFields) invoiceFields.style.display = isManual ? 'none' : 'grid';
     if (manualFields) manualFields.style.display = isManual ? 'grid' : 'none';
     if (sel) sel.required = !isManual;
-    if (manualClientSelect) manualClientSelect.required = isManual;
+    if (manualClientSearch) {
+        manualClientSearch.required = isManual;
+        if (!isManual) {
+            manualClientSearch.setCustomValidity('');
+        }
+    }
     if (sendReceiptInput) sendReceiptInput.checked = !isManual;
 
     if (methodSelect) {
@@ -85,4 +99,89 @@ if (methodSelect) {
 scopeInputs.forEach(function (input) {
     input.addEventListener('change', togglePaymentScope);
 });
+
+function hideManualClientSuggestions() {
+    if (!manualClientSuggest) return;
+    manualClientSuggest.style.display = 'none';
+    manualClientSuggest.innerHTML = '';
+}
+
+function setManualClientValidity() {
+    if (!manualClientSearch) return;
+    if (selectedScope() !== 'manual' || manualClientId.value) {
+        manualClientSearch.setCustomValidity('');
+        return;
+    }
+    manualClientSearch.setCustomValidity('Choose a client from the search results.');
+}
+
+function renderManualClientSuggestions(list) {
+    if (!manualClientSuggest) return;
+    if (!Array.isArray(list) || list.length === 0) {
+        hideManualClientSuggestions();
+        return;
+    }
+
+    manualClientSuggest.innerHTML = list.map(function (client) {
+        var meta = [];
+        if (client.email) meta.push(client.email);
+        if (client.org_name) meta.push(client.org_name);
+        return '<button type="button" data-client-id="' + escapeHtml(client.id) + '" data-client-name="' + escapeHtml(client.name) + '" style="display:block;width:100%;text-align:left;padding:9px 10px;border:0;border-bottom:1px solid #eef2f7;background:#fff;cursor:pointer">' +
+            '<strong>' + escapeHtml(client.name) + '</strong>' +
+            (meta.length ? '<span style="display:block;margin-top:2px;color:#6b7280;font-size:12px">' + escapeHtml(meta.join(' - ')) + '</span>' : '') +
+            '</button>';
+    }).join('');
+    manualClientSuggest.style.display = 'block';
+}
+
+if (manualClientSearch && manualClientId && manualClientSuggest) {
+    var manualClientSearchTimer = null;
+
+    manualClientSearch.addEventListener('input', function () {
+        manualClientId.value = '';
+        setManualClientValidity();
+        var term = manualClientSearch.value.trim();
+        clearTimeout(manualClientSearchTimer);
+        if (!term) {
+            hideManualClientSuggestions();
+            return;
+        }
+        manualClientSearchTimer = setTimeout(function () {
+            fetch('/?page=clients-search&term=' + encodeURIComponent(term))
+                .then(function (response) { return response.json(); })
+                .then(renderManualClientSuggestions)
+                .catch(hideManualClientSuggestions);
+        }, 160);
+    });
+
+    manualClientSearch.addEventListener('blur', function () {
+        window.setTimeout(setManualClientValidity, 120);
+    });
+
+    manualClientSuggest.addEventListener('click', function (event) {
+        var option = event.target.closest('[data-client-id]');
+        if (!option) return;
+        manualClientId.value = option.getAttribute('data-client-id') || '';
+        manualClientSearch.value = option.getAttribute('data-client-name') || '';
+        manualClientSearch.setCustomValidity('');
+        hideManualClientSuggestions();
+    });
+
+    document.addEventListener('click', function (event) {
+        if (!manualClientSuggest.contains(event.target) && event.target !== manualClientSearch) {
+            hideManualClientSuggestions();
+        }
+    });
+}
+
+if (recordPaymentForm) {
+    recordPaymentForm.addEventListener('submit', function (event) {
+        setManualClientValidity();
+        if (selectedScope() === 'manual' && manualClientSearch && !manualClientSearch.checkValidity()) {
+            event.preventDefault();
+            manualClientSearch.reportValidity();
+        }
+    });
+}
+
 togglePaymentScope();

--- a/public/assets/navigation.js
+++ b/public/assets/navigation.js
@@ -361,6 +361,8 @@ function updatePageTitle(page) {
         'project/projects-create': 'Create Project',
         'project/projects-edit': 'Edit Project',
         'api-keys': 'API Keys',
+        'api-keys-new': 'New API Key',
+        'api-keys-edit': 'Edit API Key',
         'settings': 'Settings',
         'financial/financial-dashboard': 'Financial Dashboard',
         'financial/expenses-list': 'Assets & Expenses',

--- a/src/controllers/api_keys_create.php
+++ b/src/controllers/api_keys_create.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../utils/api_keys_schema.php';
 require_once __DIR__ . '/../utils/api_scopes.php';
 
 if (empty($_SESSION['user']) || (($_SESSION['user']['role'] ?? 'user') !== 'admin')) {
-  header('Location: /?page=api-keys&error=' . urlencode('Only admins can create API keys'));
+  header('Location: /?page=api-keys-new&error=' . urlencode('Only admins can create API keys'));
   exit;
 }
 
@@ -14,11 +14,11 @@ $name = trim((string)($_POST['name'] ?? ''));
 $allowed_ips = trim((string)($_POST['allowed_ips'] ?? '')) ?: null;
 $scopes = api_normalize_scopes($_POST['scopes'] ?? []);
 if ($name === '') {
-  header('Location: /?page=api-keys&error=' . urlencode('Name is required'));
+  header('Location: /?page=api-keys-new&error=' . urlencode('Name is required'));
   exit;
 }
 if (!$scopes) {
-  header('Location: /?page=api-keys&error=' . urlencode('Select at least one API scope'));
+  header('Location: /?page=api-keys-new&error=' . urlencode('Select at least one API scope'));
   exit;
 }
 
@@ -33,6 +33,6 @@ try {
   header('Location: /?page=api-keys&created=1');
   exit;
 } catch (Throwable $e) {
-  header('Location: /?page=api-keys&error=' . urlencode('Failed to create key'));
+  header('Location: /?page=api-keys-new&error=' . urlencode('Failed to create key'));
   exit;
 }

--- a/src/controllers/api_keys_update.php
+++ b/src/controllers/api_keys_update.php
@@ -14,17 +14,19 @@ $id = (int)($_POST['id'] ?? 0);
 $name = trim((string)($_POST['name'] ?? ''));
 $allowedIps = trim((string)($_POST['allowed_ips'] ?? '')) ?: null;
 $scopes = api_normalize_scopes($_POST['scopes'] ?? []);
+$returnToEdit = (string)($_POST['return_to'] ?? '') === 'edit';
+$redirectBase = $returnToEdit && $id > 0 ? '/?page=api-keys-edit&id=' . $id : '/?page=api-keys';
 
 if ($id <= 0) {
   header('Location: /?page=api-keys&error=' . urlencode('Invalid key'));
   exit;
 }
 if ($name === '') {
-  header('Location: /?page=api-keys&error=' . urlencode('Name is required'));
+  header('Location: ' . $redirectBase . '&error=' . urlencode('Name is required'));
   exit;
 }
 if (!$scopes) {
-  header('Location: /?page=api-keys&error=' . urlencode('Select at least one API scope'));
+  header('Location: ' . $redirectBase . '&error=' . urlencode('Select at least one API scope'));
   exit;
 }
 
@@ -36,14 +38,14 @@ try {
     $exists = $pdo->prepare('SELECT 1 FROM api_keys WHERE id = ? AND revoked_at IS NULL');
     $exists->execute([$id]);
     if (!$exists->fetchColumn()) {
-      header('Location: /?page=api-keys&error=' . urlencode('API key was not updated'));
+      header('Location: ' . $redirectBase . '&error=' . urlencode('API key was not updated'));
       exit;
     }
   }
-  header('Location: /?page=api-keys&updated=1');
+  header('Location: ' . $redirectBase . '&updated=1');
   exit;
 } catch (Throwable $e) {
   @error_log('[api_keys_update] Failed to update API key: ' . $e->getMessage());
-  header('Location: /?page=api-keys&error=' . urlencode('Failed to update key'));
+  header('Location: ' . $redirectBase . '&error=' . urlencode('Failed to update key'));
   exit;
 }

--- a/src/controllers/client/client_onboarding_invite.php
+++ b/src/controllers/client/client_onboarding_invite.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/audit.php';
 require_once __DIR__ . '/../../utils/client_onboarding.php';
 
+client_onboarding_revoke_stale($pdo);
+
 $organizationId = request_client_org_id();
 $userId = (int)($_SESSION['user']['id'] ?? 0);
 if ($userId <= 0) {
@@ -41,7 +43,7 @@ $email = strtolower(trim((string)($_POST['email'] ?? '')));
 $clientId = max(0, (int)($_POST['client_id'] ?? 0));
 $targetOrganizationId = max(0, (int)($_POST['target_organization_id'] ?? 0));
 $delivery = ($_POST['delivery'] ?? 'link') === 'email' ? 'email' : 'link';
-$expiresHours = max(1, min(168, (int)($_POST['expires_hours'] ?? 48)));
+$expiresHours = max(1, min(336, (int)($_POST['expires_hours'] ?? 336)));
 
 if ($delivery === 'email' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
     header('Location: /?page=client/onboarding&error=' . urlencode('Enter a valid email address.'));
@@ -85,8 +87,8 @@ if ($email !== '') {
 }
 $stmt = $pdo->prepare(
     'INSERT INTO client_onboarding_invitations
-     (organization_id,target_organization_id,client_id,invited_email,token_hash,expires_at,created_by)
-     VALUES (?,?,?,?,?,?,?)'
+     (organization_id,target_organization_id,client_id,invited_email,token_hash,token_enc,expires_at,created_by)
+     VALUES (?,?,?,?,?,?,?,?)'
 );
 $stmt->execute([
     $ownerOrganizationId,
@@ -94,6 +96,7 @@ $stmt->execute([
     $clientId ?: null,
     $email !== '' ? $email : null,
     hash('sha256', $token),
+    client_onboarding_store_token($token),
     $expiresAt,
     $userId,
 ]);

--- a/src/controllers/client/client_onboarding_review.php
+++ b/src/controllers/client/client_onboarding_review.php
@@ -22,9 +22,10 @@ try {
         : 'i.organization_id IS NULL AND i.created_by=?';
     $ownerParams = $organizationId > 0 ? [$organizationId, $userId] : [$userId];
     $stmt = $pdo->prepare(
-        'SELECT s.*,i.organization_id,i.target_organization_id,i.client_id,i.invited_email
+        'SELECT s.*,i.organization_id,i.target_organization_id,i.client_id,i.invited_email,c.email AS current_client_email
          FROM client_onboarding_submissions s
          JOIN client_onboarding_invitations i ON i.id=s.invitation_id
+         LEFT JOIN clients c ON c.id=i.client_id
          WHERE s.id=? AND ' . $ownerWhere . ' FOR UPDATE'
     );
     $stmt->execute(array_merge([$submissionId], $ownerParams));
@@ -40,9 +41,12 @@ try {
 
     $clientId = (int)($submission['client_id'] ?? 0);
     if ($decision === 'approve') {
+        $emailValue = !empty($submission['invited_email'])
+            ? (string)$submission['invited_email']
+            : ($clientId > 0 ? ((string)($submission['current_client_email'] ?? '') ?: null) : null);
         $values = [
             $data['name'],
-            $submission['invited_email'],
+            $emailValue,
             $data['phone'] ?: null,
             $data['address_line1'] ?: null,
             $data['address_line2'] ?: null,

--- a/src/controllers/client/clients_search.php
+++ b/src/controllers/client/clients_search.php
@@ -9,8 +9,8 @@ $hasArchived = (bool)$pdo->query("SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE
 
 $where = [];
 if ($hasArchived) { $where[] = 'c.archived = 0'; }
-$where[] = 'c.name LIKE ?';
-$params = ['%'.$term.'%'];
+$where[] = '(c.name LIKE ? OR c.email LIKE ?)';
+$params = ['%'.$term.'%', '%'.$term.'%'];
 
 $userId = (int)($_SESSION['user']['id'] ?? 0);
 $activeOrgId = request_client_org_id();
@@ -33,7 +33,7 @@ if (!$isAdmin) {
 }
 
 $whereSQL = !empty($where) ? 'WHERE ' . implode(' AND ', $where) : '';
-$sql = "SELECT c.id, c.name, c.organization_id, o.name as org_name, o.tax_exempt_file FROM clients c LEFT JOIN organizations o ON c.organization_id = o.id {$whereSQL} ORDER BY c.name LIMIT 10";
+$sql = "SELECT c.id, c.name, c.email, c.organization_id, o.name as org_name, o.tax_exempt_file FROM clients c LEFT JOIN organizations o ON c.organization_id = o.id {$whereSQL} ORDER BY c.name LIMIT 10";
 $stmt = $pdo->prepare($sql);
 $stmt->execute($params);
 echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));

--- a/src/controllers/public_view/client_onboarding.php
+++ b/src/controllers/public_view/client_onboarding.php
@@ -6,6 +6,8 @@ require_once __DIR__ . '/../../utils/csrf.php';
 require_once __DIR__ . '/../../utils/rate_limiter.php';
 require_once __DIR__ . '/../../utils/client_onboarding.php';
 
+client_onboarding_revoke_stale($pdo);
+
 if (!rate_limit_check($pdo, 'client_onboarding_view', 30, 300, false)) {
     http_response_code(429);
     echo '<main><div class="auth-wrap"><h1>Please wait</h1><p>Too many requests were received.</p></div></main></body></html>';
@@ -20,19 +22,22 @@ $invite = null;
 $existingClient = [];
 
 if ($invitationId > 0) {
-    $stmt = $pdo->prepare('SELECT * FROM client_onboarding_invitations WHERE id=? AND status="verified"');
+    $stmt = $pdo->prepare('SELECT * FROM client_onboarding_invitations WHERE id=? AND status="pending"');
     $stmt->execute([$invitationId]);
     $invite = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
-    if ($invite && !empty($invite['client_id'])) {
-        $clientStmt = $pdo->prepare('SELECT name,phone,address_line1,address_line2,city,state,postal_code,country,client_type FROM clients WHERE id=?');
-        $clientStmt->execute([(int)$invite['client_id']]);
-        $existingClient = $clientStmt->fetch(PDO::FETCH_ASSOC) ?: [];
-    }
 } elseif ($token !== '') {
     $invite = client_onboarding_find_invitation($pdo, $token);
     if (!$invite || ($invite['status'] ?? '') !== 'pending') {
         $invite = null;
+    } else {
+        session_regenerate_id(true);
+        $_SESSION['client_onboarding_invitation_id'] = (int)$invite['id'];
     }
+}
+if ($invite && !empty($invite['client_id'])) {
+    $clientStmt = $pdo->prepare('SELECT name,phone,address_line1,address_line2,city,state,postal_code,country,client_type FROM clients WHERE id=?');
+    $clientStmt->execute([(int)$invite['client_id']]);
+    $existingClient = $clientStmt->fetch(PDO::FETCH_ASSOC) ?: [];
 }
 ?>
 <main>
@@ -43,38 +48,12 @@ if ($invitationId > 0) {
     <?php elseif (!$invite): ?>
       <h1 style="margin-top:0">Invitation unavailable</h1>
       <p>This invitation is invalid, expired, or already used. Contact the business that sent it for a new link.</p>
-    <?php elseif (($invite['status'] ?? '') === 'pending'): ?>
-      <h1 style="margin-top:0">Verify your email</h1>
-      <?php $inviteEmail = trim((string)($invite['invited_email'] ?? '')); ?>
-      <p>
-        <?php if ($inviteEmail !== ''): ?>
-          Send a verification code to <?php echo htmlspecialchars(client_onboarding_mask_email($inviteEmail)); ?>.
-        <?php else: ?>
-          Enter your email address so we can send a verification code for this onboarding link.
-        <?php endif; ?>
-      </p>
-      <?php if ($error): ?><div style="padding:10px;border:1px solid #fecaca;background:#fff1f2;color:#991b1b;margin-bottom:12px"><?php echo htmlspecialchars($error); ?></div><?php endif; ?>
-      <form method="post" action="/?page=client-onboarding-send-code" style="margin-bottom:18px;display:grid;gap:12px">
-        <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
-        <input type="hidden" name="token" value="<?php echo htmlspecialchars($token); ?>">
-        <?php if ($inviteEmail === ''): ?>
-          <label><span>Email address</span><input class="input" type="email" name="email" autocomplete="email" required></label>
-        <?php endif; ?>
-        <button type="submit" class="btn btn-primary">Send Verification Code</button>
-      </form>
-      <?php if (!empty($_GET['code_sent'])): ?>
-        <form method="post" action="/?page=client-onboarding-verify" style="display:grid;gap:12px">
-          <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
-          <input type="hidden" name="token" value="<?php echo htmlspecialchars($token); ?>">
-          <label><span>Verification code</span><input class="input" type="text" name="code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required></label>
-          <button type="submit" class="btn btn-primary">Verify Email</button>
-        </form>
-      <?php endif; ?>
     <?php else: ?>
       <h1 style="margin-top:0">Client information</h1>
       <?php if ($error): ?><div style="padding:10px;border:1px solid #fecaca;background:#fff1f2;color:#991b1b;margin-bottom:12px"><?php echo htmlspecialchars($error); ?></div><?php endif; ?>
       <form method="post" action="/?page=client-onboarding-submit" style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
         <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+        <input type="hidden" name="token" value="<?php echo htmlspecialchars($token); ?>">
         <label style="grid-column:1/-1"><span>Name</span><input class="input" name="name" maxlength="150" required value="<?php echo htmlspecialchars((string)($existingClient['name'] ?? '')); ?>"></label>
         <label><span>Phone</span><input class="input" name="phone" maxlength="50" autocomplete="tel" value="<?php echo htmlspecialchars((string)($existingClient['phone'] ?? '')); ?>"></label>
         <label><span>Client type</span><select class="input" name="client_type"><?php foreach (['unknown' => 'Not specified', 'business' => 'Business', 'consumer' => 'Individual'] as $value => $label): ?><option value="<?php echo $value; ?>" <?php echo ($existingClient['client_type'] ?? 'unknown') === $value ? 'selected' : ''; ?>><?php echo $label; ?></option><?php endforeach; ?></select></label>

--- a/src/controllers/public_view/client_onboarding_submit.php
+++ b/src/controllers/public_view/client_onboarding_submit.php
@@ -11,8 +11,9 @@ if (!rate_limit_check($pdo, 'client_onboarding_submit', 5, 900, false)) {
 }
 
 $invitationId = (int)($_SESSION['client_onboarding_invitation_id'] ?? 0);
+$token = trim((string)($_POST['token'] ?? ''));
 $name = client_onboarding_clean_text($_POST['name'] ?? '', 150);
-if ($invitationId <= 0 || $name === '') {
+if (($invitationId <= 0 && $token === '') || $name === '') {
     header('Location: /?page=client-onboarding&error=' . urlencode('Name is required.'));
     exit;
 }
@@ -36,19 +37,24 @@ $data = [
 
 try {
     $pdo->beginTransaction();
-    $inviteStmt = $pdo->prepare('SELECT * FROM client_onboarding_invitations WHERE id=? FOR UPDATE');
-    $inviteStmt->execute([$invitationId]);
-    $invite = $inviteStmt->fetch(PDO::FETCH_ASSOC);
-    if (!$invite || ($invite['status'] ?? '') !== 'verified' || strtotime((string)$invite['expires_at']) < time()) {
+    if ($token !== '') {
+        $invite = client_onboarding_find_invitation($pdo, $token, true);
+    } else {
+        $inviteStmt = $pdo->prepare('SELECT * FROM client_onboarding_invitations WHERE id=? FOR UPDATE');
+        $inviteStmt->execute([$invitationId]);
+        $invite = $inviteStmt->fetch(PDO::FETCH_ASSOC);
+    }
+    if (!$invite || ($invite['status'] ?? '') !== 'pending' || strtotime((string)$invite['expires_at']) < time()) {
         throw new RuntimeException('This onboarding session is no longer available.');
     }
+    $invitationId = (int)$invite['id'];
     $pdo->prepare(
         'INSERT INTO client_onboarding_submissions (invitation_id,proposed_data,status)
          VALUES (?,? ,"pending")
          ON DUPLICATE KEY UPDATE proposed_data=VALUES(proposed_data),status="pending",reviewed_by=NULL,reviewed_at=NULL,review_notes=NULL'
     )->execute([$invitationId, json_encode($data, JSON_UNESCAPED_SLASHES)]);
     $submissionId = (int)$pdo->lastInsertId();
-    $pdo->prepare('UPDATE client_onboarding_invitations SET status="submitted" WHERE id=?')->execute([$invitationId]);
+    $pdo->prepare('UPDATE client_onboarding_invitations SET status="submitted", consumed_at=NOW() WHERE id=? AND status="pending"')->execute([$invitationId]);
     $pdo->commit();
 
     unset($_SESSION['client_onboarding_invitation_id']);

--- a/src/controllers/public_view/public_contract_action.php
+++ b/src/controllers/public_view/public_contract_action.php
@@ -25,14 +25,14 @@ if (!csrf_sf_is_valid('public_contract_action', $submitted)) {
 
 try {
   $token = isset($_POST['token']) ? (string)$_POST['token'] : '';
-  if ($token === '') { throw new Exception('notoken'); }
+  if ($token === '' || preg_match('/^[a-f0-9]{32,64}$/', $token) !== 1) { throw new Exception('notoken'); }
 
   // Validate public link
   $st = $pdo->prepare('SELECT document_type, document_id, expires_at, revoked FROM public_links WHERE token=? LIMIT 1');
   $st->execute([$token]);
   $row = $st->fetch(PDO::FETCH_ASSOC);
   if (!$row) { throw new Exception('notfound'); }
-  if ((int)$row['revoked'] === 1 || strtotime((string)$row['expires_at']) < time()) { throw new Exception('expired'); }
+  if ((int)$row['revoked'] === 1 || (!empty($row['expires_at']) && strtotime((string)$row['expires_at']) < time())) { throw new Exception('expired'); }
   if ($row['document_type'] !== 'contract') { throw new Exception('badtype'); }
   $cid = (int)$row['document_id'];
 
@@ -42,17 +42,6 @@ try {
     exit;
   }
   $f = $_FILES['signed_pdf'];
-  if (!empty($f['size']) && $f['size'] > 25 * 1024 * 1024) {
-    header('Location: /?page=public-doc&token=' . rawurlencode($token) . '&error=' . urlencode('File too large (max 25 MB)'));
-    exit;
-  }
-  $mime = @mime_content_type($f['tmp_name']);
-  $origName = (string)($f['name'] ?? '');
-  $extOk = preg_match('/\.pdf$/i', $origName) === 1;
-  if ($mime !== 'application/pdf' && !$extOk) {
-    header('Location: /?page=public-doc&token=' . rawurlencode($token) . '&error=' . urlencode('Only PDF files are accepted (must be .pdf)'));
-    exit;
-  }
 
   // Load contract and check allowed status
   $c = $pdo->prepare('SELECT * FROM contracts WHERE id=? FOR UPDATE');
@@ -67,34 +56,49 @@ try {
   }
 
   // Store signed PDF in src/uploads directory (same logic as internal contract_sign)
-  $internal = __DIR__ . '/../../uploads';
-  $name = 'contract_' . $cid . '_signed_' . date('Ymd_His') . '_' . bin2hex(random_bytes(4)) . '.pdf';
+  $internal = __DIR__ . '/../../uploads/signed_contracts';
+  $uploadError = null;
   $filename = validate_and_store_upload(
       $f,
       ['application/pdf' => 'pdf'],
       25 * 1024 * 1024,
       $internal,
-      $uploadError
+      $uploadError,
+      [
+          'reject_archives' => true,
+          'require_pdf_header' => true,
+          'reject_pdf_active_content' => true,
+          'clamav_required' => filter_var(getenv('PUBLIC_UPLOAD_CLAMAV_REQUIRED') ?: '', FILTER_VALIDATE_BOOLEAN),
+      ]
   );
   if ($filename === null) {
       header('Location: /?page=public-doc&token=' . rawurlencode($token) . '&error=' . urlencode($uploadError ?: 'Failed to store uploaded file'));
       exit;
   }
   $name = $filename;
-  $internalDest = $internal . '/' . $name;
-
-  $publicUrl = '/?page=serve-upload&file=' . rawurlencode($name);
+  $publicUrl = '/?page=serve-upload&file=' . rawurlencode('signed_contracts/' . $name);
 
   // Save path and activate contract
   $pdo->beginTransaction();
   try {
+    $billingStartSql = '';
+    $updateParams = [$publicUrl, 'active'];
     if (pa_long_term_starts_billing_on_upload($contract)) {
-      $pdo->prepare('UPDATE contracts SET signed_pdf_path=?, status=?, signed_at=NOW(), next_invoice_date=? WHERE id=?')
-          ->execute([$publicUrl, 'active', date('Y-m-d'), $cid]);
-    } else {
-      $pdo->prepare('UPDATE contracts SET signed_pdf_path=?, status=?, signed_at=NOW() WHERE id=?')
-          ->execute([$publicUrl, 'active', $cid]);
+      $billingStartSql = ', next_invoice_date=?';
+      $updateParams[] = date('Y-m-d');
     }
+    $updateParams[] = $cid;
+    $update = $pdo->prepare("UPDATE contracts SET signed_pdf_path=?, status=?, signed_at=NOW(){$billingStartSql} WHERE id=? AND status='pending' AND (signed_pdf_path IS NULL OR signed_pdf_path='')");
+    $update->execute($updateParams);
+    if ($update->rowCount() !== 1) {
+      $storedFile = $internal . DIRECTORY_SEPARATOR . $name;
+      if (is_file($storedFile)) {
+        @unlink($storedFile);
+      }
+      throw new RuntimeException('Contract cannot be uploaded for current status');
+    }
+    $pdo->prepare('UPDATE public_links SET revoked=1 WHERE token=? AND document_type="contract" AND document_id=? AND revoked=0')
+        ->execute([$token, $cid]);
     $pdo->commit();
   } catch (Throwable $e) {
     if ($pdo->inTransaction()) $pdo->rollBack();

--- a/src/controllers/public_view/public_contract_sign.php
+++ b/src/controllers/public_view/public_contract_sign.php
@@ -27,7 +27,7 @@ if (!csrf_sf_is_valid('public_contract_sign', $submitted)) {
 try {
     $token = isset($_POST['token']) ? (string)$_POST['token'] : '';
     
-    if (empty($token)) {
+    if (empty($token) || preg_match('/^[a-f0-9]{32,64}$/', $token) !== 1) {
         throw new Exception('Missing token');
     }
     
@@ -37,23 +37,6 @@ try {
     }
     
     $file = $_FILES['signed_pdf'];
-    $maxSize = 10 * 1024 * 1024; // 10MB
-    
-    if ($file['size'] > $maxSize) {
-        throw new Exception('File too large (max 10MB)');
-    }
-    
-    // Check file type (PDF or images)
-    $allowedTypes = ['application/pdf', 'image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-    $finfo = finfo_open(FILEINFO_MIME_TYPE);
-    $mimeType = finfo_file($finfo, $file['tmp_name']);
-    if (PHP_VERSION_ID < 80500) {
-        finfo_close($finfo);
-    }
-    
-    if (!in_array($mimeType, $allowedTypes, true)) {
-        throw new Exception('Invalid file type. Please upload a PDF or image file.');
-    }
     
     // Load and validate public link
     $st = $pdo->prepare('SELECT document_type, document_id, expires_at, revoked FROM public_links WHERE token=? LIMIT 1');
@@ -107,7 +90,14 @@ try {
         $allowedMap,
         10 * 1024 * 1024,
         $uploadDir,
-        $uploadError
+        $uploadError,
+        [
+            'reject_archives' => true,
+            'max_image_pixels' => 40000000,
+            'require_pdf_header' => true,
+            'reject_pdf_active_content' => true,
+            'clamav_required' => filter_var(getenv('PUBLIC_UPLOAD_CLAMAV_REQUIRED') ?: '', FILTER_VALIDATE_BOOLEAN),
+        ]
     );
     if ($filename === null) {
         throw new Exception($uploadError ?: 'Failed to store uploaded file');

--- a/src/services/PaymentProcessorImportService.php
+++ b/src/services/PaymentProcessorImportService.php
@@ -82,12 +82,6 @@ class PaymentProcessorImportService
 
         $paymentId = self::insertStandalonePayment($pdo, $transaction, $ledgerId, $clientId);
         self::markLedger($pdo, $ledgerId, 'imported', null, $paymentId);
-        try {
-            require_once __DIR__ . '/../utils/payment_receipts.php';
-            payment_receipt_issue($pdo, $paymentId, $appConfig);
-        } catch (Throwable $receiptError) {
-            @error_log('[processor_import] Receipt issue failed for payment ' . $paymentId . ': ' . $receiptError->getMessage());
-        }
 
         return ['status' => 'imported', 'reason' => null, 'payment_id' => $paymentId, 'transaction_id' => $ledgerId];
     }

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -62,6 +62,8 @@ function page_permission_map(): array
 
         // API keys
         'api-keys'          => 'api_keys.manage',
+        'api-keys-new'      => 'api_keys.manage',
+        'api-keys-edit'     => 'api_keys.manage',
         'api-keys-create'   => 'api_keys.manage',
         'api-keys-update'   => 'api_keys.manage',
         'api-keys-revoke'   => 'api_keys.manage',

--- a/src/utils/client_onboarding.php
+++ b/src/utils/client_onboarding.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../services/EmailService.php';
 require_once __DIR__ . '/audit.php';
+require_once __DIR__ . '/crypto.php';
 
 function client_onboarding_base_url(array $appConfig): string
 {
@@ -16,6 +17,7 @@ function client_onboarding_base_url(array $appConfig): string
 
 function client_onboarding_find_invitation(PDO $pdo, string $token, bool $lock = false): ?array
 {
+    client_onboarding_revoke_stale($pdo);
     if (!preg_match('/^[a-f0-9]{64}$/', $token)) {
         return null;
     }
@@ -32,6 +34,50 @@ function client_onboarding_find_invitation(PDO $pdo, string $token, bool $lock =
         $invite['status'] = 'expired';
     }
     return $invite;
+}
+
+function client_onboarding_revoke_stale(PDO $pdo): void
+{
+    static $done = false;
+    if ($done) {
+        return;
+    }
+
+    try {
+        $pdo->prepare(
+            'UPDATE client_onboarding_invitations
+             SET status="revoked", consumed_at=NOW()
+             WHERE status IN ("pending","verified")
+               AND (expires_at < NOW() OR created_at < DATE_SUB(NOW(), INTERVAL 14 DAY))'
+        )->execute();
+    } catch (Throwable $e) {
+        @error_log('[client_onboarding] Stale revocation failed: ' . $e->getMessage());
+    }
+
+    $done = true;
+}
+
+function client_onboarding_store_token(string $token): ?string
+{
+    return crypto_encrypt($token);
+}
+
+function client_onboarding_token_from_invitation(array $invitation): string
+{
+    $encrypted = trim((string)($invitation['token_enc'] ?? ''));
+    if ($encrypted === '') {
+        return '';
+    }
+    return crypto_decrypt($encrypted) ?: '';
+}
+
+function client_onboarding_link_for_invitation(array $appConfig, array $invitation): string
+{
+    $token = client_onboarding_token_from_invitation($invitation);
+    if ($token === '') {
+        return '';
+    }
+    return client_onboarding_base_url($appConfig) . '/?page=client-onboarding&token=' . rawurlencode($token);
 }
 
 function client_onboarding_mask_email(string $email): string
@@ -68,6 +114,10 @@ function client_onboarding_send_code(PDO $pdo, array $invite, array $appConfig):
 
 function client_onboarding_clean_text(mixed $value, int $maxLength): string
 {
-    $value = trim((string)$value);
+    $value = str_replace("\0", '', (string)$value);
+    $value = strip_tags($value);
+    $value = preg_replace('/[^\P{C}\t\r\n]/u', '', $value) ?? '';
+    $value = preg_replace('/\s+/u', ' ', $value) ?? '';
+    $value = trim($value);
     return mb_substr($value, 0, $maxLength);
 }

--- a/src/utils/payment_receipts.php
+++ b/src/utils/payment_receipts.php
@@ -13,7 +13,7 @@ function payment_receipt_issue(PDO $pdo, int $paymentId, array $appConfig, bool 
     }
 
     $stmt = $pdo->prepare(
-        'SELECT p.id,p.invoice_id,p.amount,p.payment_date,p.payment_method,p.reference_number,
+        'SELECT p.id,p.invoice_id,p.processor_transaction_id,p.amount,p.payment_date,p.payment_method,p.reference_number,
                 i.doc_number,COALESCE(c.name,ppt.payer_name) AS client_name,COALESCE(c.email,ppt.payer_email) AS email
          FROM payments p
          LEFT JOIN invoices i ON i.id=p.invoice_id
@@ -24,6 +24,9 @@ function payment_receipt_issue(PDO $pdo, int $paymentId, array $appConfig, bool 
     $stmt->execute([$paymentId]);
     $payment = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$payment) {
+        return null;
+    }
+    if (empty($payment['invoice_id']) && !empty($payment['processor_transaction_id'])) {
         return null;
     }
 

--- a/src/utils/upload_validator.php
+++ b/src/utils/upload_validator.php
@@ -16,6 +16,7 @@
  * @param int        $maxBytes     Maximum allowed file size in bytes (default 8 MB).
  * @param string     $targetDir    Directory where the file will be stored (must exist/be writable).
  * @param string|null $error       Populated with an error message on failure.
+ * @param array      $options      Optional hardening flags for higher-risk surfaces.
  * @return string|null The generated safe filename on success, or null on failure.
  */
 function validate_and_store_upload(
@@ -23,7 +24,8 @@ function validate_and_store_upload(
     array $allowedMap,
     int $maxBytes,
     string $targetDir,
-    ?string &$error = null
+    ?string &$error = null,
+    array $options = []
 ): ?string {
     if (!isset($file['error'])) {
         $error = 'No upload data provided';
@@ -32,6 +34,11 @@ function validate_and_store_upload(
 
     if ($file['error'] !== UPLOAD_ERR_OK) {
         $error = 'Upload failed with error code ' . $file['error'];
+        return null;
+    }
+
+    if ((int)$file['size'] <= 0) {
+        $error = 'File is empty';
         return null;
     }
 
@@ -47,6 +54,12 @@ function validate_and_store_upload(
 
     $finfo = new finfo(FILEINFO_MIME_TYPE);
     $mime = $finfo->file($file['tmp_name']);
+    $originalExt = strtolower(pathinfo((string) ($file['name'] ?? ''), PATHINFO_EXTENSION));
+
+    if (!empty($options['reject_archives']) && upload_looks_like_archive($mime, $originalExt)) {
+        $error = 'Archive files are not accepted';
+        return null;
+    }
 
     if (!array_key_exists($mime, $allowedMap)) {
         $error = 'Invalid file type';
@@ -56,13 +69,32 @@ function validate_and_store_upload(
     $allowedExts = $allowedMap[$mime];
     $exts = is_array($allowedExts) ? $allowedExts : [$allowedExts];
 
-    $originalExt = strtolower(pathinfo((string) ($file['name'] ?? ''), PATHINFO_EXTENSION));
     if (!in_array($originalExt, $exts, true)) {
         $error = 'Invalid file extension';
         return null;
     }
 
-    $clamavError = scan_clamav($file['tmp_name']);
+    if (str_starts_with((string)$mime, 'image/')) {
+        $imageError = validate_image_upload_shape((string)$file['tmp_name'], (int)($options['max_image_pixels'] ?? 0));
+        if ($imageError !== null) {
+            $error = $imageError;
+            return null;
+        }
+    }
+
+    if ($mime === 'application/pdf') {
+        $pdfError = validate_pdf_upload_content(
+            (string)$file['tmp_name'],
+            !empty($options['require_pdf_header']),
+            !empty($options['reject_pdf_active_content'])
+        );
+        if ($pdfError !== null) {
+            $error = $pdfError;
+            return null;
+        }
+    }
+
+    $clamavError = scan_clamav($file['tmp_name'], !empty($options['clamav_required']));
     if ($clamavError !== null) {
         $error = $clamavError;
         return null;
@@ -86,6 +118,66 @@ function validate_and_store_upload(
     }
 
     return $filename;
+}
+
+function upload_looks_like_archive(string|false $mime, string $extension): bool
+{
+    $archiveExts = ['zip', 'rar', '7z', 'gz', 'gzip', 'bz2', 'xz', 'tar', 'tgz', 'tbz', 'jar', 'war', 'ear'];
+    if (in_array($extension, $archiveExts, true)) {
+        return true;
+    }
+
+    $archiveMimes = [
+        'application/zip',
+        'application/x-zip-compressed',
+        'application/x-rar',
+        'application/vnd.rar',
+        'application/x-7z-compressed',
+        'application/gzip',
+        'application/x-gzip',
+        'application/x-bzip2',
+        'application/x-xz',
+        'application/x-tar',
+        'application/java-archive',
+    ];
+
+    return in_array((string)$mime, $archiveMimes, true);
+}
+
+function validate_image_upload_shape(string $path, int $maxPixels): ?string
+{
+    $info = @getimagesize($path);
+    if ($info === false || empty($info[0]) || empty($info[1])) {
+        return 'Invalid image file';
+    }
+
+    if ($maxPixels > 0 && ((int)$info[0] * (int)$info[1]) > $maxPixels) {
+        return 'Image dimensions are too large';
+    }
+
+    return null;
+}
+
+function validate_pdf_upload_content(string $path, bool $requireHeader, bool $rejectActiveContent): ?string
+{
+    if ($requireHeader) {
+        $head = @file_get_contents($path, false, null, 0, 1024);
+        if (!is_string($head) || strpos($head, '%PDF-') === false) {
+            return 'Invalid PDF file';
+        }
+    }
+
+    if ($rejectActiveContent) {
+        $contents = @file_get_contents($path);
+        if (!is_string($contents)) {
+            return 'Failed to inspect PDF file';
+        }
+        if (preg_match('/\/\s*(JavaScript|JS|Launch|EmbeddedFile|RichMedia|OpenAction)\b/i', $contents) === 1) {
+            return 'PDF contains active or embedded content that is not accepted';
+        }
+    }
+
+    return null;
 }
 
 /**
@@ -148,10 +240,13 @@ function validate_upload(array $file, array $allowedMimes, int $maxBytes = 5 * 1
  * @param string $filepath Path to the file to scan
  * @return string|null Error message if malware detected or scan failed, null if clean/skipped
  */
-function scan_clamav(string $filepath): ?string
+function scan_clamav(string $filepath, bool $required = false): ?string
 {
     $host = getenv('CLAMAV_HOST');
     if (!$host) {
+        if ($required) {
+            return 'Virus scanning is required but not configured';
+        }
         // ClamAV not configured — fail open
         return null;
     }
@@ -161,6 +256,9 @@ function scan_clamav(string $filepath): ?string
 
     $socket = @fsockopen($host, $port, $errno, $errstr, $timeout);
     if (!$socket) {
+        if ($required) {
+            return 'Virus scanner is unavailable';
+        }
         // Daemon unreachable — fail open (log for admin awareness)
         @error_log('[clamav] Cannot connect to daemon at ' . $host . ':' . $port . ' — skipping scan');
         return null;
@@ -189,6 +287,9 @@ function scan_clamav(string $filepath): ?string
     fclose($socket);
 
     if ($response === false) {
+        if ($required) {
+            return 'Virus scanner did not respond';
+        }
         @error_log('[clamav] No response from daemon — skipping scan');
         return null;
     }
@@ -204,6 +305,10 @@ function scan_clamav(string $filepath): ?string
     }
 
     // Unknown response — fail open
+    if ($required) {
+        return 'Virus scanner returned an unexpected response';
+    }
+
     @error_log('[clamav] Unexpected response: ' . $response);
     return null;
 }

--- a/src/views/pages/api-keys-edit.php
+++ b/src/views/pages/api-keys-edit.php
@@ -1,0 +1,93 @@
+<?php
+// src/views/pages/api-keys-edit.php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/api_keys_schema.php';
+require_once __DIR__ . '/api_keys_shared.php';
+
+if (!api_keys_require_admin()) {
+    return;
+}
+
+$id = (int)($_GET['id'] ?? 0);
+$key = null;
+$schemaError = null;
+try {
+    pa_ensure_api_keys_schema($pdo);
+    if ($id > 0) {
+        $stmt = $pdo->prepare('SELECT id, name, key_prefix, scopes, allowed_ips, created_at, last_used_at, revoked_at FROM api_keys WHERE id = ?');
+        $stmt->execute([$id]);
+        $key = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+    }
+} catch (Throwable $e) {
+    $schemaError = $e->getMessage();
+}
+
+$scopeOptions = api_scope_options_for_form();
+$selectedScopes = $key ? api_normalize_scopes($key['scopes'] ?? 'full') : ['full'];
+api_keys_render_styles();
+?>
+
+<div class="api-key-page">
+  <div class="api-key-header">
+    <div>
+      <h1>Edit API Key</h1>
+      <p>Adjust the name, network limits, and ACL scopes for this integration.</p>
+    </div>
+    <a class="btn" href="/?page=api-keys">Back to API Keys</a>
+  </div>
+
+  <?php if ($schemaError): ?>
+    <div class="alert alert-danger">API key storage is not ready: <?php echo api_keys_e($schemaError); ?></div>
+  <?php elseif (!$key): ?>
+    <div class="alert alert-danger">API key not found.</div>
+  <?php else: ?>
+    <?php if (!empty($_GET['error'])): ?>
+      <div class="alert alert-danger"><?php echo api_keys_e($_GET['error']); ?></div>
+    <?php endif; ?>
+    <?php if (!empty($_GET['updated'])): ?>
+      <div class="alert alert-success">API key updated.</div>
+    <?php endif; ?>
+
+    <div class="api-key-card">
+      <div class="api-key-form-grid" style="margin-bottom:14px">
+        <div>
+          <span class="api-key-muted">Prefix</span><br>
+          <span class="api-key-prefix"><?php echo api_keys_e($key['key_prefix'] ?? ''); ?></span>
+        </div>
+        <div>
+          <span class="api-key-muted">Last used</span><br>
+          <?php echo api_keys_e($key['last_used_at'] ?: 'Never'); ?>
+        </div>
+      </div>
+
+      <?php if (!empty($key['revoked_at'])): ?>
+        <div class="alert alert-danger">This API key was revoked on <?php echo api_keys_e($key['revoked_at']); ?> and cannot be edited.</div>
+      <?php else: ?>
+        <form class="api-key-form" method="post" action="/?page=api-keys-update">
+          <input type="hidden" name="csrf" value="<?php echo api_keys_e(csrf_token()); ?>">
+          <input type="hidden" name="id" value="<?php echo (int)$key['id']; ?>">
+          <input type="hidden" name="return_to" value="edit">
+          <div class="api-key-form-grid">
+            <div class="api-key-field">
+              <label for="api-key-name">Key name</label>
+              <input type="text" id="api-key-name" name="name" value="<?php echo api_keys_e($key['name'] ?? ''); ?>" required>
+            </div>
+            <div class="api-key-field">
+              <label for="api-key-ips">Allowed IPs</label>
+              <input type="text" id="api-key-ips" name="allowed_ips" value="<?php echo api_keys_e($key['allowed_ips'] ?? ''); ?>" placeholder="Any">
+              <small>Leave blank to allow any source IP.</small>
+            </div>
+          </div>
+          <div class="api-key-field">
+            <span>API access</span>
+            <?php echo api_keys_scope_checkboxes($scopeOptions, $selectedScopes ?: ['full'], 'scopes'); ?>
+          </div>
+          <div class="api-key-form-actions">
+            <button type="submit" class="btn btn-primary">Save Changes</button>
+            <a class="btn" href="/?page=api-keys">Cancel</a>
+          </div>
+        </form>
+      <?php endif; ?>
+    </div>
+  <?php endif; ?>
+</div>

--- a/src/views/pages/api-keys-new.php
+++ b/src/views/pages/api-keys-new.php
@@ -1,0 +1,62 @@
+<?php
+// src/views/pages/api-keys-new.php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/api_keys_schema.php';
+require_once __DIR__ . '/api_keys_shared.php';
+
+if (!api_keys_require_admin()) {
+    return;
+}
+
+$schemaError = null;
+try {
+    pa_ensure_api_keys_schema($pdo);
+} catch (Throwable $e) {
+    $schemaError = $e->getMessage();
+}
+
+$scopeOptions = api_scope_options_for_form();
+api_keys_render_styles();
+?>
+
+<div class="api-key-page">
+  <div class="api-key-header">
+    <div>
+      <h1>New API Key</h1>
+      <p>Create a key for an external integration and choose its access.</p>
+    </div>
+    <a class="btn" href="/?page=api-keys">Back to API Keys</a>
+  </div>
+
+  <?php if ($schemaError): ?>
+    <div class="alert alert-danger">API key storage is not ready: <?php echo api_keys_e($schemaError); ?></div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['error'])): ?>
+    <div class="alert alert-danger"><?php echo api_keys_e($_GET['error']); ?></div>
+  <?php endif; ?>
+
+  <div class="api-key-card">
+    <form class="api-key-form" method="post" action="/?page=api-keys-create">
+      <input type="hidden" name="csrf" value="<?php echo api_keys_e(csrf_token()); ?>">
+      <div class="api-key-form-grid">
+        <div class="api-key-field">
+          <label for="api-key-name">Key name</label>
+          <input type="text" id="api-key-name" name="name" placeholder="Hermes agent" required>
+        </div>
+        <div class="api-key-field">
+          <label for="api-key-ips">Allowed IPs</label>
+          <input type="text" id="api-key-ips" name="allowed_ips" placeholder="Optional, comma separated">
+          <small>Leave blank unless the integration has fixed source IPs.</small>
+        </div>
+      </div>
+      <div class="api-key-field">
+        <span>API access</span>
+        <?php echo api_keys_scope_checkboxes($scopeOptions, ['full'], 'scopes'); ?>
+      </div>
+      <div class="api-key-form-actions">
+        <button type="submit" class="btn btn-primary">Create Key</button>
+        <a class="btn" href="/?page=api-keys">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/views/pages/api-keys.php
+++ b/src/views/pages/api-keys.php
@@ -2,41 +2,9 @@
 // src/views/pages/api-keys.php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/api_keys_schema.php';
-require_once __DIR__ . '/../../utils/api_scopes.php';
+require_once __DIR__ . '/api_keys_shared.php';
 
-if (!function_exists('api_keys_e')) {
-    function api_keys_e($value): string
-    {
-        return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
-    }
-}
-
-if (!function_exists('api_keys_scope_checkboxes')) {
-    function api_keys_scope_checkboxes(array $scopeOptions, array $selectedScopes, string $inputName, string $formId = ''): string
-    {
-        $selected = array_fill_keys(api_normalize_scopes($selectedScopes), true);
-        if (!$selected) {
-            $selected = ['full' => true];
-        }
-        $formAttr = $formId !== '' ? ' form="' . api_keys_e($formId) . '"' : '';
-        $html = '<div class="api-scope-grid">';
-        foreach ($scopeOptions as $scope => $option) {
-            $id = preg_replace('/[^a-z0-9_-]+/i', '-', $inputName . '-' . $formId . '-' . $scope);
-            $checked = isset($selected[$scope]) ? ' checked' : '';
-            $html .= '<label class="api-scope-option" for="' . api_keys_e($id) . '">';
-            $html .= '<input type="checkbox" id="' . api_keys_e($id) . '" name="' . api_keys_e($inputName) . '[]" value="' . api_keys_e($scope) . '"' . $checked . $formAttr . '>';
-            $html .= '<span><strong>' . api_keys_e($option['label'] ?? $scope) . '</strong>';
-            $html .= '<small>' . api_keys_e($option['description'] ?? '') . '</small></span>';
-            $html .= '</label>';
-        }
-        $html .= '</div>';
-        return $html;
-    }
-}
-
-$user = $_SESSION['user'] ?? [];
-if (($user['role'] ?? 'user') !== 'admin') {
-    echo '<div class="alert alert-danger">Only admins can manage API keys.</div>';
+if (!api_keys_require_admin()) {
     return;
 }
 
@@ -55,52 +23,16 @@ try {
 $scopeOptions = api_scope_options_for_form();
 $newKey = $_SESSION['flash_api_key'] ?? null;
 unset($_SESSION['flash_api_key']);
+api_keys_render_styles();
 ?>
-
-<style>
-.api-key-page { max-width: 1180px; margin: 0 auto; }
-.api-key-header { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; margin-bottom: 18px; }
-.api-key-header h1 { margin: 0 0 6px; font-size: 28px; }
-.api-key-header p { margin: 0; color: #64748b; }
-.api-key-card { background: #fff; border: 1px solid #d9e2ec; border-radius: 8px; padding: 18px; margin-bottom: 18px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04); }
-.api-key-card h2 { margin: 0 0 14px; font-size: 18px; }
-.api-key-form-grid { display: grid; grid-template-columns: minmax(180px, 1fr) minmax(220px, 1.2fr); gap: 14px; align-items: start; }
-.api-key-field label { display: block; font-weight: 600; font-size: 13px; margin-bottom: 6px; color: #334155; }
-.api-key-field input[type="text"] { width: 100%; min-height: 38px; border: 1px solid #cbd5e1; border-radius: 6px; padding: 8px 10px; }
-.api-key-field small { display: block; margin-top: 5px; color: #64748b; }
-.api-scope-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 8px; }
-.api-scope-option { display: flex; gap: 8px; align-items: flex-start; min-height: 64px; border: 1px solid #d9e2ec; border-radius: 8px; padding: 10px; background: #f8fafc; cursor: pointer; }
-.api-scope-option input { margin-top: 3px; }
-.api-scope-option strong { display: block; font-size: 13px; color: #0f172a; }
-.api-scope-option small { display: block; margin-top: 3px; color: #64748b; line-height: 1.3; }
-.api-key-table-wrap { overflow-x: auto; }
-.api-key-table { width: 100%; border-collapse: collapse; font-size: 14px; }
-.api-key-table th, .api-key-table td { border-bottom: 1px solid #e2e8f0; padding: 10px; text-align: left; vertical-align: top; }
-.api-key-table th { color: #475569; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; background: #f8fafc; }
-.api-key-table input[type="text"] { width: 100%; min-width: 150px; min-height: 34px; border: 1px solid #cbd5e1; border-radius: 6px; padding: 7px 9px; }
-.api-key-prefix { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: #0f172a; white-space: nowrap; }
-.api-key-actions { display: flex; flex-wrap: wrap; gap: 8px; }
-.api-key-empty { color: #64748b; padding: 18px; text-align: center; }
-.api-key-secret { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-wrap: anywhere; background: #ecfdf5; color: #065f46; border: 1px solid #a7f3d0; border-radius: 8px; padding: 12px; }
-.api-key-badge { display: inline-flex; align-items: center; border-radius: 999px; padding: 4px 8px; font-size: 12px; background: #e0f2fe; color: #075985; }
-.api-key-badge.revoked { background: #fee2e2; color: #991b1b; }
-.alert { padding: 12px 14px; border-radius: 8px; margin-bottom: 14px; }
-.alert-info { background: #eff6ff; color: #1e40af; border: 1px solid #bfdbfe; }
-.alert-success { background: #ecfdf5; color: #065f46; border: 1px solid #a7f3d0; }
-.alert-danger { background: #fef2f2; color: #991b1b; border: 1px solid #fecaca; }
-@media (max-width: 760px) {
-    .api-key-header, .api-key-form-grid { display: block; }
-    .api-key-field { margin-bottom: 12px; }
-}
-</style>
 
 <div class="api-key-page">
   <div class="api-key-header">
     <div>
       <h1>API Keys</h1>
-      <p>Create keys for external agents and choose exactly which API areas they can read.</p>
+      <p>Manage external access for agents and integrations.</p>
     </div>
-    <span class="api-key-badge">Beta</span>
+    <a class="btn btn-primary" href="/?page=api-keys-new">New API Key</a>
   </div>
 
   <?php if ($schemaError): ?>
@@ -112,6 +44,9 @@ unset($_SESSION['flash_api_key']);
   <?php if (!empty($_GET['updated'])): ?>
     <div class="alert alert-success">API key updated.</div>
   <?php endif; ?>
+  <?php if (!empty($_GET['revoked'])): ?>
+    <div class="alert alert-success">API key revoked.</div>
+  <?php endif; ?>
   <?php if ($newKey): ?>
     <div class="alert alert-success">
       <strong>Copy this key now. It will not be shown again.</strong>
@@ -120,30 +55,6 @@ unset($_SESSION['flash_api_key']);
   <?php endif; ?>
 
   <div class="api-key-card">
-    <h2>Create API Key</h2>
-    <form method="post" action="/?page=api-keys-create">
-      <input type="hidden" name="csrf" value="<?php echo api_keys_e(csrf_token()); ?>">
-      <div class="api-key-form-grid">
-        <div class="api-key-field">
-          <label for="api-key-name">Key name</label>
-          <input type="text" id="api-key-name" name="name" placeholder="Hermes agent" required>
-        </div>
-        <div class="api-key-field">
-          <label for="api-key-ips">Allowed IPs</label>
-          <input type="text" id="api-key-ips" name="allowed_ips" placeholder="Optional, comma separated">
-          <small>Leave blank unless the integration has fixed source IPs.</small>
-        </div>
-      </div>
-      <div class="api-key-field" style="margin-top:14px;">
-        <label>API access</label>
-        <?php echo api_keys_scope_checkboxes($scopeOptions, ['full'], 'scopes'); ?>
-      </div>
-      <button type="submit" class="btn btn-primary" style="margin-top:14px;">Create Key</button>
-    </form>
-  </div>
-
-  <div class="api-key-card">
-    <h2>Existing API Keys</h2>
     <?php if (!$keys): ?>
       <div class="api-key-empty">No API keys have been created yet.</div>
     <?php else: ?>
@@ -164,33 +75,17 @@ unset($_SESSION['flash_api_key']);
           <?php foreach ($keys as $key): ?>
             <?php
               $id = (int)($key['id'] ?? 0);
-              $formId = 'api-key-update-' . $id;
               $revoked = !empty($key['revoked_at']);
               $selectedScopes = api_normalize_scopes($key['scopes'] ?? 'full');
             ?>
             <tr>
               <td>
-                <?php if ($revoked): ?>
-                  <?php echo api_keys_e($key['name'] ?? ''); ?>
-                <?php else: ?>
-                  <input type="text" name="name" value="<?php echo api_keys_e($key['name'] ?? ''); ?>" form="<?php echo api_keys_e($formId); ?>" required>
-                <?php endif; ?>
+                <strong><?php echo api_keys_e($key['name'] ?? ''); ?></strong>
+                <div class="api-key-muted">Created <?php echo api_keys_e($key['created_at'] ?: 'Unknown'); ?></div>
               </td>
               <td><span class="api-key-prefix"><?php echo api_keys_e($key['key_prefix'] ?? ''); ?></span></td>
-              <td>
-                <?php if ($revoked): ?>
-                  <?php echo api_keys_e(implode(', ', $selectedScopes ?: ['full'])); ?>
-                <?php else: ?>
-                  <?php echo api_keys_scope_checkboxes($scopeOptions, $selectedScopes ?: ['full'], 'scopes', $formId); ?>
-                <?php endif; ?>
-              </td>
-              <td>
-                <?php if ($revoked): ?>
-                  <?php echo api_keys_e($key['allowed_ips'] ?: 'Any'); ?>
-                <?php else: ?>
-                  <input type="text" name="allowed_ips" value="<?php echo api_keys_e($key['allowed_ips'] ?? ''); ?>" placeholder="Any" form="<?php echo api_keys_e($formId); ?>">
-                <?php endif; ?>
-              </td>
+              <td><?php echo api_keys_e(api_keys_scope_labels($scopeOptions, $selectedScopes ?: ['full'])); ?></td>
+              <td><?php echo api_keys_e($key['allowed_ips'] ?: 'Any'); ?></td>
               <td><?php echo api_keys_e($key['last_used_at'] ?: 'Never'); ?></td>
               <td>
                 <?php if ($revoked): ?>
@@ -202,16 +97,14 @@ unset($_SESSION['flash_api_key']);
               <td>
                 <div class="api-key-actions">
                   <?php if (!$revoked): ?>
-                    <form id="<?php echo api_keys_e($formId); ?>" method="post" action="/?page=api-keys-update">
-                      <input type="hidden" name="csrf" value="<?php echo api_keys_e(csrf_token()); ?>">
-                      <input type="hidden" name="id" value="<?php echo $id; ?>">
-                      <button type="submit" class="btn btn-sm btn-primary">Save</button>
-                    </form>
+                    <a class="btn btn-sm" href="/?page=api-keys-edit&amp;id=<?php echo $id; ?>">Edit</a>
                     <form method="post" action="/?page=api-keys-revoke" onsubmit="return confirm('Revoke this API key? Existing integrations using it will stop working.');">
                       <input type="hidden" name="csrf" value="<?php echo api_keys_e(csrf_token()); ?>">
                       <input type="hidden" name="id" value="<?php echo $id; ?>">
                       <button type="submit" class="btn btn-sm btn-danger">Revoke</button>
                     </form>
+                  <?php else: ?>
+                    <span class="api-key-muted">No actions</span>
                   <?php endif; ?>
                 </div>
               </td>

--- a/src/views/pages/api_keys_shared.php
+++ b/src/views/pages/api_keys_shared.php
@@ -1,0 +1,73 @@
+<?php
+
+require_once __DIR__ . '/../../utils/api_scopes.php';
+
+if (!function_exists('api_keys_e')) {
+    function api_keys_e($value): string
+    {
+        return htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (!function_exists('api_keys_require_admin')) {
+    function api_keys_require_admin(): bool
+    {
+        $user = $_SESSION['user'] ?? [];
+        if (($user['role'] ?? 'user') !== 'admin') {
+            echo '<div class="alert alert-danger">Only admins can manage API keys.</div>';
+            return false;
+        }
+        return true;
+    }
+}
+
+if (!function_exists('api_keys_scope_labels')) {
+    function api_keys_scope_labels(array $scopeOptions, array $selectedScopes): string
+    {
+        $selected = api_normalize_scopes($selectedScopes ?: ['full']);
+        $labels = [];
+        foreach ($selected as $scope) {
+            $labels[] = (string)($scopeOptions[$scope]['label'] ?? $scope);
+        }
+        return implode(', ', $labels ?: ['Full API access']);
+    }
+}
+
+if (!function_exists('api_keys_scope_checkboxes')) {
+    function api_keys_scope_checkboxes(array $scopeOptions, array $selectedScopes, string $inputName, string $formId = ''): string
+    {
+        $selected = array_fill_keys(api_normalize_scopes($selectedScopes), true);
+        if (!$selected) {
+            $selected = ['full' => true];
+        }
+        $formAttr = $formId !== '' ? ' form="' . api_keys_e($formId) . '"' : '';
+        $html = '<div class="api-scope-grid">';
+        foreach ($scopeOptions as $scope => $option) {
+            $id = preg_replace('/[^a-z0-9_-]+/i', '-', $inputName . '-' . $formId . '-' . $scope);
+            $checked = isset($selected[$scope]) ? ' checked' : '';
+            $html .= '<label class="api-scope-option" for="' . api_keys_e($id) . '">';
+            $html .= '<input type="checkbox" id="' . api_keys_e($id) . '" name="' . api_keys_e($inputName) . '[]" value="' . api_keys_e($scope) . '"' . $checked . $formAttr . '>';
+            $html .= '<span><strong>' . api_keys_e($option['label'] ?? $scope) . '</strong>';
+            $html .= '<small>' . api_keys_e($option['description'] ?? '') . '</small></span>';
+            $html .= '</label>';
+        }
+        $html .= '</div>';
+        return $html;
+    }
+}
+
+if (!function_exists('api_keys_render_styles')) {
+    function api_keys_render_styles(): void
+    {
+        static $rendered = false;
+        if ($rendered) {
+            return;
+        }
+        $rendered = true;
+        ?>
+<style>
+.api-key-page{max-width:1180px;margin:0 auto}.api-key-header{display:flex;justify-content:space-between;gap:16px;align-items:flex-start;margin-bottom:18px}.api-key-header h1{margin:0 0 6px;font-size:28px}.api-key-header p{margin:0;color:#64748b}.api-key-card{background:#fff;border:1px solid #d9e2ec;border-radius:8px;padding:18px;margin-bottom:18px;box-shadow:0 1px 2px rgba(15,23,42,.04)}.api-key-card h2{margin:0 0 14px;font-size:18px}.api-key-form{display:grid;gap:14px}.api-key-form-grid{display:grid;grid-template-columns:minmax(180px,1fr) minmax(220px,1.2fr);gap:14px;align-items:start}.api-key-field label,.api-key-field>span{display:block;font-weight:600;font-size:13px;margin-bottom:6px;color:#334155}.api-key-field input[type=text]{width:100%;min-height:38px;border:1px solid #cbd5e1;border-radius:6px;padding:8px 10px}.api-key-field small{display:block;margin-top:5px;color:#64748b}.api-scope-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:8px}.api-scope-option{display:flex;gap:8px;align-items:flex-start;min-height:64px;border:1px solid #d9e2ec;border-radius:8px;padding:10px;background:#f8fafc;cursor:pointer}.api-scope-option input{margin-top:3px}.api-scope-option strong{display:block;font-size:13px;color:#0f172a}.api-scope-option small{display:block;margin-top:3px;color:#64748b;line-height:1.3}.api-key-table-wrap{overflow-x:auto;border:1px solid #e2e8f0;border-radius:8px}.api-key-table{width:100%;border-collapse:collapse;font-size:14px;background:#fff}.api-key-table th,.api-key-table td{border-bottom:1px solid #e2e8f0;padding:10px;text-align:left;vertical-align:middle}.api-key-table tr:last-child td{border-bottom:0}.api-key-table th{color:#475569;font-size:12px;text-transform:uppercase;letter-spacing:.04em;background:#f8fafc}.api-key-prefix{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:#0f172a;white-space:nowrap}.api-key-muted{color:#64748b}.api-key-actions{display:flex;flex-wrap:wrap;gap:8px;align-items:center}.api-key-empty{color:#64748b;padding:18px;text-align:center;border:1px dashed #cbd5e1;border-radius:8px;background:#f8fafc}.api-key-secret{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;overflow-wrap:anywhere;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0;border-radius:8px;padding:12px}.api-key-badge{display:inline-flex;align-items:center;border-radius:999px;padding:4px 8px;font-size:12px;background:#e0f2fe;color:#075985;white-space:nowrap}.api-key-badge.revoked{background:#fee2e2;color:#991b1b}.api-key-form-actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center}.alert{padding:12px 14px;border-radius:8px;margin-bottom:14px}.alert-info{background:#eff6ff;color:#1e40af;border:1px solid #bfdbfe}.alert-success{background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0}.alert-danger{background:#fef2f2;color:#991b1b;border:1px solid #fecaca}@media(max-width:760px){.api-key-header,.api-key-form-grid{display:block}.api-key-field{margin-bottom:12px}.api-key-actions{min-width:150px}}
+</style>
+        <?php
+    }
+}

--- a/src/views/pages/client/clients-edit.php
+++ b/src/views/pages/client/clients-edit.php
@@ -65,7 +65,7 @@ $organizations = $orgStmt->fetchAll();
           <div>State</div><input name="state" value="<?php echo htmlspecialchars($client['state'] ?? 'WI'); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
         </label>
         <label>
-          <div>Postal (zip)</div><input name="postal" value="<?php echo htmlspecialchars($client['postal'] ?? ''); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+          <div>Postal (zip)</div><input name="postal" value="<?php echo htmlspecialchars($client['postal_code'] ?? ''); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
         </label>
       </div>
     </fieldset>

--- a/src/views/pages/client/onboarding.php
+++ b/src/views/pages/client/onboarding.php
@@ -1,8 +1,12 @@
 <?php
 
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../config/app.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
+require_once __DIR__ . '/../../../utils/client_onboarding.php';
+
+client_onboarding_revoke_stale($pdo);
 
 $organizationId = request_client_org_id();
 $clients = $pdo->query('SELECT id,name,email FROM clients WHERE archived=0 ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
@@ -90,7 +94,7 @@ unset($_SESSION['client_onboarding_link']);
       </label>
       <label class="field"><span class="label-muted">Existing Client</span><select class="input" name="client_id" data-onboarding-client-select><option value="0">New client</option><?php foreach ($clients as $client): ?><option value="<?php echo (int)$client['id']; ?>" data-email="<?php echo htmlspecialchars((string)($client['email'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($client['name'] . (!empty($client['email']) ? ' - ' . $client['email'] : '')); ?></option><?php endforeach; ?></select></label>
       <label class="field"><span class="label-muted">Client Organization <span style="font-weight:400;color:var(--muted)">(optional)</span></span><select class="input" name="target_organization_id"><option value="0">No organization</option><?php foreach ($organizations as $organization): ?><option value="<?php echo (int)$organization['id']; ?>"><?php echo htmlspecialchars($organization['name']); ?></option><?php endforeach; ?></select></label>
-      <label class="field"><span class="label-muted">Expires In</span><select class="input" name="expires_hours"><option value="24">24 hours</option><option value="48" selected>48 hours</option><option value="72">3 days</option><option value="168">7 days</option></select></label>
+      <label class="field"><span class="label-muted">Expires In</span><select class="input" name="expires_hours"><option value="24">24 hours</option><option value="48">48 hours</option><option value="72">3 days</option><option value="168">7 days</option><option value="336" selected>14 days</option></select></label>
     </div>
     <div class="onboarding-invite-actions">
       <button class="btn" type="submit" name="delivery" value="link">Generate Link</button>
@@ -106,7 +110,7 @@ unset($_SESSION['client_onboarding_link']);
       <?php foreach ($invitations as $invitation): ?>
         <?php $proposal = json_decode((string)($invitation['proposed_data'] ?? ''), true); $proposal = is_array($proposal) ? $proposal : []; ?>
         <tr>
-          <td><?php echo !empty($invitation['invited_email']) ? htmlspecialchars((string)$invitation['invited_email']) : '<span class="muted">Provided during verification</span>'; ?></td>
+          <td><?php echo !empty($invitation['invited_email']) ? htmlspecialchars((string)$invitation['invited_email']) : '<span class="muted">Not required</span>'; ?></td>
           <td><?php echo htmlspecialchars((string)($invitation['client_name'] ?: 'New client')); ?></td>
           <td><?php echo htmlspecialchars((string)($invitation['target_organization_name'] ?: 'None')); ?></td>
           <td><span class="status-pill status-pill--<?php echo htmlspecialchars((string)$invitation['status']); ?>"><?php echo htmlspecialchars(ucfirst((string)$invitation['status'])); ?></span></td>
@@ -123,9 +127,18 @@ unset($_SESSION['client_onboarding_link']);
                 <button class="btn btn-sm btn-primary" name="decision" value="approve">Approve</button><button class="btn btn-sm btn-danger" name="decision" value="reject">Reject</button>
               </form>
             <?php elseif (in_array((string)$invitation['status'], ['pending','verified'], true)): ?>
-              <form method="post" action="/?page=client/onboarding-invite" onsubmit="return confirm('Revoke this invitation?')">
-                <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="action" value="revoke"><input type="hidden" name="id" value="<?php echo (int)$invitation['id']; ?>"><button class="btn btn-sm btn-danger">Revoke</button>
-              </form>
+              <?php $storedLink = client_onboarding_link_for_invitation($appConfig, $invitation); ?>
+              <div style="display:flex;gap:6px;flex-wrap:wrap">
+                <?php if ($storedLink !== ''): ?>
+                  <input id="onboardingLink<?php echo (int)$invitation['id']; ?>" class="input" readonly value="<?php echo htmlspecialchars($storedLink); ?>" style="position:absolute;left:-9999px;width:1px;height:1px">
+                  <button type="button" class="btn btn-sm" data-copy-onboarding-link="onboardingLink<?php echo (int)$invitation['id']; ?>">Copy Link</button>
+                <?php else: ?>
+                  <span class="muted" style="font-size:12px">Original link not recoverable</span>
+                <?php endif; ?>
+                <form method="post" action="/?page=client/onboarding-invite" onsubmit="return confirm('Revoke this invitation?')" style="display:inline">
+                  <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="action" value="revoke"><input type="hidden" name="id" value="<?php echo (int)$invitation['id']; ?>"><button class="btn btn-sm btn-danger">Revoke</button>
+                </form>
+              </div>
             <?php else: ?><span class="muted">Complete</span><?php endif; ?>
           </td>
         </tr>

--- a/src/views/pages/contract/contracts-edit.php
+++ b/src/views/pages/contract/contracts-edit.php
@@ -7,7 +7,7 @@ require_once __DIR__ . '/../../../utils/acl.php';
 require_once __DIR__ . '/../../../utils/project_selection.php';
 $id = (int)($_GET['id'] ?? 0);
 require_record_ownership($pdo, 'contracts', $id);
-$co = $pdo->prepare('SELECT * FROM contracts WHERE id=?');
+$co = $pdo->prepare('SELECT co.*, c.name AS client_name FROM contracts co LEFT JOIN clients c ON c.id = co.client_id WHERE co.id=?');
 $co->execute([$id]);
 $contract = $co->fetch(PDO::FETCH_ASSOC);
 if (!$contract) {
@@ -17,7 +17,6 @@ if (!$contract) {
 $items = $pdo->prepare('SELECT * FROM contract_items WHERE contract_id=?');
 $items->execute([$id]);
 $items = $items->fetchAll(PDO::FETCH_ASSOC);
-$clients = $pdo->query("SELECT id, name FROM clients ORDER BY name ASC")->fetchAll();
 $projectOptions = [];
 if (!empty($contract['client_id'])) {
   try {
@@ -67,11 +66,12 @@ try {
     <div style="display:grid;gap:12px;grid-template-columns:1fr 1fr">
       <label>
         <div>Client</div>
-        <select required name="client_id" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
-          <?php foreach ($clients as $c): ?>
-            <option value="<?php echo (int)$c['id']; ?>" <?php echo (int)$contract['client_id'] === (int)$c['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($c['name']); ?></option>
-          <?php endforeach; ?>
-        </select>
+        <div style="position:relative">
+          <input type="hidden" name="client_id" id="contractEditClientId" value="<?php echo (int)($contract['client_id'] ?? 0); ?>">
+          <input type="text" id="contractEditClientSearch" value="<?php echo htmlspecialchars($contract['client_name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" placeholder="Type a client name or email..." autocomplete="off" required style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+          <div id="contractEditClientSuggest" style="display:none;position:absolute;left:0;right:0;top:100%;z-index:40;max-height:220px;overflow:auto;background:#fff;border:1px solid #ddd;border-radius:8px;box-shadow:0 12px 24px rgba(15,23,42,.12)"></div>
+        </div>
+        <small style="display:block;margin-top:6px;color:var(--muted)">Start typing, then choose the matching client.</small>
       </label>
       <label>
         <div>Tax (%)</div>
@@ -79,7 +79,7 @@ try {
       </label>
       <label>
         <div>Project</div>
-        <select name="project_id" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+        <select name="project_id" id="contractEditProjectSelect" data-selected-project-id="<?php echo (int)($contract['project_id'] ?? 0); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
           <option value="">No project</option>
           <?php foreach ($projectOptions as $projectOption): ?>
             <option value="<?php echo (int)$projectOption['id']; ?>" <?php echo (int)($contract['project_id'] ?? 0) === (int)$projectOption['id'] ? 'selected' : ''; ?>>

--- a/src/views/pages/payments/payments-create.php
+++ b/src/views/pages/payments/payments-create.php
@@ -18,7 +18,6 @@ $invoices = $pdo->query("
   ORDER BY i.created_at DESC
   LIMIT 200
 ")->fetchAll(PDO::FETCH_ASSOC);
-$clients = $pdo->query('SELECT id,name,email FROM clients ORDER BY name ASC LIMIT 500')->fetchAll(PDO::FETCH_ASSOC);
 $pref = (int)($_GET['invoice_id'] ?? 0);
 $prefAmount = '';
 if ($pref > 0) {
@@ -42,7 +41,7 @@ if ($pref > 0) {
 ?>
 <section>
   <h2>Record Payment</h2>
-  <form method="post" action="/?page=payments/payments-create" style="display:grid;gap:12px;max-width:560px">
+  <form method="post" action="/?page=payments/payments-create" id="recordPaymentForm" style="display:grid;gap:12px;max-width:560px">
     <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
 
     <div style="display:grid;gap:8px">
@@ -74,14 +73,12 @@ if ($pref > 0) {
     <div id="manualPaymentFields" style="display:none;gap:12px">
       <label>
         <div>Client</div>
-        <select name="client_id" id="manualClientSelect" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
-          <option value="">Select client...</option>
-          <?php foreach ($clients as $client): ?>
-            <option value="<?php echo (int)$client['id']; ?>">
-              <?php echo htmlspecialchars($client['name']); ?><?php echo !empty($client['email']) ? ' - ' . htmlspecialchars($client['email']) : ''; ?>
-            </option>
-          <?php endforeach; ?>
-        </select>
+        <div style="position:relative">
+          <input type="hidden" name="client_id" id="manualClientId">
+          <input type="text" id="manualClientSearch" placeholder="Type a client name or email..." autocomplete="off" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+          <div id="manualClientSuggest" style="display:none;position:absolute;left:0;right:0;top:100%;z-index:30;max-height:220px;overflow:auto;background:#fff;border:1px solid #ddd;border-radius:8px;box-shadow:0 12px 24px rgba(15,23,42,.12)"></div>
+        </div>
+        <small style="display:block;margin-top:6px;color:var(--muted)">Start typing, then choose the matching client.</small>
       </label>
     </div>
 

--- a/src/views/pages/settings/billing.php
+++ b/src/views/pages/settings/billing.php
@@ -58,7 +58,10 @@ $stripeImportToday = date('Y-m-d');
   </label>
 </fieldset>
 
-<fieldset style="border:1px solid #eee;border-radius:8px;padding:12px;margin-top:16px">
+<details style="border:1px solid #eee;border-radius:8px;padding:12px;margin-top:16px">
+  <summary style="cursor:pointer;font-weight:600;color:#111827">Advanced</summary>
+  <div style="margin-top:14px">
+  <fieldset style="border:1px solid #eee;border-radius:8px;padding:12px">
   <legend style="padding:0 6px;color:var(--muted)">Processor Imports</legend>
   <?php if (!empty($_GET['stripe_net_backfill'])): ?>
     <div style="margin-bottom:12px;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0"><?php echo htmlspecialchars((string)$_GET['stripe_net_backfill']); ?></div>
@@ -110,7 +113,9 @@ $stripeImportToday = date('Y-m-d');
       <button type="submit" formaction="/?page=settings/stripe-net-backfill" formmethod="post" style="padding:8px 10px;border-radius:8px;border:1px solid #ddd;background:#fff;font-weight:600">Backfill Stripe Net Income</button>
     </div>
   </div>
-</fieldset>
+  </fieldset>
+  </div>
+</details>
 
 <!-- <div style="margin-top:20px;padding:16px;background:#f0f9ff;border:1px solid #bae6fd;border-radius:8px;font-size:14px">
   <strong>💡 Looking for Tax Rates?</strong>

--- a/src/views/public/doc-template.twig
+++ b/src/views/public/doc-template.twig
@@ -41,7 +41,7 @@
       <form method="post" action="/?page=public-contract-action" enctype="multipart/form-data" style="display:flex;gap:8px;align-items:center">
         <input type="hidden" name="csrf" value="{{ csrf|default('') }}">
         <input type="hidden" name="token" value="{{ token|e }}">
-        <input type="file" name="signed_pdf" accept="application/pdf" required style="padding:6px">
+        <input type="file" name="signed_pdf" accept="application/pdf,.pdf" required style="padding:6px">
         <button type="submit" style="padding:8px 12px;border-radius:8px;border:0;background:#0ea5a4;color:#fff">Upload Signed Contract</button>
       </form>
       <div style="margin-top:8px;color:var(--muted);font-size:13px">Upload a signed PDF to mark this contract active. Maximum 25 MB. PDF only.</div>

--- a/src/views/public/doc-wrapper.php
+++ b/src/views/public/doc-wrapper.php
@@ -312,7 +312,7 @@ if (in_array($type, ['invoice', 'project_invoice'], true)) {
     <form method="post" action="/?page=public-contract-sign" enctype="multipart/form-data" style="display:flex;flex-direction:column;align-items:center;gap:12px">
       <input type="hidden" name="csrf" value="<?php echo htmlspecialchars($csrf); ?>">
       <input type="hidden" name="token" value="<?php echo htmlspecialchars($token); ?>">
-      <input type="file" name="signed_pdf" accept="application/pdf,image/*" required style="padding:8px;border:1px solid #93c5fd;border-radius:8px;background:#fff">
+      <input type="file" name="signed_pdf" accept="application/pdf,.pdf,image/jpeg,.jpg,.jpeg,image/png,.png,image/gif,.gif,image/webp,.webp" required style="padding:8px;border:1px solid #93c5fd;border-radius:8px;background:#fff">
       <button type="submit" style="padding:12px 28px;border-radius:8px;border:0;background:#2563eb;color:#fff;font-weight:600;font-size:15px;cursor:pointer;box-shadow:0 2px 8px rgba(37,99,235,0.3)">📤 Upload Signed Contract</button>
     </form>
     <p style="margin-top:12px;font-size:13px;color:#6b7280">Accepts PDF or image files. Maximum 10 MB.</p>

--- a/tests/Payments/ProcessorImportTest.php
+++ b/tests/Payments/ProcessorImportTest.php
@@ -57,6 +57,7 @@ final class ProcessorImportTest extends TestCase
         self::assertStringContainsString('payer_email', $service);
         self::assertStringContainsString('processor_provider, processor_payment_id, processor_transaction_id', $service);
         self::assertStringContainsString('processor_net_amount, processor_fee_policy, processor_fee_source', $service);
+        self::assertStringNotContainsString('payment_receipt_issue', $service);
     }
 
     public function testStripeReconciliationUsesGenericStandaloneImportFallback(): void
@@ -142,6 +143,7 @@ final class ProcessorImportTest extends TestCase
         self::assertStringContainsString('Processor income', $paymentsList);
         self::assertStringContainsString('LEFT JOIN clients c ON c.id=p.client_id', $receipts);
         self::assertStringContainsString('COALESCE(c.email,ppt.payer_email)', $receipts);
+        self::assertStringContainsString('empty($payment[\'invoice_id\']) && !empty($payment[\'processor_transaction_id\'])', $receipts);
         self::assertStringContainsString('LEFT JOIN clients c ON c.id=p.client_id', $publicReceipt);
     }
 

--- a/tests/Security/SecurityHardeningTest.php
+++ b/tests/Security/SecurityHardeningTest.php
@@ -220,6 +220,9 @@ final class SecurityHardeningTest extends TestCase
         $auth = $this->read('src/utils/api_auth.php');
         $scopes = $this->read('src/utils/api_scopes.php');
         $view = $this->read('src/views/pages/api-keys.php');
+        $newView = $this->read('src/views/pages/api-keys-new.php');
+        $editView = $this->read('src/views/pages/api-keys-edit.php');
+        $sharedView = $this->read('src/views/pages/api_keys_shared.php');
         $create = $this->read('src/controllers/api_keys_create.php');
         $update = $this->read('src/controllers/api_keys_update.php');
         $acl = $this->read('src/utils/acl_middleware.php');
@@ -242,14 +245,53 @@ final class SecurityHardeningTest extends TestCase
         self::assertStringContainsString("['read', 'write', 'read.write', 'read_write']", $scopes);
         self::assertStringContainsString("['*', 'all', 'admin', 'full_access', 'full-access']", $scopes);
 
-        self::assertStringContainsString('api_scope_options_for_form()', $view);
-        self::assertStringContainsString('api_keys_scope_checkboxes', $view);
-        self::assertStringContainsString('/?page=api-keys-update', $view);
+        self::assertStringContainsString('api_keys_shared.php', $view);
+        self::assertStringContainsString('api_scope_options_for_form()', $newView);
+        self::assertStringContainsString('api_scope_options_for_form()', $editView);
+        self::assertStringContainsString('api_keys_scope_checkboxes', $sharedView);
+        self::assertStringContainsString('/?page=api-keys-update', $editView);
+        self::assertStringContainsString('/?page=api-keys-edit&amp;id=', $view);
         self::assertStringContainsString('pa_api_keys_existing_columns($pdo)', $view);
         self::assertStringContainsString('api_scopes_to_storage($scopes)', $create);
         self::assertStringContainsString('api_scopes_to_storage($scopes)', $update);
+        self::assertStringContainsString("'api-keys-new'", $acl);
+        self::assertStringContainsString("'api-keys-edit'", $acl);
         self::assertStringContainsString("'api-keys-update'", $acl);
         self::assertStringContainsString("'api-keys-update'", $audit);
+    }
+
+    public function testPublicLinkUploadsAndTextInputsAreHardened(): void
+    {
+        $billing = $this->read('src/views/pages/settings/billing.php');
+        self::assertStringContainsString('<summary style="cursor:pointer;font-weight:600;color:#111827">Advanced</summary>', $billing);
+        self::assertStringContainsString('Processor Imports', $billing);
+
+        $uploadValidator = $this->read('src/utils/upload_validator.php');
+        self::assertStringContainsString('array $options = []', $uploadValidator);
+        self::assertStringContainsString('function upload_looks_like_archive', $uploadValidator);
+        self::assertStringContainsString('function validate_image_upload_shape', $uploadValidator);
+        self::assertStringContainsString('function validate_pdf_upload_content', $uploadValidator);
+        self::assertStringContainsString('Virus scanning is required but not configured', $uploadValidator);
+        self::assertStringContainsString('scan_clamav(string $filepath, bool $required = false)', $uploadValidator);
+
+        foreach ([
+            'src/controllers/public_view/public_contract_sign.php',
+            'src/controllers/public_view/public_contract_action.php',
+        ] as $path) {
+            $controller = $this->read($path);
+            self::assertStringContainsString('reject_archives', $controller);
+            self::assertStringContainsString('reject_pdf_active_content', $controller);
+            self::assertStringContainsString('PUBLIC_UPLOAD_CLAMAV_REQUIRED', $controller);
+            self::assertStringContainsString("preg_match('/^[a-f0-9]{32,64}$/", $controller);
+        }
+        self::assertStringContainsString('max_image_pixels', $this->read('src/controllers/public_view/public_contract_sign.php'));
+
+        $onboarding = $this->read('src/utils/client_onboarding.php');
+        self::assertStringContainsString('strip_tags($value)', $onboarding);
+        self::assertStringContainsString('/[^\\P{C}\\t\\r\\n]/u', $onboarding);
+
+        $publicDoc = $this->read('src/views/public/doc-wrapper.php');
+        self::assertStringContainsString('accept="application/pdf,.pdf,image/jpeg,.jpg,.jpeg,image/png,.png,image/gif,.gif,image/webp,.webp"', $publicDoc);
     }
 
     public function testMigrationRunnerRetriesTransientMysqlLockFailures(): void

--- a/tests/Workflows/ClientOnboardingTest.php
+++ b/tests/Workflows/ClientOnboardingTest.php
@@ -13,14 +13,19 @@ final class ClientOnboardingTest extends TestCase
         $this->root = dirname(__DIR__, 2);
     }
 
-    public function testInvitationStoresOnlyTokenAndCodeHashes(): void
+    public function testInvitationStoresTokenHashAndEncryptedRecoveryToken(): void
     {
         $baseline = file_get_contents($this->root . '/database/baseline.sql');
+        $migration = file_get_contents($this->root . '/database/migrations/0020_client_onboarding_recoverable_links.sql');
         $invite = file_get_contents($this->root . '/src/controllers/client/client_onboarding_invite.php');
         $utility = file_get_contents($this->root . '/src/utils/client_onboarding.php');
         self::assertStringContainsString('token_hash CHAR(64)', (string)$baseline);
+        self::assertStringContainsString('token_enc TEXT NULL', (string)$baseline);
+        self::assertStringContainsString('ADD COLUMN token_enc TEXT NULL', (string)$migration);
+        self::assertStringContainsString('created_at < DATE_SUB(NOW(), INTERVAL 14 DAY)', (string)$migration);
         self::assertStringContainsString('organization_id INT NULL', (string)$baseline);
         self::assertStringContainsString("hash('sha256', \$token)", (string)$invite);
+        self::assertStringContainsString('client_onboarding_store_token($token)', (string)$invite);
         self::assertStringContainsString('password_hash($code, PASSWORD_DEFAULT)', (string)$utility);
     }
 
@@ -31,9 +36,15 @@ final class ClientOnboardingTest extends TestCase
         $review = file_get_contents($this->root . '/src/controllers/client/client_onboarding_review.php');
         self::assertStringContainsString('No organization', (string)$view);
         self::assertStringContainsString('Generate Link', (string)$view);
+        self::assertStringContainsString('Copy Link', (string)$view);
+        self::assertStringContainsString('client_onboarding_link_for_invitation($appConfig, $invitation)', (string)$view);
+        self::assertStringContainsString('<option value="336" selected>14 days</option>', (string)$view);
         self::assertStringNotContainsString('Select an organization before creating an invitation.', (string)$invite);
         self::assertStringContainsString('$ownerOrganizationId = $organizationId > 0 ? $organizationId : null', (string)$invite);
+        self::assertStringContainsString("min(336, (int)(\$_POST['expires_hours'] ?? 336))", (string)$invite);
         self::assertStringContainsString("in_array(\$decision, ['approve', 'reject']", (string)$review);
+        self::assertStringContainsString('c.email AS current_client_email', (string)$review);
+        self::assertStringContainsString('$emailValue = !empty($submission[\'invited_email\'])', (string)$review);
     }
 
     public function testPublicOnboardingIsRateLimitedAndDoesNotCollectPaymentData(): void
@@ -45,20 +56,22 @@ final class ClientOnboardingTest extends TestCase
         self::assertStringNotContainsString('payment_method', (string)$submit . (string)$page);
     }
 
-    public function testLinkOnlyInvitationsCanCollectEmailDuringVerification(): void
+    public function testPublicOnboardingLinkOpensFormDirectlyAndConsumesOnSubmit(): void
     {
         $baseline = file_get_contents($this->root . '/database/baseline.sql');
         $invite = file_get_contents($this->root . '/src/controllers/client/client_onboarding_invite.php');
         $page = file_get_contents($this->root . '/src/controllers/public_view/client_onboarding.php');
-        $sendCode = file_get_contents($this->root . '/src/controllers/public_view/client_onboarding_send_code.php');
+        $submit = file_get_contents($this->root . '/src/controllers/public_view/client_onboarding_submit.php');
 
         self::assertStringContainsString('invited_email VARCHAR(255) NULL', (string)$baseline);
         self::assertStringContainsString('$delivery === \'email\'', (string)$invite);
         self::assertStringContainsString('$email !== \'\' ? $email : null', (string)$invite);
-        self::assertStringContainsString('Enter your email address so we can send a verification code', (string)$page);
-        self::assertStringContainsString('name="email" autocomplete="email" required', (string)$page);
-        self::assertStringContainsString('SET invited_email=?', (string)$sendCode);
-        self::assertStringContainsString('The verification email could not be sent.', (string)$sendCode);
+        self::assertStringContainsString('SELECT * FROM client_onboarding_invitations WHERE id=? AND status="pending"', (string)$page);
+        self::assertStringContainsString('name="token"', (string)$page);
+        self::assertStringNotContainsString('Verify your email', (string)$page);
+        self::assertStringNotContainsString('Send Verification Code', (string)$page);
+        self::assertStringContainsString('client_onboarding_find_invitation($pdo, $token, true)', (string)$submit);
+        self::assertStringContainsString('status="submitted", consumed_at=NOW()', (string)$submit);
     }
 
     public function testReceiptDeliveryHasNoUserToggleOrDuplicateConfirmation(): void

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -113,6 +113,7 @@ final class ProjectWorkflowUiTest extends TestCase
         foreach ([$clientCreate, $clientEdit, $clientOnboarding, $orgCreate, $orgEdit, $accountEdit, $systemSettings] as $view) {
             self::assertStringContainsString('Apartment / Suite', (string)$view);
         }
+        self::assertStringContainsString('$client[\'postal_code\'] ?? \'\'', (string)$clientEdit);
         foreach ([$clientCreateController, $clientUpdateController, $orgCreateController, $orgUpdateController] as $controller) {
             self::assertStringContainsString('address_line2', (string)$controller);
         }
@@ -193,12 +194,18 @@ final class ProjectWorkflowUiTest extends TestCase
         $projectSelection = file_get_contents($this->root . '/src/utils/project_selection.php');
         $contractCreate = file_get_contents($this->root . '/src/views/pages/contract/contracts-create.php');
         $contractEdit = file_get_contents($this->root . '/src/views/pages/contract/contracts-edit.php');
+        $contractEditScript = file_get_contents($this->root . '/public/assets/js/contracts-edit-logic.js');
         $contractUpdate = file_get_contents($this->root . '/src/controllers/contract/contracts_update.php');
         $details = file_get_contents($this->root . '/src/views/pages/project/projects-details.php');
 
         self::assertStringContainsString('p.status IN ("active","not_started")', (string)$projectSelection);
         self::assertStringContainsString('p.status IN ("active","not_started")', (string)$contractCreate);
         self::assertStringContainsString('name="project_id"', (string)$contractEdit);
+        self::assertStringContainsString('id="contractEditClientSearch"', (string)$contractEdit);
+        self::assertStringContainsString('id="contractEditClientId"', (string)$contractEdit);
+        self::assertStringNotContainsString('SELECT id, name FROM clients ORDER BY name ASC', (string)$contractEdit);
+        self::assertStringContainsString('/?page=clients-search&term=', (string)$contractEditScript);
+        self::assertStringContainsString('/?page=projects-search&client_id=', (string)$contractEditScript);
         self::assertStringContainsString('pa_project_is_active_for_client($pdo, $project_id, $client_id', (string)$contractUpdate);
         self::assertStringContainsString('project_documents WHERE document_type="contract" AND document_id=?', (string)$contractUpdate);
         self::assertStringContainsString('foreach ($projectClients as $projectClient)', (string)$details);
@@ -311,8 +318,13 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('$sig[\'signer_title\'] ?? \'Client Signature\'', (string)$longTermDetails);
         self::assertStringContainsString('data-remaining=', (string)$paymentView);
         self::assertStringContainsString('name="reference_number"', (string)$paymentView);
+        self::assertStringContainsString('id="manualClientSearch"', (string)$paymentView);
+        self::assertStringContainsString('id="manualClientId"', (string)$paymentView);
+        self::assertStringNotContainsString('id="manualClientSelect"', (string)$paymentView);
         self::assertStringContainsString('reference_number', (string)$paymentController);
         self::assertStringContainsString('referenceLabel.textContent', (string)$paymentScript);
+        self::assertStringContainsString('/?page=clients-search&term=', (string)$paymentScript);
+        self::assertStringContainsString('Choose a client from the search results.', (string)$paymentScript);
     }
 
     public function testLegacyServerSchemaRepairsProtectAjaxPages(): void
@@ -336,7 +348,8 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('bindValue(count($params) + 1, $limit, PDO::PARAM_INT)', (string)$clientsList);
         self::assertStringContainsString('ensure_activity_log_table($pdo)', (string)$notifications);
         self::assertStringContainsString('PHP_VERSION_ID < 80500', (string)$dropbox);
-        self::assertStringContainsString('PHP_VERSION_ID < 80500', (string)$publicSign);
+        self::assertStringContainsString('validate_and_store_upload', (string)$publicSign);
+        self::assertStringNotContainsString('finfo_close', (string)$publicSign);
     }
 
     public function testPaymentsExpensesAndPdfPreviewsHandleLegacyServers(): void


### PR DESCRIPTION
## Summary
- Redesign API key management into a compact list with dedicated create/edit pages.
- Replace large client dropdowns with searchable client pickers for manual payments and contract edits.
- Simplify client onboarding links with recoverable links and 14-day stale revocation.
- Harden public upload validation and avoid sending receipts for standalone processor imports.

## Validation
- php src\\migrations\\run_migrations.php --validate-files
- git diff --check
- PHP lint on touched PHP views/controllers/tests
- node --check on touched JS files

Note: local PHPUnit is currently blocked because vendor\\phpunit\\phpunit\\phpunit cannot load PHPUnit\\TextUI\\Application.