### PR TITLE
Fix standalone client invoice links

### DIFF
--- a/src/utils/invoice_links.php
+++ b/src/utils/invoice_links.php
@@ -120,6 +120,49 @@ function pa_invoice_links_for_context(
         return [];
     }
 
+    $links = pa_invoice_links_query_for_context(
+        $pdo,
+        $projectId,
+        $organizationId,
+        $departmentId,
+        $primaryClientId,
+        $recipientClientIds
+    );
+    if ($links) {
+        return $links;
+    }
+
+    pa_invoice_links_run_just_in_time_refresh(
+        $pdo,
+        $projectId,
+        $organizationId,
+        $departmentId,
+        $primaryClientId,
+        $recipientClientIds
+    );
+
+    return pa_invoice_links_query_for_context(
+        $pdo,
+        $projectId,
+        $organizationId,
+        $departmentId,
+        $primaryClientId,
+        $recipientClientIds
+    );
+}
+
+/**
+ * @return list<array{id:int,title:?string,url:string,link_type:string,entity_type:string,entity_id:int,source_label:string}>
+ */
+function pa_invoice_links_query_for_context(
+    PDO $pdo,
+    ?int $projectId,
+    ?int $organizationId,
+    ?int $departmentId,
+    ?int $primaryClientId,
+    ?array $recipientClientIds
+): array {
+
     $projectSpecificEnabled = (string)pa_config_value($pdo, 'project_specific_links_enabled', '0') === '1';
     $candidateClauses = [];
     $params = [];
@@ -223,6 +266,61 @@ function pa_invoice_links_for_context(
     }
 
     return $links;
+}
+
+function pa_invoice_links_run_just_in_time_refresh(
+    PDO $pdo,
+    ?int $projectId,
+    ?int $organizationId,
+    ?int $departmentId,
+    ?int $primaryClientId,
+    ?array $recipientClientIds
+): void {
+    if ((string)pa_config_value($pdo, 'link_resolver_invoice_auto_attach_enabled', '0') !== '1') {
+        return;
+    }
+    if ((string)pa_config_value($pdo, 'link_resolver_enabled', '0') !== '1') {
+        return;
+    }
+
+    $servicePath = __DIR__ . '/../services/LinkResolverService.php';
+    if (!is_file($servicePath)) {
+        return;
+    }
+    require_once $servicePath;
+    if (!class_exists('LinkResolverService')) {
+        return;
+    }
+
+    try {
+        $service = new LinkResolverService($pdo);
+        if ($departmentId) {
+            $service->refreshLinks('department', $departmentId);
+            return;
+        }
+        if ($organizationId) {
+            $service->refreshLinks('organization', $organizationId);
+            return;
+        }
+
+        $clientIds = [];
+        if ($recipientClientIds !== null) {
+            $clientIds = array_values(array_unique(array_filter(array_map('intval', $recipientClientIds), static fn($id) => $id > 0)));
+        } elseif ($primaryClientId) {
+            $clientIds[] = $primaryClientId;
+        }
+        if ($projectId && pa_table_has_column($pdo, 'project_clients', 'can_view_invoice_links')) {
+            $stmt = $pdo->prepare('SELECT client_id FROM project_clients WHERE project_id = ? AND can_view_invoice_links = 1');
+            $stmt->execute([$projectId]);
+            $clientIds = array_values(array_unique(array_map('intval', array_merge($clientIds, $stmt->fetchAll(PDO::FETCH_COLUMN)))));
+        }
+
+        foreach ($clientIds as $clientId) {
+            $service->refreshLinks('client', $clientId);
+        }
+    } catch (Throwable $e) {
+        @error_log('[invoice_links] Just-in-time link resolver refresh failed: ' . $e->getMessage());
+    }
 }
 
 function pa_invoice_links_html(array $links): string

--- a/src/views/pages/settings/links.php
+++ b/src/views/pages/settings/links.php
@@ -157,7 +157,7 @@ $dropboxCallbackUri = rtrim($dropboxCallbackBase, '/') . '/?page=settings/dropbo
             <label style="display:flex;align-items:flex-start;gap:10px">
                 <input type="checkbox" name="link_resolver_invoice_auto_attach_enabled" value="1" <?php echo !empty($appConfig['link_resolver_invoice_auto_attach_enabled']) ? 'checked' : ''; ?> style="margin-top:3px">
                 <span>
-                    <span class="font-600">Just-in-time invoice link scan<?php echo $helpIcon('Before emailing an invoice, PA may check only the relevant org/department if the invoice has no content links.'); ?></span>
+                    <span class="font-600">Just-in-time invoice link scan<?php echo $helpIcon('Before emailing an invoice, PA may check the relevant department, organization, or standalone client if the invoice has no content links.'); ?></span>
                     <span class="pa-setting-note">Ambiguous matches must be reviewed instead of auto-attached.</span>
                 </span>
             </label>

--- a/tests/Workflows/InvoiceContentLinksTest.php
+++ b/tests/Workflows/InvoiceContentLinksTest.php
@@ -44,6 +44,9 @@ final class InvoiceContentLinksTest extends TestCase
         foreach (array_reverse($this->ids['project_invoices'] ?? []) as $id) {
             $this->pdo->prepare('DELETE FROM project_invoices WHERE id = ?')->execute([$id]);
         }
+        foreach (array_reverse($this->ids['invoices'] ?? []) as $id) {
+            $this->pdo->prepare('DELETE FROM invoices WHERE id = ?')->execute([$id]);
+        }
         foreach (array_reverse($this->ids['projects'] ?? []) as $id) {
             $this->pdo->prepare('DELETE FROM projects WHERE id = ?')->execute([$id]);
         }
@@ -211,6 +214,18 @@ final class InvoiceContentLinksTest extends TestCase
         $this->assertSame([], invoice_content_links_for_project_invoice($this->pdo, $projectInvoiceId));
     }
 
+    public function testStandaloneClientInvoiceUsesClientContentLinks(): void
+    {
+        $suffix = bin2hex(random_bytes(5));
+        $clientId = $this->insertClient('Standalone Client ' . $suffix, null, 'standalone-' . $suffix . '@example.invalid');
+        $invoiceId = $this->insertInvoice($clientId);
+        $this->insertLink('client', $clientId, 'Standalone folder', 'https://example.invalid/standalone-' . $suffix, 'manual_dropbox', 'entity_only');
+
+        $urls = array_column(invoice_content_links_for_invoice($this->pdo, $invoiceId), 'url');
+
+        $this->assertContains('https://example.invalid/standalone-' . $suffix, $urls, 'Standalone clients without an organization should still pull client links.');
+    }
+
     public function testMissingContentLinksWarningIsEnforcedBeforeEmailSend(): void
     {
         $emailSend = file_get_contents(dirname(__DIR__, 2) . '/src/controllers/email_send.php');
@@ -220,8 +235,12 @@ final class InvoiceContentLinksTest extends TestCase
         $invoiceDetails = file_get_contents(dirname(__DIR__, 2) . '/src/views/pages/invoice/invoice-details.php');
         $projectInvoiceDetails = file_get_contents(dirname(__DIR__, 2) . '/src/views/pages/project/project-invoice-details.php');
         $contentLinks = file_get_contents(dirname(__DIR__, 2) . '/src/utils/invoice_content_links.php');
+        $invoiceLinks = file_get_contents(dirname(__DIR__, 2) . '/src/utils/invoice_links.php');
 
         self::assertStringContainsString('invoice_missing_content_links_behavior', (string)$contentLinks);
+        self::assertStringContainsString('link_resolver_invoice_auto_attach_enabled', (string)$invoiceLinks);
+        self::assertStringContainsString('pa_invoice_links_run_just_in_time_refresh', (string)$invoiceLinks);
+        self::assertStringContainsString('refreshLinks(\'client\'', (string)$invoiceLinks);
         self::assertStringContainsString('invoice_should_prompt_for_missing_content_links', (string)$emailSend);
         self::assertStringContainsString('confirm_missing_content_links', (string)$emailSend);
         self::assertStringContainsString('invoice_should_prompt_for_missing_content_links', (string)$projectEmail);
@@ -257,11 +276,22 @@ final class InvoiceContentLinksTest extends TestCase
         return $this->remember('departments', (int)$this->pdo->lastInsertId());
     }
 
-    private function insertClient(string $name, int $organizationId, string $email): int
+    private function insertClient(string $name, ?int $organizationId, string $email): int
     {
         $stmt = $this->pdo->prepare('INSERT INTO clients (name, email, organization_id) VALUES (?, ?, ?)');
         $stmt->execute([$name, $email, $organizationId]);
         return $this->remember('clients', (int)$this->pdo->lastInsertId());
+    }
+
+    private function insertInvoice(int $clientId): int
+    {
+        $stmt = $this->pdo->prepare('
+            INSERT INTO invoices
+                (client_id, status, billing_mode, subtotal, total, balance_due, collection_mode, finalized_at)
+            VALUES (?, "sent", "fixed", 100, 100, 100, "direct", NOW())
+        ');
+        $stmt->execute([$clientId]);
+        return $this->remember('invoices', (int)$this->pdo->lastInsertId());
     }
 
     private function insertProject(int $organizationId, int $departmentId, int $clientId, string $name): int

--- a/tests/Workflows/LinkResolverServiceTest.php
+++ b/tests/Workflows/LinkResolverServiceTest.php
@@ -228,6 +228,27 @@ final class LinkResolverServiceTest extends TestCase
         self::assertSame(0, $this->countLinks('client', $clientId));
     }
 
+    public function testStandaloneClientAutoGenerationAttachesClientFolder(): void
+    {
+        $clientName = 'Standalone Client ' . bin2hex(random_bytes(3));
+        $clientId = $this->insertClient(null, $clientName);
+        $service = $this->service(new FakeResolverProvider([
+            $clientName => [
+                ['folder_id' => '/' . $clientName, 'name' => $clientName, 'path' => '/' . $clientName],
+            ],
+        ]));
+
+        $result = $service->autoGenerateForClient($clientId);
+
+        self::assertTrue($result['success'], json_encode($result));
+        $link = $this->fetchOneLink('client', $clientId);
+        $this->remember('links', (int)$link['id']);
+        self::assertSame('auto_dropbox', $link['link_type']);
+        self::assertSame('resolver', $link['link_source']);
+        self::assertSame(1, (int)$link['include_on_invoices']);
+        self::assertSame('https://example.invalid/' . $clientName, $link['url']);
+    }
+
     private function service(FakeResolverProvider $provider): LinkResolverService
     {
         return new LinkResolverService($this->pdo, static fn(string $name, array $credentials): object => $provider);
@@ -260,7 +281,7 @@ final class LinkResolverServiceTest extends TestCase
         return $this->remember('departments', (int)$this->pdo->lastInsertId());
     }
 
-    private function insertClient(int $orgId, string $name): int
+    private function insertClient(?int $orgId, string $name): int
     {
         $stmt = $this->pdo->prepare('INSERT INTO clients (name, email, organization_id) VALUES (?, ?, ?)');
         $stmt->execute([$name, strtolower(str_replace(' ', '-', $name)) . '-' . bin2hex(random_bytes(3)) . '@example.invalid', $orgId]);


### PR DESCRIPTION
## Summary
- let invoice content link lookup run the just-in-time resolver when no eligible links exist
- include standalone clients in that just-in-time refresh path while preserving org/department priority
- update link settings help text and add workflow coverage for standalone client links

## Root cause
Standalone clients could have eligible client links, but the invoice lookup never invoked the configured just-in-time resolver when no links were already stored. Org and department paths worked because those links were being created elsewhere.

## Validation
- php -l src/utils/invoice_links.php
- php -l src/views/pages/settings/links.php
- php -l tests/Workflows/InvoiceContentLinksTest.php
- php -l tests/Workflows/LinkResolverServiceTest.php
- php src/migrations/run_migrations.php --validate-files
- git diff --check

Focused PHPUnit was attempted, but the local vendor install fails before tests run with PHPUnit TextUI Application not found.