### PR TITLE
Add tax import progress logging

### DIFF
--- a/database/baseline.sql
+++ b/database/baseline.sql
@@ -1383,6 +1383,25 @@ CREATE TABLE IF NOT EXISTS tax_import_files (
     UNIQUE KEY uq_tax_import_file (state_fips, file_type)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS tax_import_runs (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    state_fips VARCHAR(2) NOT NULL,
+    state_abbr VARCHAR(2) NOT NULL,
+    status ENUM('running','completed','failed') NOT NULL DEFAULT 'running',
+    phase VARCHAR(80) NOT NULL DEFAULT 'starting',
+    message VARCHAR(255) NULL,
+    fips_rows INT NOT NULL DEFAULT 0,
+    rate_rows INT NOT NULL DEFAULT 0,
+    boundary_rows INT NOT NULL DEFAULT 0,
+    warning_count INT NOT NULL DEFAULT 0,
+    started_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    completed_at DATETIME NULL,
+    error_message TEXT NULL,
+    INDEX idx_tax_import_runs_state (state_fips, started_at),
+    INDEX idx_tax_import_runs_status (status, updated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- ITEM LIBRARY
 CREATE TABLE IF NOT EXISTS item_library (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/database/migrations/0027_tax_import_run_logging.sql
+++ b/database/migrations/0027_tax_import_run_logging.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS tax_import_runs (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    state_fips VARCHAR(2) NOT NULL,
+    state_abbr VARCHAR(2) NOT NULL,
+    status ENUM('running','completed','failed') NOT NULL DEFAULT 'running',
+    phase VARCHAR(80) NOT NULL DEFAULT 'starting',
+    message VARCHAR(255) NULL,
+    fips_rows INT NOT NULL DEFAULT 0,
+    rate_rows INT NOT NULL DEFAULT 0,
+    boundary_rows INT NOT NULL DEFAULT 0,
+    warning_count INT NOT NULL DEFAULT 0,
+    started_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    completed_at DATETIME NULL,
+    error_message TEXT NULL,
+    INDEX idx_tax_import_runs_state (state_fips, started_at),
+    INDEX idx_tax_import_runs_status (status, updated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/controllers/settings/tax-import-handler.php
+++ b/src/controllers/settings/tax-import-handler.php
@@ -27,8 +27,10 @@ if (empty($_SESSION['csrf']) || !is_string($token) || !hash_equals($_SESSION['cs
 ignore_user_abort(true);
 
 const TAX_IMPORT_BATCH_SIZE = 2000;
+const TAX_IMPORT_SCAN_LOG_INTERVAL = 50000;
 
 try {
+    $runId = 0;
     $stats = [
         'counties_loaded' => 0,
         'fips_reused' => 0,
@@ -60,39 +62,51 @@ try {
     $importStateAbbr = pa_tax_state_abbr_for_fips($importStateFips);
     $_SESSION['tax_import_state'] = $importStateAbbr;
     $stateTaxRate = max(0.0, min(20.0, (float)($_POST['state_tax_rate'] ?? 5.0)));
+    $runId = taxImportStartRun($pdo, $importStateFips, $importStateAbbr);
+    taxImportLog($pdo, $runId, 'validating_uploads', 'Validating uploaded tax source files.');
 
     if ($hasFipsFile) {
+        taxImportLog($pdo, $runId, 'importing_fips', 'Reading selected-state counties from the FIPS file.');
         taxImportValidateFile('fips_file', ['txt']);
-        [$importStateFips, $importStateAbbr] = importFipsFile($pdo, $_FILES['fips_file']['tmp_name'], $stats, $importStateFips);
+        [$importStateFips, $importStateAbbr] = importFipsFile($pdo, $_FILES['fips_file']['tmp_name'], $stats, $importStateFips, $runId);
         taxImportRememberFile($pdo, $importStateFips, 'fips', $_FILES['fips_file'], null);
         $stats['files_uploaded'][] = 'FIPS counties';
+        taxImportLog($pdo, $runId, 'importing_fips', 'FIPS counties imported.', [
+            'fips_rows' => $stats['counties_loaded'],
+            'warning_count' => count($stats['errors']),
+        ]);
     }
 
     if ($hasRateFile) {
+        taxImportLog($pdo, $runId, 'importing_rates', 'Reading active tax jurisdiction rows from the rate file.');
         taxImportValidateFile('rate_file', ['csv']);
-        [$rateStateFips, $rateStateAbbr] = importRateFile($pdo, $_FILES['rate_file']['tmp_name'], $stateTaxRate, $stats, $importStateFips);
+        [$rateStateFips, $rateStateAbbr] = importRateFile($pdo, $_FILES['rate_file']['tmp_name'], $stateTaxRate, $stats, $importStateFips, $runId);
         $importStateFips = $rateStateFips;
         $importStateAbbr = $rateStateAbbr;
         taxImportRememberFile($pdo, $rateStateFips, 'rates', $_FILES['rate_file'], $stateTaxRate);
         $stats['files_uploaded'][] = 'Tax rates';
     } else {
         $stats['files_reused'][] = 'Existing tax rates';
+        taxImportLog($pdo, $runId, 'refreshing_rates', 'No new rate file uploaded; refreshing cached names from stored FIPS counties.');
         refreshTaxRateNamesFromFips($pdo, $importStateFips);
     }
 
     if ($hasBoundaryFile) {
+        taxImportLog($pdo, $runId, 'importing_boundaries', 'Streaming boundary rows into the staging table.');
         taxImportValidateFile('boundary_file', ['csv']);
-        [$boundaryStateFips, $boundaryStateAbbr] = importBoundaryFile($pdo, $_FILES['boundary_file']['tmp_name'], $stats, $importStateFips);
+        [$boundaryStateFips, $boundaryStateAbbr] = importBoundaryFile($pdo, $_FILES['boundary_file']['tmp_name'], $stats, $importStateFips, $runId);
         $importStateFips = $boundaryStateFips;
         $importStateAbbr = $boundaryStateAbbr;
         taxImportRememberFile($pdo, $boundaryStateFips, 'boundaries', $_FILES['boundary_file'], null);
         $stats['files_uploaded'][] = 'Boundaries';
     } else {
         $stats['files_reused'][] = 'Existing boundaries';
+        taxImportLog($pdo, $runId, 'reusing_boundaries', 'No new boundary file uploaded; existing boundary rows remain in place.');
     }
 
     $_SESSION['tax_import_summary'] = buildImportSummary($stats, $importStateAbbr);
     $_SESSION['tax_import_stats'] = $stats;
+    taxImportFinishRun($pdo, $runId, $stats, 'completed');
 
     header('Location: /?page=settings&tab=taxes&import_success=1&tax_state=' . rawurlencode($importStateAbbr));
     exit;
@@ -100,7 +114,11 @@ try {
     if (isset($pdo) && $pdo->inTransaction()) {
         $pdo->rollBack();
     }
-    @error_log('[tax-import] Error: ' . $e->getMessage());
+    if (!empty($runId)) {
+        taxImportFinishRun($pdo, (int)$runId, $stats ?? [], 'failed', $e->getMessage());
+    } else {
+        taxImportServerLog(0, 'failed', $e->getMessage());
+    }
     $stateParam = isset($_SESSION['tax_import_state']) ? '&tax_state=' . rawurlencode((string)$_SESSION['tax_import_state']) : '';
     header('Location: /?page=settings&tab=taxes&import_error=' . rawurlencode($e->getMessage()) . $stateParam);
     exit;
@@ -128,7 +146,7 @@ function taxImportValidateFile(string $field, array $extensions): void
     }
 }
 
-function importFipsFile(PDO $pdo, string $path, array &$stats, string $expectedStateFips): array
+function importFipsFile(PDO $pdo, string $path, array &$stats, string $expectedStateFips, int $runId = 0): array
 {
     $handle = fopen($path, 'rb');
     if (!$handle) {
@@ -188,11 +206,15 @@ function importFipsFile(PDO $pdo, string $path, array &$stats, string $expectedS
         $stats['counties_loaded']++;
     }
     $pdo->commit();
+    taxImportLog($pdo, $runId, 'importing_fips', 'Loaded ' . number_format($stats['counties_loaded']) . ' selected-state FIPS counties.', [
+        'fips_rows' => $stats['counties_loaded'],
+        'warning_count' => count($stats['errors']),
+    ]);
 
     return [$importStateFips, $importStateAbbr];
 }
 
-function importRateFile(PDO $pdo, string $path, float $stateTaxRate, array &$stats, string $expectedStateFips): array
+function importRateFile(PDO $pdo, string $path, float $stateTaxRate, array &$stats, string $expectedStateFips, int $runId = 0): array
 {
     $handle = fopen($path, 'rb');
     if (!$handle) {
@@ -218,6 +240,7 @@ function importRateFile(PDO $pdo, string $path, float $stateTaxRate, array &$sta
         throw new Exception("No FIPS counties stored for {$stateAbbr}. Upload that state's FIPS file before importing rates.");
     }
     $stateAbbr = reset($stateFipsRows)['state_abbr'] ?? $stateAbbr;
+    taxImportLog($pdo, $runId, 'importing_rates', 'Clearing previous imported tax jurisdictions for ' . $stateAbbr . '.');
     $pdo->beginTransaction();
     $pdo->prepare('DELETE FROM tax_jurisdictions WHERE state_fips = ?')->execute([$stateFips]);
 
@@ -230,6 +253,12 @@ function importRateFile(PDO $pdo, string $path, float $stateTaxRate, array &$sta
     );
     while (($parts = fgetcsv($handle)) !== false) {
         $lineNum++;
+        if ($lineNum % TAX_IMPORT_SCAN_LOG_INTERVAL === 0) {
+            taxImportServerLog($runId, 'importing_rates', 'Scanned rate CSV row ' . number_format($lineNum) . '; inserted ' . number_format($stats['jurisdictions_inserted']) . ' active jurisdictions so far.', [
+                'rate_rows' => $stats['jurisdictions_inserted'],
+                'warning_count' => count($stats['errors']),
+            ]);
+        }
         if (count($parts) < 9) {
             $stats['errors'][] = "Rate line {$lineNum}: expected 9 columns, got " . count($parts);
             continue;
@@ -305,6 +334,10 @@ function importRateFile(PDO $pdo, string $path, float $stateTaxRate, array &$sta
 
         if ($batch >= TAX_IMPORT_BATCH_SIZE) {
             $pdo->commit();
+            taxImportLog($pdo, $runId, 'importing_rates', 'Processed rate CSV row ' . number_format($lineNum) . '; inserted ' . number_format($stats['jurisdictions_inserted']) . ' active jurisdictions.', [
+                'rate_rows' => $stats['jurisdictions_inserted'],
+                'warning_count' => count($stats['errors']),
+            ]);
             $pdo->beginTransaction();
             $batch = 0;
         }
@@ -320,10 +353,19 @@ function importRateFile(PDO $pdo, string $path, float $stateTaxRate, array &$sta
     if ($pdo->inTransaction()) {
         $pdo->commit();
     }
+    taxImportLog($pdo, $runId, 'importing_rates', 'Finished reading rate CSV row ' . number_format($lineNum) . '; inserted ' . number_format($stats['jurisdictions_inserted']) . ' active jurisdictions.', [
+        'rate_rows' => $stats['jurisdictions_inserted'],
+        'warning_count' => count($stats['errors']),
+    ]);
 
+    taxImportLog($pdo, $runId, 'refreshing_cached_rates', 'Mirroring county totals into the tax rate list.');
     $stats['county_rates_mirrored'] = rebuildCountyTaxRateMirror($pdo, $stateFips, $stateAbbr, $hasCountry, $hasDefault);
     summarizeCountyRates($pdo, $stateFips, $stats);
     addCountyRateSanityWarnings($pdo, $stateFips, $stats);
+    taxImportLog($pdo, $runId, 'refreshing_cached_rates', 'Mirrored ' . number_format($stats['county_rates_mirrored']) . ' county tax rates.', [
+        'rate_rows' => $stats['jurisdictions_inserted'],
+        'warning_count' => count($stats['errors']),
+    ]);
 
     return [$stateFips, $stateAbbr];
 }
@@ -435,7 +477,7 @@ function addCountyRateSanityWarnings(PDO $pdo, string $stateFips, array &$stats)
     }
 }
 
-function importBoundaryFile(PDO $pdo, string $path, array &$stats, string $expectedStateFips): array
+function importBoundaryFile(PDO $pdo, string $path, array &$stats, string $expectedStateFips, int $runId = 0): array
 {
     $handle = fopen($path, 'rb');
     if (!$handle) {
@@ -445,6 +487,7 @@ function importBoundaryFile(PDO $pdo, string $path, array &$stats, string $expec
     $batchKey = bin2hex(random_bytes(12));
     $stateFips = $expectedStateFips;
     $stateAbbr = pa_tax_state_abbr_for_fips($expectedStateFips);
+    $lineNum = 0;
     $rowCount = 0;
     $batch = 0;
 
@@ -457,6 +500,13 @@ function importBoundaryFile(PDO $pdo, string $path, array &$stats, string $expec
 
     $pdo->beginTransaction();
     while (($row = fgetcsv($handle)) !== false) {
+        $lineNum++;
+        if ($lineNum % TAX_IMPORT_SCAN_LOG_INTERVAL === 0) {
+            taxImportServerLog($runId, 'importing_boundaries', 'Scanned boundary CSV row ' . number_format($lineNum) . '; staged ' . number_format($rowCount) . ' selected-state rows so far.', [
+                'boundary_rows' => $rowCount,
+                'warning_count' => count($stats['errors']),
+            ]);
+        }
         if (count($row) < 26 || trim((string)$row[0]) !== '4') {
             continue;
         }
@@ -493,6 +543,10 @@ function importBoundaryFile(PDO $pdo, string $path, array &$stats, string $expec
 
         if ($batch >= TAX_IMPORT_BATCH_SIZE) {
             $pdo->commit();
+            taxImportLog($pdo, $runId, 'importing_boundaries', 'Streamed ' . number_format($rowCount) . ' selected-state boundary rows into staging.', [
+                'boundary_rows' => $rowCount,
+                'warning_count' => count($stats['errors']),
+            ]);
             $pdo->beginTransaction();
             $batch = 0;
         }
@@ -501,12 +555,17 @@ function importBoundaryFile(PDO $pdo, string $path, array &$stats, string $expec
     if ($pdo->inTransaction()) {
         $pdo->commit();
     }
+    taxImportLog($pdo, $runId, 'importing_boundaries', 'Finished staging ' . number_format($rowCount) . ' selected-state boundary rows.', [
+        'boundary_rows' => $rowCount,
+        'warning_count' => count($stats['errors']),
+    ]);
 
     if ($rowCount === 0) {
         $pdo->prepare('DELETE FROM tax_boundaries_stage WHERE batch_key = ?')->execute([$batchKey]);
         throw new Exception('No usable boundary rows found for selected state ' . $stateAbbr . '.');
     }
 
+    taxImportLog($pdo, $runId, 'publishing_boundaries', 'Replacing live boundary rows for ' . $stateAbbr . '.');
     $pdo->beginTransaction();
     $pdo->prepare('DELETE FROM tax_boundaries WHERE state_fips = ?')->execute([$stateFips]);
     $pdo->prepare(
@@ -542,6 +601,10 @@ function importBoundaryFile(PDO $pdo, string $path, array &$stats, string $expec
     $pdo->commit();
 
     $stats['boundaries_imported'] = $rowCount;
+    taxImportLog($pdo, $runId, 'publishing_boundaries', 'Published ' . number_format($rowCount) . ' boundary rows and flagged ' . number_format($stats['complex_zips']) . ' complex ZIPs.', [
+        'boundary_rows' => $rowCount,
+        'warning_count' => count($stats['errors']),
+    ]);
     return [$stateFips, $stateAbbr];
 }
 
@@ -614,6 +677,94 @@ function taxImportRememberFile(PDO $pdo, string $stateFips, string $fileType, ar
         (int)($file['size'] ?? 0),
         $stateTaxRate,
     ]);
+}
+
+function taxImportStartRun(PDO $pdo, string $stateFips, string $stateAbbr): int
+{
+    $stmt = $pdo->prepare(
+        'INSERT INTO tax_import_runs
+            (state_fips, state_abbr, status, phase, message, started_at, updated_at)
+         VALUES (?, ?, "running", "starting", "Tax import queued.", NOW(), NOW())'
+    );
+    try {
+        $stmt->execute([$stateFips, $stateAbbr]);
+        $runId = (int)$pdo->lastInsertId();
+    } catch (Throwable $e) {
+        taxImportServerLog(0, 'starting', 'Could not create import run record: ' . $e->getMessage());
+        return 0;
+    }
+    taxImportServerLog($runId, 'starting', 'Tax import started for ' . $stateAbbr . '.');
+    return $runId;
+}
+
+function taxImportLog(PDO $pdo, int $runId, string $phase, string $message, array $counts = [], string $status = 'running'): void
+{
+    taxImportServerLog($runId, $phase, $message, $counts);
+    if ($runId <= 0) {
+        return;
+    }
+
+    $allowedCounts = [
+        'fips_rows' => true,
+        'rate_rows' => true,
+        'boundary_rows' => true,
+        'warning_count' => true,
+    ];
+    $sets = ['status = ?', 'phase = ?', 'message = ?', 'updated_at = NOW()'];
+    $params = [$status, substr($phase, 0, 80), substr($message, 0, 255)];
+    foreach ($counts as $column => $value) {
+        if (isset($allowedCounts[$column])) {
+            $sets[] = $column . ' = ?';
+            $params[] = max(0, (int)$value);
+        }
+    }
+    $params[] = $runId;
+
+    try {
+        $stmt = $pdo->prepare('UPDATE tax_import_runs SET ' . implode(', ', $sets) . ' WHERE id = ?');
+        $stmt->execute($params);
+    } catch (Throwable $e) {
+        taxImportServerLog($runId, 'logging_failed', $e->getMessage());
+    }
+}
+
+function taxImportFinishRun(PDO $pdo, int $runId, array $stats, string $status, ?string $error = null): void
+{
+    $message = $status === 'completed'
+        ? 'Import completed.'
+        : 'Import failed: ' . (string)$error;
+    taxImportLog($pdo, $runId, $status, $message, [
+        'fips_rows' => (int)($stats['counties_loaded'] ?? 0),
+        'rate_rows' => (int)($stats['jurisdictions_inserted'] ?? 0),
+        'boundary_rows' => (int)($stats['boundaries_imported'] ?? 0),
+        'warning_count' => count($stats['errors'] ?? []),
+    ], $status);
+
+    if ($runId <= 0) {
+        return;
+    }
+
+    try {
+        $stmt = $pdo->prepare(
+            'UPDATE tax_import_runs
+             SET completed_at = NOW(),
+                 error_message = ?
+             WHERE id = ?'
+        );
+        $stmt->execute([$error, $runId]);
+    } catch (Throwable $e) {
+        taxImportServerLog($runId, 'logging_failed', $e->getMessage());
+    }
+}
+
+function taxImportServerLog(int $runId, string $phase, string $message, array $counts = []): void
+{
+    $parts = [];
+    foreach ($counts as $key => $value) {
+        $parts[] = $key . '=' . (int)$value;
+    }
+    $suffix = $parts ? ' (' . implode(', ', $parts) . ')' : '';
+    @error_log('[tax-import][' . ($runId > 0 ? (string)$runId : 'no-run') . '][' . $phase . '] ' . $message . $suffix);
 }
 
 function ensureTablesExist(PDO $pdo): void
@@ -729,6 +880,25 @@ function ensureTablesExist(PDO $pdo): void
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         UNIQUE KEY uq_tax_import_file (state_fips, file_type)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+    $pdo->exec("CREATE TABLE IF NOT EXISTS tax_import_runs (
+        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+        state_fips VARCHAR(2) NOT NULL,
+        state_abbr VARCHAR(2) NOT NULL,
+        status ENUM('running','completed','failed') NOT NULL DEFAULT 'running',
+        phase VARCHAR(80) NOT NULL DEFAULT 'starting',
+        message VARCHAR(255) NULL,
+        fips_rows INT NOT NULL DEFAULT 0,
+        rate_rows INT NOT NULL DEFAULT 0,
+        boundary_rows INT NOT NULL DEFAULT 0,
+        warning_count INT NOT NULL DEFAULT 0,
+        started_at DATETIME NOT NULL,
+        updated_at DATETIME NOT NULL,
+        completed_at DATETIME NULL,
+        error_message TEXT NULL,
+        INDEX idx_tax_import_runs_state (state_fips, started_at),
+        INDEX idx_tax_import_runs_status (status, updated_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
 }
 

--- a/src/views/pages/settings/taxes.php
+++ b/src/views/pages/settings/taxes.php
@@ -18,6 +18,7 @@ $editTaxId = (int)($_GET['edit_tax_id'] ?? 0);
 $taxRates = [];
 $taxImportStates = pa_tax_state_options();
 $taxImportStatus = [];
+$taxImportRuns = [];
 foreach ($taxImportStates as $stateOption) {
   $taxImportStatus[$stateOption['fips']] = [
     'state' => $stateOption,
@@ -54,6 +55,16 @@ try {
   }
 } catch (Throwable $e) {
   // ignore if import cache is not created yet
+}
+try {
+  $taxImportRuns = $pdo->query(
+    "SELECT id, state_fips, state_abbr, status, phase, message, fips_rows, rate_rows, boundary_rows, warning_count, started_at, updated_at, completed_at, error_message
+     FROM tax_import_runs
+     ORDER BY started_at DESC, id DESC
+     LIMIT 8"
+  )->fetchAll(PDO::FETCH_ASSOC);
+} catch (Throwable $e) {
+  // ignore if import runs table is not created yet
 }
 foreach ([
   'counties' => 'SELECT state_fips, COUNT(*) AS row_count FROM fips_counties GROUP BY state_fips',
@@ -317,6 +328,58 @@ $selectedStateTaxRateValue = $selectedRateFile && $selectedRateFile['state_tax_r
         </table>
       </div>
     </div>
+
+    <?php if ($taxImportRuns): ?>
+      <div style="margin-bottom:18px;border:1px solid #e5e7eb;border-radius:8px;overflow:hidden">
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 14px;background:#f9fafb;border-bottom:1px solid #e5e7eb">
+          <div>
+            <div style="font-weight:600;color:#374151">Recent Import Runs</div>
+            <div style="font-size:12px;color:#6b7280;margin-top:2px">Refresh this page to see the latest database progress. Server logs also include <code>[tax-import]</code> entries.</div>
+          </div>
+        </div>
+        <div style="overflow:auto">
+          <table class="pa-table">
+            <thead style="background:#f9fafb">
+              <tr style="text-align:left;border-bottom:1px solid #e5e7eb">
+                <th style="padding:10px 12px">State</th>
+                <th style="padding:10px 12px">Status</th>
+                <th style="padding:10px 12px">Phase</th>
+                <th style="padding:10px 12px">Rows</th>
+                <th style="padding:10px 12px">Message</th>
+                <th style="padding:10px 12px">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($taxImportRuns as $run): ?>
+                <?php
+                  $status = (string)($run['status'] ?? '');
+                  $statusStyle = match ($status) {
+                    'completed' => 'background:#d1fae5;color:#065f46',
+                    'failed' => 'background:#fee2e2;color:#991b1b',
+                    default => 'background:#dbeafe;color:#1e40af',
+                  };
+                  $rowCounts = 'FIPS ' . number_format((int)($run['fips_rows'] ?? 0))
+                    . ' | Rates ' . number_format((int)($run['rate_rows'] ?? 0))
+                    . ' | Boundaries ' . number_format((int)($run['boundary_rows'] ?? 0))
+                    . ' | Warnings ' . number_format((int)($run['warning_count'] ?? 0));
+                  $message = $run['error_message'] ?: ($run['message'] ?? '');
+                ?>
+                <tr style="border-bottom:1px solid #f3f4f6">
+                  <td style="padding:10px 12px;font-weight:600;white-space:nowrap"><?php echo htmlspecialchars((string)$run['state_abbr']); ?></td>
+                  <td style="padding:10px 12px;white-space:nowrap">
+                    <span style="padding:4px 8px;border-radius:6px;font-size:12px;font-weight:600;<?php echo $statusStyle; ?>"><?php echo htmlspecialchars(ucfirst($status)); ?></span>
+                  </td>
+                  <td style="padding:10px 12px;white-space:nowrap"><?php echo htmlspecialchars(str_replace('_', ' ', (string)$run['phase'])); ?></td>
+                  <td style="padding:10px 12px;font-size:12px;white-space:nowrap;color:#374151"><?php echo htmlspecialchars($rowCounts); ?></td>
+                  <td style="padding:10px 12px;min-width:220px;color:#374151"><?php echo htmlspecialchars((string)$message); ?></td>
+                  <td style="padding:10px 12px;white-space:nowrap;color:#6b7280;font-size:12px"><?php echo htmlspecialchars((string)$run['updated_at']); ?></td>
+                </tr>
+              <?php endforeach; ?>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    <?php endif; ?>
     
     <?php if ($importSuccess && $importSummary): ?>
       <div style="margin-bottom:16px;padding:12px;background:#ecfdf5;border:1px solid #a7f3d0;border-radius:6px">

--- a/tests/Workflows/TaxImportBackendTest.php
+++ b/tests/Workflows/TaxImportBackendTest.php
@@ -19,8 +19,15 @@ final class TaxImportBackendTest extends TestCase
 
         self::assertIsString($handler);
         self::assertStringContainsString('TAX_IMPORT_BATCH_SIZE', $handler);
+        self::assertStringContainsString('TAX_IMPORT_SCAN_LOG_INTERVAL', $handler);
         self::assertStringContainsString('set_time_limit(0)', $handler);
         self::assertStringContainsString('tax_boundaries_stage', $handler);
+        self::assertStringContainsString('tax_import_runs', $handler);
+        self::assertStringContainsString('taxImportLog', $handler);
+        self::assertStringContainsString('[tax-import]', $handler);
+        self::assertStringContainsString('Processed rate CSV row', $handler);
+        self::assertStringContainsString('Scanned boundary CSV row', $handler);
+        self::assertStringContainsString('Streamed ', $handler);
         self::assertStringContainsString('batch_key', $handler);
         self::assertStringContainsString('fgetcsv($handle)', $handler);
         self::assertStringContainsString('Upload at least one FIPS, tax rate, or boundary file.', $handler);
@@ -44,6 +51,8 @@ final class TaxImportBackendTest extends TestCase
         self::assertStringContainsString('Reused when omitted', $view);
         self::assertStringContainsString('name="tax_state"', $view);
         self::assertStringContainsString('Imported State Coverage', $view);
+        self::assertStringContainsString('Recent Import Runs', $view);
+        self::assertStringContainsString('[tax-import]', $view);
         self::assertStringContainsString('PA imports and replaces rows only for this selected state.', $view);
         self::assertStringNotContainsString('name="fips_file" accept=".txt" required', $view);
         self::assertStringNotContainsString('name="rate_file" accept=".csv" required', $view);
@@ -140,6 +149,8 @@ final class TaxImportBackendTest extends TestCase
         self::assertStringContainsString('country VARCHAR(100) NULL DEFAULT', $baseline);
         self::assertStringContainsString('is_active TINYINT(1) NOT NULL DEFAULT 1', $baseline);
         self::assertStringContainsString('uq_tax_zip_complexity_state_zip', $baseline);
+        self::assertStringContainsString('tax_import_runs', $baseline);
+        self::assertStringContainsString('tax_import_runs', file_get_contents($this->root . '/database/migrations/0027_tax_import_run_logging.sql'));
     }
 
     public function testTaxStateHelpersNormalizeNamesAndAbbreviations(): void


### PR DESCRIPTION
Summary: Adds durable tax import run records, server log progress with [tax-import] prefixes, large CSV scan ticks, and a Recent Import Runs panel on the Tax settings page. Validation: php -l on changed PHP files, migration file validation, and git diff --check. Note: local PHPUnit remains blocked by the existing vendor issue: Class PHPUnit\\TextUI\\Application not found.