### PR TITLE
Fix invoice time linking and expense categories

### DIFF
--- a/src/controllers/financial/category_handler.php
+++ b/src/controllers/financial/category_handler.php
@@ -40,6 +40,26 @@ function category_handler_finish(array $response, int $status = 200, string $fal
     exit;
 }
 
+function category_handler_safe_return_url(?string $url, string $default = '/?page=financial/expenses-list&tab=categories'): string
+{
+    $url = trim((string)$url);
+    if ($url === '' || str_starts_with($url, '//') || preg_match('/^[A-Za-z][A-Za-z0-9+.-]*:/', $url)) {
+        return $default;
+    }
+
+    if (!str_starts_with($url, '/?page=')) {
+        return $default;
+    }
+
+    return $url;
+}
+
+function category_handler_append_query(string $url, string $key, string $value): string
+{
+    $join = str_contains($url, '?') ? '&' : '?';
+    return $url . $join . rawurlencode($key) . '=' . rawurlencode($value);
+}
+
 $response = ['success' => false, 'message' => ''];
 
 // Auth required
@@ -131,7 +151,12 @@ try {
                 'color' => $color,
             ]);
 
-            jsonResponse(true, 'Category created successfully', ['id' => $categoryId]);
+            $redirect = category_handler_safe_return_url($_POST['return_to'] ?? null);
+            if (str_contains($redirect, 'page=financial/expense-create')) {
+                $redirect = category_handler_append_query($redirect, 'category_id', (string)$categoryId);
+            }
+
+            jsonResponse(true, 'Category created successfully', ['id' => $categoryId, 'name' => $name, 'redirect' => $redirect]);
 
         case 'update':
             $id = (int)($_POST['id'] ?? 0);

--- a/src/controllers/invoice/invoices_create.php
+++ b/src/controllers/invoice/invoices_create.php
@@ -112,14 +112,14 @@ try {
         $ii->execute([$invoice_id, $it['item'], $it['description'], $it['quantity'], $it['unit_price'], $it['line_total'], $it['billing_unit'], $primaryTimeEntryId, $it['billing_unit'] === 'hour' ? ($it['quantity'] ?? null) : null]);
         if (!empty($it['time_entry_ids'])) {
             $itemId = (int)$pdo->lastInsertId();
-            $check = $pdo->prepare('SELECT id FROM time_entries WHERE id = ? AND client_id = ? AND billed = 0');
-            $mark = $pdo->prepare('UPDATE time_entries SET billed = 1, invoice_item_id = ?, invoice_id = ? WHERE id = ?');
+            $check = $pdo->prepare('SELECT id FROM time_entries WHERE id = ? AND billed = 0 AND (client_id = ? OR client_id IS NULL OR client_id = 0)');
+            $mark = $pdo->prepare('UPDATE time_entries SET client_id = CASE WHEN client_id IS NULL OR client_id = 0 THEN ? ELSE client_id END, billed = 1, invoice_item_id = ?, invoice_id = ? WHERE id = ?');
             foreach ($it['time_entry_ids'] as $teId) {
                 $check->execute([(int)$teId, $client_id]);
                 if (!$check->fetchColumn()) {
                     throw new RuntimeException('Invalid or already billed time entry selected.');
                 }
-                $mark->execute([$itemId, $invoice_id, (int)$teId]);
+                $mark->execute([$client_id, $itemId, $invoice_id, (int)$teId]);
             }
         }
     }

--- a/src/controllers/invoice/invoices_update.php
+++ b/src/controllers/invoice/invoices_update.php
@@ -132,6 +132,13 @@ try {
   
   // Delete only extra charge items (if column exists), otherwise do not delete contract items
   if ($hasExtraChargeCol) {
+    $releaseExtraTime = $pdo->prepare('
+      UPDATE time_entries te
+      INNER JOIN invoice_items ii ON ii.id = te.invoice_item_id
+      SET te.billed = 0, te.invoice_item_id = NULL, te.invoice_id = NULL
+      WHERE ii.invoice_id = ? AND ii.is_extra_charge = 1
+    ');
+    $releaseExtraTime->execute([$id]);
     $pdo->prepare('DELETE FROM invoice_items WHERE invoice_id=? AND is_extra_charge=1')->execute([$id]);
 
     // Insert new extra charges with the flag
@@ -146,6 +153,14 @@ try {
       $ii->execute([$id, $it['i'], $it['d'], $it['q'], $it['p'], $it['t'], $it['u']]);
     }
   }
+
+  $syncTimeEntries = $pdo->prepare('
+    UPDATE time_entries te
+    LEFT JOIN invoice_items ii ON ii.id = te.invoice_item_id
+    SET te.client_id = ?, te.invoice_id = ?
+    WHERE te.invoice_id = ? OR ii.invoice_id = ?
+  ');
+  $syncTimeEntries->execute([$client_id, $id, $id, $id]);
 
   if (!$isDraft && !empty($invoiceState['finalized_at'])) {
     invoice_refresh_payment_totals($pdo, $id, false);

--- a/src/controllers/time-tracking/time_entries_unbilled.php
+++ b/src/controllers/time-tracking/time_entries_unbilled.php
@@ -34,7 +34,7 @@ $sql = 'SELECT te.id, te.started_at, te.ended_at, te.project_code, te.contract_i
         LEFT JOIN item_library il ON il.id = te.service_item_id
         WHERE te.user_id = ? AND te.billable = ? AND te.billed = ?';
 if ($clientId > 0) {
-    $sql .= ' AND te.client_id = ?';
+    $sql .= ' AND (te.client_id = ? OR te.client_id IS NULL OR te.client_id = 0)';
     $params[] = $clientId;
 }
 if ($projectCode !== '') {

--- a/src/controllers/time-tracking/time_entry_update.php
+++ b/src/controllers/time-tracking/time_entry_update.php
@@ -125,7 +125,7 @@ if ($hours <= 0) {
 }
 
 try {
-    $stmt = $pdo->prepare('UPDATE time_entries SET client_id=?, project_id=?, project_code=?, contract_id=?, invoice_id=?, service_item_id=?, description=?, started_at=?, ended_at=?, hours=?, billable=?, rate=? WHERE id=? AND user_id=? AND billed=0');
+    $stmt = $pdo->prepare('UPDATE time_entries SET client_id=?, project_id=?, project_code=?, contract_id=?, invoice_id=?, invoice_item_id=NULL, service_item_id=?, description=?, started_at=?, ended_at=?, hours=?, billable=?, rate=? WHERE id=? AND user_id=? AND billed=0');
     $stmt->execute([$clientId, $projectId, $projectCode, $contractId, $invoiceId, $serviceItemId, $description, $startedAt, $endedAt, $hours, $billable, $rate, $id, $userId]);
 } catch (Throwable $e) {
     @error_log('[TimeTrackingUpdate] Failed to save time entry: ' . $e->getMessage());

--- a/src/views/pages/financial/categories-list.php
+++ b/src/views/pages/financial/categories-list.php
@@ -30,7 +30,7 @@ $csrf = csrf_token();
       <p class="muted" style="margin:4px 0 0">Manage expense categories and IRS Schedule C defaults</p>
     </div>
     <div class="flex">
-      <a href="/?page=financial/vendor-form" class="btn btn-primary">+ Add Category</a>
+      <button type="button" class="btn btn-primary" onclick="createCategory()">+ Add Category</button>
     </div>
   </div>
 
@@ -118,7 +118,7 @@ $csrf = csrf_token();
   <form method="post" action="/?page=financial/category-handler">
     <input type="hidden" name="_token" value="<?php echo htmlspecialchars(csrf_sf_token('category')); ?>">
     <input type="hidden" name="csrf" value="<?php echo htmlspecialchars($csrf); ?>">
-    <input type="hidden" name="action" value="update">
+    <input type="hidden" name="action" id="categoryAction" value="update">
     <input type="hidden" name="id" id="categoryId">
 
     <div class="field">
@@ -167,17 +167,40 @@ $csrf = csrf_token();
     backdrop.style.display = 'block';
   }
 
+  function resetParentOptions() {
+    var parent = document.getElementById('cat-parent');
+    parent.disabled = false;
+    for (var i = 0; i < parent.options.length; i++) {
+      parent.options[i].disabled = false;
+    }
+  }
+
   window.closeModal = function() {
     modal.style.display = 'none';
     backdrop.style.display = 'none';
   };
 
+  window.createCategory = function() {
+    document.getElementById('categoryAction').value = 'create';
+    document.getElementById('categoryId').value = '';
+    document.getElementById('cat-name').value = '';
+    document.getElementById('cat-parent').value = '';
+    document.getElementById('cat-tax').checked = true;
+    document.getElementById('cat-color').value = '#3b82f6';
+    document.getElementById('taxDeductibleField').style.display = 'block';
+    document.getElementById('modalTitle').textContent = 'Add Category';
+    resetParentOptions();
+    openModal();
+  };
+
   window.editCategory = function(category) {
+    document.getElementById('categoryAction').value = 'update';
     document.getElementById('categoryId').value = category.id;
     document.getElementById('cat-name').value = category.name || '';
     document.getElementById('cat-parent').value = category.parent_id || '';
     document.getElementById('cat-tax').checked = parseInt(category.tax_deductible, 10) === 1;
     document.getElementById('cat-color').value = category.color || '#3b82f6';
+    resetParentOptions();
 
     var taxField = document.getElementById('taxDeductibleField');
     if (parseInt(category.is_system, 10) === 1) {

--- a/src/views/pages/financial/expense-create.php
+++ b/src/views/pages/financial/expense-create.php
@@ -15,6 +15,7 @@ $prefillAmount = $_GET['amount'] ?? '';
 $prefillDate = $_GET['date'] ?? date('Y-m-d');
 $prefillVendor = $_GET['vendor'] ?? '';
 $prefillReceiptId = (int)($_GET['receipt_id'] ?? 0);
+$prefillCategoryId = (int)($_GET['category_id'] ?? 0);
 
 // Fetch dropdowns
 $cats = $pdo->prepare('SELECT id, name FROM expense_categories ORDER BY name');
@@ -50,6 +51,11 @@ if ($editId > 0) {
         exit;
     }
 }
+$selectedCategoryId = (int)($expense['category_id'] ?? $prefillCategoryId);
+$expenseCreateReturnUrl = '/?page=financial/expense-create';
+if ($editId > 0) {
+    $expenseCreateReturnUrl .= '&id=' . $editId;
+}
 ?>
 
 <div style="max-width:800px;margin:0 auto;padding:24px">
@@ -60,6 +66,8 @@ if ($editId > 0) {
 
   <?php if (!empty($_GET['error'])): ?>
     <div class="alert alert-danger" style="margin-bottom:16px"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+  <?php elseif (!empty($_GET['success'])): ?>
+    <div class="alert alert-success" style="margin-bottom:16px"><?php echo htmlspecialchars((string)$_GET['success']); ?></div>
   <?php endif; ?>
   <?php if (!empty($_GET['created']) || !empty($_GET['updated'])): ?>
     <div class="alert alert-success" style="margin-bottom:16px">Expense saved.</div>
@@ -85,11 +93,14 @@ if ($editId > 0) {
       </div>
 
       <div class="field">
-        <label class="label">Category</label>
-        <select name="category_id" class="input">
-          <option value="0">— No category —</option>
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+          <label class="label" for="expenseCategory">Category</label>
+          <button type="button" class="btn btn-sm" id="openCategoryModal">New Category</button>
+        </div>
+        <select name="category_id" id="expenseCategory" class="input">
+          <option value="0">No category</option>
           <?php foreach ($categories as $cat): ?>
-            <option value="<?php echo (int)$cat['id']; ?>" <?php echo ($expense['category_id'] ?? 0) === (int)$cat['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($cat['name']); ?></option>
+            <option value="<?php echo (int)$cat['id']; ?>" <?php echo $selectedCategoryId === (int)$cat['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($cat['name']); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -152,6 +163,43 @@ if ($editId > 0) {
       <button type="submit" class="btn btn-primary"><?php echo $editId > 0 ? 'Update' : 'Create'; ?> Expense</button>
     </div>
   </form>
+
+  <div id="categoryModalBackdrop" style="display:none;position:fixed;inset:0;background:rgba(15,23,42,.45);z-index:998"></div>
+  <div id="categoryModal" class="card" style="display:none;position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);width:min(480px,calc(100vw - 32px));z-index:999">
+    <div class="card-head">
+      <h3 class="card-title">New Category</h3>
+      <button type="button" class="btn btn-sm" id="closeCategoryModal">Close</button>
+    </div>
+    <form id="newCategoryForm" method="post" action="/?page=financial/category-handler">
+      <input type="hidden" name="_token" value="<?php echo htmlspecialchars(csrf_sf_token('category')); ?>">
+      <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+      <input type="hidden" name="action" value="create">
+      <input type="hidden" name="return_to" value="<?php echo htmlspecialchars($expenseCreateReturnUrl); ?>">
+
+      <div id="categoryFormError" class="alert alert-danger" style="display:none;margin-bottom:12px"></div>
+
+      <div class="field">
+        <label for="newCategoryName" class="label">Name *</label>
+        <input type="text" id="newCategoryName" name="name" required class="input" autocomplete="off">
+      </div>
+
+      <div class="grid grid-2">
+        <label class="label" style="display:flex;align-items:center;gap:6px">
+          <input type="checkbox" name="tax_deductible" value="1" checked>
+          Tax Deductible
+        </label>
+        <div class="field">
+          <label for="newCategoryColor" class="label">Color</label>
+          <input type="color" id="newCategoryColor" name="color" value="#3b82f6" class="input" style="padding:4px;height:40px">
+        </div>
+      </div>
+
+      <div class="flex-end" style="margin-top:16px">
+        <button type="button" class="btn" id="cancelCategoryCreate">Cancel</button>
+        <button type="submit" class="btn btn-primary">Create Category</button>
+      </div>
+    </form>
+  </div>
 </div>
 
 <script>
@@ -176,6 +224,77 @@ vendorNameInput.addEventListener('change', function() {
     if (opt.value === val) { vendorIdInput.value = opt.dataset.id; found = true; }
   });
   if (!found) vendorIdInput.value = 0;
+});
+
+const openCategoryModal = document.getElementById('openCategoryModal');
+const closeCategoryModal = document.getElementById('closeCategoryModal');
+const cancelCategoryCreate = document.getElementById('cancelCategoryCreate');
+const categoryModal = document.getElementById('categoryModal');
+const categoryBackdrop = document.getElementById('categoryModalBackdrop');
+const newCategoryForm = document.getElementById('newCategoryForm');
+const categorySelect = document.getElementById('expenseCategory');
+const categoryFormError = document.getElementById('categoryFormError');
+const newCategoryName = document.getElementById('newCategoryName');
+
+function setCategoryModal(open) {
+  categoryModal.style.display = open ? 'block' : 'none';
+  categoryBackdrop.style.display = open ? 'block' : 'none';
+  if (open) {
+    categoryFormError.style.display = 'none';
+    categoryFormError.textContent = '';
+    setTimeout(function() { newCategoryName.focus(); }, 0);
+  }
+}
+
+openCategoryModal.addEventListener('click', function() { setCategoryModal(true); });
+closeCategoryModal.addEventListener('click', function() { setCategoryModal(false); });
+cancelCategoryCreate.addEventListener('click', function() { setCategoryModal(false); });
+categoryBackdrop.addEventListener('click', function() { setCategoryModal(false); });
+
+newCategoryForm.addEventListener('submit', function(event) {
+  event.preventDefault();
+  categoryFormError.style.display = 'none';
+  categoryFormError.textContent = '';
+
+  fetch(newCategoryForm.action, {
+    method: 'POST',
+    body: new FormData(newCategoryForm),
+    headers: {
+      'Accept': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest'
+    }
+  })
+    .then(function(response) {
+      return response.text().then(function(text) {
+        let payload = null;
+        try {
+          payload = JSON.parse(text);
+        } catch (error) {
+          throw new Error('Category request failed. Please refresh and try again.');
+        }
+        if (!response.ok) {
+          throw new Error(payload.message || 'Category could not be created.');
+        }
+        return payload;
+      });
+    })
+    .then(function(payload) {
+      if (!payload || !payload.success) {
+        throw new Error((payload && payload.message) || 'Category could not be created.');
+      }
+      const option = document.createElement('option');
+      option.value = String(payload.id);
+      option.textContent = payload.name || newCategoryName.value;
+      option.selected = true;
+      categorySelect.appendChild(option);
+      newCategoryForm.reset();
+      document.getElementById('newCategoryColor').value = '#3b82f6';
+      setCategoryModal(false);
+    })
+    .catch(function(error) {
+      categoryFormError.textContent = error.message || 'Category could not be created.';
+      categoryFormError.style.display = 'block';
+    });
 });
 
 })();

--- a/src/views/pages/invoice/invoices-create.php
+++ b/src/views/pages/invoice/invoices-create.php
@@ -104,7 +104,7 @@ if ($selectedProjectId > 0) {
     <div>
       <div style="font-weight:600;margin-bottom:8px">Items / Time</div>
       <div id="itemsInv" style="display:grid;gap:8px"></div>
-      <div style="display:flex;gap:8px;flex-wrap:wrap">
+      <div style="display:flex;gap:8px;flex-wrap:wrap;padding-top:8px">
         <button type="button" onclick="addItemInv()" style="padding:8px 12px;border-radius:8px;border:1px solid #ddd;background:#fff">+ Add Item</button>
         <button type="button" id="btnAddFromTrackedTime" style="padding:8px 12px;border-radius:8px;border:1px solid #2ea3d6;background:#eff6ff;color:#0b4a6a;font-weight:600">+ Add from Tracked Time</button>
       </div>

--- a/tests/Workflows/FinancialAssetsTest.php
+++ b/tests/Workflows/FinancialAssetsTest.php
@@ -58,12 +58,27 @@ final class FinancialAssetsTest extends TestCase
         self::assertStringNotContainsString('fetch(form.action', $form);
         self::assertStringContainsString('$_GET[\'error\']', $form);
         self::assertStringContainsString('/?page=financial/expenses-list&tab=expenses', $form);
+        self::assertStringContainsString('id="newCategoryForm"', $form);
+        self::assertStringContainsString('id="expenseCategory"', $form);
+        self::assertStringContainsString('New Category', $form);
+        self::assertStringContainsString('payload.id', $form);
 
         $handler = $this->read('src/controllers/financial/expense_handler.php');
         self::assertStringContainsString('function expense_handler_is_ajax()', $handler);
         self::assertStringContainsString("'status_param' => 'created'", $handler);
         self::assertStringContainsString("'status_param' => 'updated'", $handler);
         self::assertStringContainsString('/?page=financial/expenses-list&tab=expenses', $handler);
+
+        $categoryHandler = $this->read('src/controllers/financial/category_handler.php');
+        self::assertStringContainsString('function category_handler_safe_return_url', $categoryHandler);
+        self::assertStringContainsString('category_id', $categoryHandler);
+        self::assertStringContainsString("'name' => \$name", $categoryHandler);
+
+        $categories = $this->read('src/views/pages/financial/categories-list.php');
+        self::assertStringContainsString('onclick="createCategory()"', $categories);
+        self::assertStringContainsString('id="categoryAction"', $categories);
+        self::assertStringContainsString('window.createCategory', $categories);
+        self::assertStringNotContainsString('/?page=financial/vendor-form" class="btn btn-primary">+ Add Category', $categories);
     }
 
     public function testAssetsAreExposedInFinancialHubUi(): void

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -157,6 +157,7 @@ final class ProjectWorkflowUiTest extends TestCase
             self::assertStringContainsString('pa_time_tracking_ensure_schema($pdo)', (string)$controller);
             self::assertStringContainsString('Failed to save time entry', (string)$controller);
         }
+        self::assertStringContainsString('invoice_item_id=NULL', (string)$updateController);
         self::assertStringContainsString('function pa_time_tracking_ensure_schema', (string)$schema);
         self::assertStringContainsString('service_item_id', (string)$migration);
         self::assertStringContainsString('project_code', (string)$migration);
@@ -180,13 +181,22 @@ final class ProjectWorkflowUiTest extends TestCase
     {
         $view = file_get_contents($this->root . '/src/views/pages/invoice/invoices-create.php');
         $controller = file_get_contents($this->root . '/src/controllers/invoice/invoices_create.php');
+        $updateController = file_get_contents($this->root . '/src/controllers/invoice/invoices_update.php');
+        $unbilledTime = file_get_contents($this->root . '/src/controllers/time-tracking/time_entries_unbilled.php');
 
         self::assertStringContainsString('value="save" class="btn">Save Invoice</button>', (string)$view);
         self::assertStringContainsString('value="finalize_send" class="btn btn-primary">Save &amp; Send</button>', (string)$view);
+        self::assertStringContainsString('display:flex;gap:8px;flex-wrap:wrap;padding-top:8px', (string)$view);
         self::assertStringNotContainsString('Save Draft</button>', (string)$view);
         self::assertStringContainsString("\$invoiceAction = (string)(\$_POST['invoice_action'] ?? 'save');", (string)$controller);
         self::assertStringContainsString("['save', 'draft', 'finalize_send']", (string)$controller);
         self::assertStringContainsString('$finalizeAndSend = $invoiceAction === \'finalize_send\';', (string)$controller);
+        self::assertStringContainsString('client_id = ? OR client_id IS NULL OR client_id = 0', (string)$controller);
+        self::assertStringContainsString('CASE WHEN client_id IS NULL OR client_id = 0 THEN ? ELSE client_id END', (string)$controller);
+        self::assertStringContainsString('UPDATE time_entries te', (string)$updateController);
+        self::assertStringContainsString('SET te.client_id = ?, te.invoice_id = ?', (string)$updateController);
+        self::assertStringContainsString('SET te.billed = 0, te.invoice_item_id = NULL, te.invoice_id = NULL', (string)$updateController);
+        self::assertStringContainsString('te.client_id = ? OR te.client_id IS NULL OR te.client_id = 0', (string)$unbilledTime);
     }
 
     public function testDocumentsCanAttachToActiveOrNotStartedProjects(): void


### PR DESCRIPTION
## Summary
- allow unassigned tracked time entries to be added to client invoices and keep linked time entries synced when invoices change
- add inline expense category creation from the expense form and repair the categories tab add button
- add workflow assertions for invoice/time and expense category behavior

## Verification
- php -l on touched PHP files
- git diff --check

Note: local PHPUnit is blocked in this checkout because vendor/phpunit is missing PHPUnit\\TextUI\\Application.