### PR TITLE
Restore immutable org link migration

### DIFF
--- a/database/migrations/0006_org_link_strategy_and_link_only_onboarding.sql
+++ b/database/migrations/0006_org_link_strategy_and_link_only_onboarding.sql
@@ -8,7 +8,7 @@ SET @org_link_strategy_exists := (
 
 SET @org_link_strategy_sql := IF(
     @org_link_strategy_exists = 0,
-    'ALTER TABLE organizations ADD COLUMN link_strategy ENUM(''department_links_only'',''overall_folder'',''shared_folder'') NOT NULL DEFAULT ''overall_folder'' AFTER tax_exempt_uploaded_at',
+    'ALTER TABLE organizations ADD COLUMN link_strategy ENUM(''department_links_only'',''overall_folder'',''shared_folder'') NOT NULL DEFAULT ''department_links_only'' AFTER tax_exempt_uploaded_at',
     'SELECT 1'
 );
 

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -122,12 +122,14 @@ final class ProjectWorkflowUiTest extends TestCase
     public function testOrganizationLinksSwitchFromOverallFolderToDepartmentLinks(): void
     {
         $baseline = file_get_contents($this->root . '/database/baseline.sql');
+        $originalMigration = file_get_contents($this->root . '/database/migrations/0006_org_link_strategy_and_link_only_onboarding.sql');
         $migration = file_get_contents($this->root . '/database/migrations/0022_dynamic_org_link_strategy.sql');
         $view = file_get_contents($this->root . '/src/views/pages/organization/organization-view.php');
         $handler = file_get_contents($this->root . '/src/controllers/organization/organization_departments.php');
         $resolver = file_get_contents($this->root . '/src/services/LinkResolverService.php');
 
         self::assertStringContainsString("DEFAULT 'overall_folder'", (string)$baseline);
+        self::assertStringContainsString("DEFAULT ''department_links_only''", (string)$originalMigration);
         self::assertStringContainsString("DEFAULT 'overall_folder'", (string)$migration);
         self::assertStringContainsString('PA uses the overall organization folder until the first department is added.', (string)$view);
         self::assertStringContainsString('When a first department is created, PA switches this organization to department links only', (string)$view);


### PR DESCRIPTION
## Summary
- Restores migration 0006 to the originally shipped department_links_only default so deployed databases with an applied checksum can start again.
- Keeps the newer overall_folder default in migration 0022, where it belongs as a forward-only schema change.
- Adds a workflow test guard to make the migration split explicit.

## Validation
- php src/migrations/run_migrations.php --validate-files
- php -l tests/Workflows/ProjectWorkflowUiTest.php
- git diff --check