### PR TITLE
Fix recurring contract workflows and scheduled backups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           docker compose -f docker-compose.yml config >/tmp/compose.prod.yml
           docker compose -f docker-compose.yml -f docker-compose.override.yml config >/tmp/compose.local.yml
+          docker compose -f docker-compose.truenas.yml config >/tmp/compose.truenas.yml
 
       - name: Validate Compose configuration
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,11 +121,12 @@ COPY ./database/ /var/www/database/
 COPY ./public/ /var/www/public/
 COPY ./cron/ /var/www/cron/
 COPY ./docker/ /var/www/docker/
+COPY ./docker-compose.truenas.yml /var/www/docker-compose.truenas.yml
 COPY ./.github/ /var/www/.github/
 COPY ./SECURITY.md /var/www/SECURITY.md
 RUN mkdir -p /var/www/config
 COPY ./config/.env.example /var/www/config/.env.example
-RUN chown -R www-data:www-data /var/www/vendor /var/www/tests /var/www/database /var/www/public /var/www/cron /var/www/docker /var/www/.github /var/www/config /var/www/phpunit.xml /var/www/composer.json /var/www/composer.lock /var/www/SECURITY.md
+RUN chown -R www-data:www-data /var/www/vendor /var/www/tests /var/www/database /var/www/public /var/www/cron /var/www/docker /var/www/docker-compose.truenas.yml /var/www/.github /var/www/config /var/www/phpunit.xml /var/www/composer.json /var/www/composer.lock /var/www/SECURITY.md
 
 # ---------- Stage 3: Cron service ----------
 # Uses the same vendor stage as web. Source code is volume-mounted at runtime.

--- a/cron/README.md
+++ b/cron/README.md
@@ -2,7 +2,7 @@
 
 The cron image runs Project Alpha's scheduled PHP jobs independently from Apache. The current schedule is installed from `cron/crontab` and uses the PA system timezone loaded from `app_config.timezone` when the cron container starts.
 
-On container startup, the entrypoint also runs `stripe_reconciliation.php --startup` once before starting cron. This catches recent Stripe payments after downtime, while the normal six-hour schedule continues to reconcile missed webhooks.
+On container startup, the entrypoint runs a scheduled backup catch-up check and `stripe_reconciliation.php --startup` before starting cron. The backup check creates today's missing backup when the configured backup time has already passed. Stripe reconciliation catches recent payments after downtime, while the normal six-hour schedule continues to reconcile missed webhooks.
 
 ## Installed Schedule
 
@@ -56,6 +56,8 @@ The container schedule always starts with the service. Individual scripts also h
 - invoice email-on-generation toggle
 - Stripe and SMTP configuration
 
+Database backups are infrastructure protection and do not depend on the automatic-invoice `cron_enabled` setting.
+
 ## Troubleshooting
 
 1. Confirm the cron service is running and connected to MySQL.
@@ -64,5 +66,6 @@ The container schedule always starts with the service. Individual scripts also h
 4. Run the affected PHP script manually in the cron container.
 5. Confirm the configuration and encryption-key volumes are mounted.
 6. Confirm the deployed cron tag matches the intended branch.
+7. Confirm `/etc/cron.d/project-alpha` includes `/usr/local/bin` in `PATH`; otherwise the official PHP image's executable is not available to cron jobs.
 
 Do not paste production logs into a public issue without removing credentials and customer information.

--- a/cron/crontab
+++ b/cron/crontab
@@ -3,6 +3,7 @@
 # so they are available to cron jobs via the shell wrapper below.
 
 SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Unified log file for all cron jobs
 CRON_LOG=/var/www/config/logs/cron/cron.log

--- a/cron/entrypoint.sh
+++ b/cron/entrypoint.sh
@@ -18,13 +18,15 @@ fi
 # ── Export environment variables so cron jobs can access them ──
 # Cron does NOT inherit the container's env vars, so we dump them
 # to /etc/environment which each cron job sources before running.
-printenv | awk -F= '
-  /^(MYSQL_|DB_|APP_|STRIPE_|SMTP_|BACKUP_)/ {
-    value = substr($0, index($0, "=") + 1)
-    gsub(/"/, "\\\"", value)
-    print $1 "=\"" value "\""
-  }
-' > /etc/environment
+ENV_FILE="/etc/environment"
+: > "$ENV_FILE"
+while IFS='=' read -r name value; do
+  case "$name" in
+    MYSQL_*|DB_*|APP_*|STRIPE_*|SMTP_*|BACKUP_*)
+      printf 'export %s=%q\n' "$name" "$value" >> "$ENV_FILE"
+      ;;
+  esac
+done < <(printenv)
 
 # ── Create log directory if it doesn't exist ──
 LOG_DIR="/var/www/config/logs/cron"
@@ -107,9 +109,12 @@ else
   echo "[cron-entrypoint] Timezone '${APP_TIMEZONE}' is unavailable; using UTC."
 fi
 
-grep -v '^TZ=' /etc/environment > /tmp/project-alpha-environment || true
-echo "TZ=\"${TZ}\"" >> /tmp/project-alpha-environment
-mv /tmp/project-alpha-environment /etc/environment
+grep -vE '^(export[[:space:]]+)?TZ=' "$ENV_FILE" > /tmp/project-alpha-environment || true
+printf 'export TZ=%q\n' "$TZ" >> /tmp/project-alpha-environment
+mv /tmp/project-alpha-environment "$ENV_FILE"
+
+echo "[cron-entrypoint] Running startup scheduled backup check..."
+php /var/www/src/cron/backup_database.php --scheduled || echo "[cron-entrypoint] Startup scheduled backup check failed; cron will retry at the next hourly check."
 
 echo "[cron-entrypoint] Running startup Stripe reconciliation..."
 php /var/www/src/cron/stripe_reconciliation.php --startup || echo "[cron-entrypoint] Startup Stripe reconciliation failed; cron will continue."

--- a/database/migrations/0028_repair_open_ended_long_term_contract_status.sql
+++ b/database/migrations/0028_repair_open_ended_long_term_contract_status.sql
@@ -1,0 +1,20 @@
+-- Restore open-ended recurring contracts that were incorrectly completed when
+-- one of their invoices was paid. Legitimate termination records have an end
+-- date; fixed-total contracts may also complete after their final installment
+-- is generated, so both are intentionally excluded.
+UPDATE contracts
+SET status = 'active'
+WHERE contract_type = 'long_term'
+  AND pricing_type = 'per_invoice'
+  AND status = 'completed'
+  AND completed_at IS NULL
+  AND end_date IS NULL
+  AND next_invoice_date IS NOT NULL;
+
+-- Older recurring invoices were created as unpaid without initializing their
+-- stored balance. Recalculate only collectible recurring invoices; paid and
+-- terminal invoice history remains untouched.
+UPDATE invoices
+SET balance_due = GREATEST(total - amount_paid, 0)
+WHERE invoice_type = 'long_term'
+  AND status IN ('sent', 'unpaid', 'partial', 'overdue');

--- a/database/migrations/0029_long_term_recurring_services.sql
+++ b/database/migrations/0029_long_term_recurring_services.sql
@@ -1,0 +1,83 @@
+-- Effective-dated recurring services let one long-term agreement carry
+-- independently scheduled charges (for example annual hosting plus monthly
+-- advertising management) without rewriting historical invoices.
+CREATE TABLE IF NOT EXISTS contract_recurring_services (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    contract_id INT NOT NULL,
+    name VARCHAR(190) NOT NULL,
+    description TEXT NULL,
+    amount DECIMAL(12,2) NOT NULL DEFAULT 0,
+    billing_interval_count INT NOT NULL DEFAULT 1,
+    billing_interval_unit ENUM('day','week','month','year') NOT NULL DEFAULT 'month',
+    effective_from DATE NOT NULL,
+    effective_until DATE NULL,
+    next_invoice_date DATE NULL,
+    last_invoice_date DATE NULL,
+    status ENUM('pending','active','paused','ended') NOT NULL DEFAULT 'pending',
+    approval_status ENUM('pending','approved','rejected') NOT NULL DEFAULT 'pending',
+    is_base TINYINT(1) NOT NULL DEFAULT 0,
+    created_by INT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_crs_contract (contract_id),
+    INDEX idx_crs_due (status, approval_status, next_invoice_date),
+    INDEX idx_crs_effective (effective_from, effective_until),
+    CONSTRAINT fk_crs_contract FOREIGN KEY (contract_id) REFERENCES contracts(id) ON DELETE CASCADE,
+    CONSTRAINT fk_crs_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS contract_amendments (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    contract_id INT NOT NULL,
+    recurring_service_id BIGINT NULL,
+    amendment_type ENUM('service_added','service_updated','service_approved','service_paused','service_resumed','service_ended','proration') NOT NULL,
+    approval_status ENUM('pending','approved','rejected') NOT NULL DEFAULT 'pending',
+    effective_date DATE NOT NULL,
+    summary VARCHAR(500) NOT NULL,
+    old_values JSON NULL,
+    new_values JSON NULL,
+    signed_document_path VARCHAR(500) NULL,
+    approved_at TIMESTAMP NULL,
+    created_by INT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_ca_contract (contract_id, created_at),
+    INDEX idx_ca_service (recurring_service_id),
+    CONSTRAINT fk_ca_contract FOREIGN KEY (contract_id) REFERENCES contracts(id) ON DELETE CASCADE,
+    CONSTRAINT fk_ca_service FOREIGN KEY (recurring_service_id) REFERENCES contract_recurring_services(id) ON DELETE SET NULL,
+    CONSTRAINT fk_ca_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Materialize the existing per-invoice terms as the base service. This keeps
+-- every existing monthly/yearly contract on its current schedule.
+INSERT INTO contract_recurring_services (
+    contract_id, name, description, amount, billing_interval_count,
+    billing_interval_unit, effective_from, effective_until, next_invoice_date,
+    last_invoice_date, status, approval_status, is_base, created_by
+)
+SELECT
+    c.id,
+    LEFT(COALESCE(NULLIF(c.scope, ''), 'Recurring service'), 190),
+    c.scope,
+    COALESCE(c.price_per_invoice, 0),
+    GREATEST(c.billing_interval_count, 1),
+    c.billing_interval_unit,
+    COALESCE(c.start_date, DATE(c.created_at)),
+    c.end_date,
+    c.next_invoice_date,
+    c.last_invoice_date,
+    CASE
+        WHEN c.status = 'active' THEN 'active'
+        WHEN c.status = 'paused' THEN 'paused'
+        WHEN c.status IN ('completed','cancelled','denied','void') THEN 'ended'
+        ELSE 'pending'
+    END,
+    'approved',
+    1,
+    c.created_by
+FROM contracts c
+WHERE c.contract_type = 'long_term'
+  AND c.pricing_type = 'per_invoice'
+  AND NOT EXISTS (
+      SELECT 1 FROM contract_recurring_services s
+      WHERE s.contract_id = c.id AND s.is_base = 1
+  );

--- a/docker-compose.truenas.yml
+++ b/docker-compose.truenas.yml
@@ -12,10 +12,12 @@
 #   6. Go to Settings > Billing to enter Stripe keys
 #
 # Replace /mnt/tank with your actual pool mount point.
+# Production follows the images published from main. Recreate every service,
+# including cron, after pulling so scheduled-job fixes are actually installed.
 
 services:
   migrate:
-    image: "ghcr.io/ledgetoptechnologies/project-alpha:0.5.0-rc1"
+    image: "ghcr.io/ledgetoptechnologies/project-alpha:latest"
     command: ["/usr/local/bin/migrate.sh"]
     environment:
       DB_HOST: db
@@ -33,7 +35,7 @@ services:
       - /mnt/tank/apps/project-alpha/backups:/var/www/backups
 
   web:
-    image: "ghcr.io/ledgetoptechnologies/project-alpha:0.5.0-rc1"
+    image: "ghcr.io/ledgetoptechnologies/project-alpha:latest"
     ports:
       - "1627:80"
     environment:
@@ -62,7 +64,7 @@ services:
       - /mnt/tank/apps/project-alpha/backups:/var/www/backups
 
   cron:
-    image: "ghcr.io/ledgetoptechnologies/project-alpha:cron-0.5.0-rc1"
+    image: "ghcr.io/ledgetoptechnologies/project-alpha:cron-latest"
     environment:
       DB_HOST: db
       DB_PORT: 3306

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -39,3 +39,5 @@ Put PA behind HTTPS before using public links, Stripe webhooks, or client-facing
 
 Validate new images in staging, confirm backups, review migration notes, then deploy production. Publishing an image does not automatically update a TrueNAS Custom App.
 
+When an upgrade changes scheduled jobs, pull and recreate the `cron` service as well as `web`. Verify `/var/www/config/logs/cron/cron.log` and confirm Settings > Backup records a successful `backup_database` run with a file under `/var/www/backups/daily`.
+

--- a/docs/workflows/recurring-billing.md
+++ b/docs/workflows/recurring-billing.md
@@ -9,15 +9,39 @@ Recurring billing is driven by long-term contracts.
 
 ## Billing Schedule
 
-A long-term contract stores the interval count, interval unit, start date, next invoice date, and pricing rules. The interval can be changed later, such as moving a client from monthly billing to yearly billing.
+A per-invoice long-term contract contains one or more recurring service schedules. Each service stores its own amount, interval, effective dates, approval state, and next invoice date. This supports combinations such as annual website hosting and monthly advertising management under one agreement.
+
+Services due on the same date are combined into one invoice with separate line items. Services on different dates generate independently. Editing a service changes only future invoices; generated invoices remain historical records.
+
+## Amendments and Add-ons
+
+Use **Recurring Services & Amendments** on the long-term contract details page to add or change a service.
+
+- Unapproved services remain pending and are excluded from invoice generation.
+- Approval may be recorded directly or evidenced by an uploaded signed addendum PDF.
+- Every addition, edit, approval, pause, resume, end, and proration is recorded in amendment history.
+- An optional explicit prorated subtotal can generate a one-time long-term invoice without changing the full recurring amount.
 
 ## First Invoice
 
 When a long-term contract becomes active and the first invoice is already due, PA attempts to generate it immediately. This avoids waiting until the next scheduled cron run or the next yearly date.
 
+When `invoice_auto_email_on_generate` is enabled, each generated direct-collection invoice is finalized and emailed once with a public payment link. Delivery uses an idempotent `on_generate` notification record, so a cron retry does not send the same invoice twice.
+
 ## Catch-Up Behavior
 
 The cron job can generate missed invoices when PA has been offline. It uses an idempotency guard and a maximum catch-up pass count to avoid duplicate or runaway generation.
+
+## Contract and Invoice Status
+
+The contract lifecycle and each invoice lifecycle are independent:
+
+- Paying a monthly or yearly invoice marks that invoice paid and leaves the long-term contract active.
+- Pausing a contract stops scheduled generation while preserving existing invoice history.
+- A long-term contract completes only when its configured end or fixed-total schedule is reached, or when an operator explicitly terminates it.
+- Open-ended per-invoice contracts continue until explicitly terminated.
+
+The **Recurring Billing** page shows both the active schedules and a filterable history of every generated recurring invoice, including paid invoices.
 
 ## Manual Recovery
 

--- a/public/index.php
+++ b/public/index.php
@@ -1069,6 +1069,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/../src/controllers/contract/long_term_contract_terminate.php';
         exit;
     }
+    if ($page === 'long-term-recurring-service-save') {
+        require_once __DIR__ . '/../src/controllers/contract/long_term_recurring_service_save.php';
+        exit;
+    }
+    if ($page === 'long-term-recurring-service-action') {
+        require_once __DIR__ . '/../src/controllers/contract/long_term_recurring_service_action.php';
+        exit;
+    }
     if ($page === 'document-reenable') {
         require_once __DIR__ . '/../src/controllers/document_reenable_handler.php';
         exit;

--- a/src/controllers/contract/contract_complete.php
+++ b/src/controllers/contract/contract_complete.php
@@ -15,6 +15,9 @@ try {
   $st->execute([$id]);
   $co = $st->fetch(PDO::FETCH_ASSOC);
   if (!$co) throw new Exception('Contract not found');
+  if (($co['contract_type'] ?? 'regular') !== 'regular') {
+    throw new Exception('Recurring contracts must be ended with their dedicated Terminate action.');
+  }
 
   // Mark completed
   $pdo->prepare('UPDATE contracts SET status=?, completed_at=CURRENT_TIMESTAMP WHERE id=?')->execute(['completed', $id]);

--- a/src/controllers/contract/contracts_update.php
+++ b/src/controllers/contract/contracts_update.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/acl_middleware.php';
 require_once __DIR__ . '/../../utils/project_selection.php';
 require_once __DIR__ . '/../../utils/contract_signatures.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 $id = (int)($_POST['id'] ?? 0);
 require_record_ownership($pdo, 'contracts', $id);
 $client_id = (int)($_POST['client_id'] ?? 0);
@@ -29,6 +30,12 @@ $contractTypeStmt->execute([$id]);
 $existingContract = $contractTypeStmt->fetch(PDO::FETCH_ASSOC);
 $contractType = (string)($existingContract['contract_type'] ?? '');
 $isLongTermContract = $contractType === 'long_term';
+$existingBaseService = null;
+if ($isLongTermContract) {
+  $baseServiceStmt = $pdo->prepare('SELECT * FROM contract_recurring_services WHERE contract_id=? AND is_base=1 ORDER BY id LIMIT 1');
+  $baseServiceStmt->execute([$id]);
+  $existingBaseService = $baseServiceStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+}
 $detailPage = $contractType === 'long_term' ? 'contract/long-term-contract-details' : 'contract/contract-details';
 if ($project_id && !pa_project_is_active_for_client($pdo, $project_id, $client_id, (int)($_SESSION['user']['id'] ?? 0))) {
   header('Location: /?page=contract/contracts-edit&id=' . $id . '&error=' . urlencode('Select an active or not-started project for this client or organization.'));
@@ -117,6 +124,36 @@ try{
       $longTerm['price_per_invoice'],$longTerm['billing_start_mode'],$longTerm['invoice_count'],$longTerm['next_invoice_date'],
       $id
     ]);
+    if ($longTerm['pricing_type'] === 'per_invoice') {
+      $baseServiceId = pa_recurring_service_ensure_base($pdo, $id);
+      pa_recurring_service_sync_base($pdo, $id);
+      pa_recurring_service_sync_contract_next_date($pdo, $id);
+      $oldBilling = [
+        'amount' => (float)($existingBaseService['amount'] ?? $existingContract['price_per_invoice'] ?? 0),
+        'billing_interval_count' => (int)($existingBaseService['billing_interval_count'] ?? $existingContract['billing_interval_count'] ?? 1),
+        'billing_interval_unit' => (string)($existingBaseService['billing_interval_unit'] ?? $existingContract['billing_interval_unit'] ?? 'month'),
+        'effective_from' => $existingBaseService['effective_from'] ?? $existingContract['start_date'] ?? null,
+        'effective_until' => $existingBaseService['effective_until'] ?? $existingContract['end_date'] ?? null,
+        'next_invoice_date' => $existingBaseService['next_invoice_date'] ?? $existingContract['next_invoice_date'] ?? null,
+      ];
+      $newBilling = [
+        'amount' => (float)$longTerm['price_per_invoice'],
+        'billing_interval_count' => (int)$longTerm['billing_interval_count'],
+        'billing_interval_unit' => (string)$longTerm['billing_interval_unit'],
+        'effective_from' => $longTerm['start_date'],
+        'effective_until' => $longTerm['end_date'],
+        'next_invoice_date' => $longTerm['next_invoice_date'],
+      ];
+      if ($oldBilling !== $newBilling) {
+        pa_recurring_service_record_amendment(
+          $pdo, $id, $baseServiceId, 'service_updated', 'approved', date('Y-m-d'),
+          'Base recurring service billing terms updated', $oldBilling, $newBilling, null,
+          (int)($_SESSION['user']['id'] ?? 0) ?: null
+        );
+      }
+    } else {
+      $pdo->prepare('UPDATE contract_recurring_services SET status="ended",next_invoice_date=NULL WHERE contract_id=? AND is_base=1 AND status<>"ended"')->execute([$id]);
+    }
   } else {
     $pdo->prepare('UPDATE contracts SET client_id=?, project_id=?, billing_mode=?, discount_type=?, discount_value=?, tax_percent=?, subtotal=?, total=?, terms=?, estimated_completion=?, weather_pending=?, deposit_type=?, deposit_amount=?, deposit_paid=?, fulfillment_date=?, scope=?, memo=?, custom_fields=? WHERE id=?')->execute([$client_id,$project_id,$billing_mode,$discount_type,$discount_value,$tax_percent,$subtotal,$total,$terms,$estimated,$weather,$deposit_type,$deposit_amount,$deposit_paid,$fulfillment_date,$scope,$memo,$customFieldsJson,$id]);
   }

--- a/src/controllers/contract/long_term_contract_activate.php
+++ b/src/controllers/contract/long_term_contract_activate.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../../config/app.php';
 require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/recurring_billing.php';
 require_once __DIR__ . '/../../utils/contract_billing_start.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id <= 0) {
@@ -41,6 +42,7 @@ try {
     // Update contract status to active
     $update = $pdo->prepare('UPDATE contracts SET status=?, next_invoice_date=? WHERE id=? AND contract_type="long_term"');
     $update->execute(['active', $nextInvoiceDate, $id]);
+    pa_recurring_services_activate($pdo, $id, $nextInvoiceDate);
 
     $pdo->commit();
 

--- a/src/controllers/contract/long_term_contract_pause.php
+++ b/src/controllers/contract/long_term_contract_pause.php
@@ -1,18 +1,21 @@
 <?php
 // src/controllers/contract/long_term_contract_pause.php
 require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id <= 0) {
     header('Location: /?page=contract/long-term-contracts-list&error=Invalid%20contract%20ID');
     exit;
 }
+require_record_ownership($pdo, 'contracts', $id);
 
 try {
     $pdo->beginTransaction();
     
     // Get contract details
-    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term"');
+    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term" FOR UPDATE');
     $stmt->execute([$id]);
     $contract = $stmt->fetch(PDO::FETCH_ASSOC);
     
@@ -27,6 +30,7 @@ try {
     // Update contract status to paused
     $update = $pdo->prepare('UPDATE contracts SET status=? WHERE id=? AND contract_type="long_term"');
     $update->execute(['paused', $id]);
+    pa_recurring_services_pause($pdo, $id);
     
     $pdo->commit();
     

--- a/src/controllers/contract/long_term_contract_resume.php
+++ b/src/controllers/contract/long_term_contract_resume.php
@@ -1,18 +1,21 @@
 <?php
 // src/controllers/contract/long_term_contract_resume.php
 require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id <= 0) {
     header('Location: /?page=contract/long-term-contracts-list&error=Invalid%20contract%20ID');
     exit;
 }
+require_record_ownership($pdo, 'contracts', $id);
 
 try {
     $pdo->beginTransaction();
     
     // Get contract details
-    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term"');
+    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term" FOR UPDATE');
     $stmt->execute([$id]);
     $contract = $stmt->fetch(PDO::FETCH_ASSOC);
     
@@ -27,6 +30,7 @@ try {
     // Update contract status to active
     $update = $pdo->prepare('UPDATE contracts SET status=? WHERE id=? AND contract_type="long_term"');
     $update->execute(['active', $id]);
+    pa_recurring_services_resume($pdo, $id);
     
     $pdo->commit();
     

--- a/src/controllers/contract/long_term_contract_start_billing.php
+++ b/src/controllers/contract/long_term_contract_start_billing.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../config/app.php';
 require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/recurring_billing.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id <= 0) {
@@ -35,6 +36,7 @@ try {
     $startDate = date('Y-m-d');
     $update = $pdo->prepare('UPDATE contracts SET status="active", next_invoice_date=? WHERE id=? AND contract_type="long_term"');
     $update->execute([$startDate, $id]);
+    pa_recurring_services_activate($pdo, $id, $startDate);
 
     $pdo->commit();
 

--- a/src/controllers/contract/long_term_contract_terminate.php
+++ b/src/controllers/contract/long_term_contract_terminate.php
@@ -2,6 +2,7 @@
 // src/controllers/contract/long_term_contract_terminate.php
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id <= 0) {
@@ -14,7 +15,7 @@ try {
     $pdo->beginTransaction();
     
     // Get contract details
-    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term"');
+    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term" FOR UPDATE');
     $stmt->execute([$id]);
     $contract = $stmt->fetch(PDO::FETCH_ASSOC);
     
@@ -28,8 +29,9 @@ try {
     
     // Update contract status to completed and set end_date to today if not set
     $endDate = $contract['end_date'] ?: date('Y-m-d');
-    $update = $pdo->prepare('UPDATE contracts SET status=?, end_date=?, next_invoice_date=NULL WHERE id=? AND contract_type="long_term"');
+    $update = $pdo->prepare('UPDATE contracts SET status=?, end_date=?, next_invoice_date=NULL, completed_at=COALESCE(completed_at,NOW()) WHERE id=? AND contract_type="long_term"');
     $update->execute(['completed', $endDate, $id]);
+    pa_recurring_services_end($pdo, $id, $endDate);
     
     $pdo->commit();
     

--- a/src/controllers/contract/long_term_contracts_create.php
+++ b/src/controllers/contract/long_term_contracts_create.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/project_id.php';
 require_once __DIR__ . '/../../utils/project_selection.php';
 require_once __DIR__ . '/../../utils/contract_signatures.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 @error_log('[long_term_contracts_create] POST received', 0);
 
@@ -178,6 +179,9 @@ try{
     ]);
     
     $contract_id = (int)$pdo->lastInsertId();
+    if ($pricing_type === 'per_invoice') {
+        pa_recurring_service_ensure_base($pdo, $contract_id);
+    }
 
     // Assign doc number
     $maxDoc = (int)$pdo->query('SELECT COALESCE(MAX(doc_number),0) FROM contracts WHERE contract_type = "long_term"')->fetchColumn();

--- a/src/controllers/contract/long_term_recurring_service_action.php
+++ b/src/controllers/contract/long_term_recurring_service_action.php
@@ -1,0 +1,85 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../config/app.php';
+require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
+require_once __DIR__ . '/../../utils/recurring_billing.php';
+
+$contractId = (int)($_POST['contract_id'] ?? 0);
+$serviceId = (int)($_POST['service_id'] ?? 0);
+$action = strtolower(trim((string)($_POST['service_action'] ?? '')));
+if ($contractId <= 0 || $serviceId <= 0 || !in_array($action, ['approve', 'pause', 'resume', 'end'], true)) {
+    header('Location: /?page=contract/long-term-contracts-list&error=' . urlencode('Invalid recurring service action.'));
+    exit;
+}
+require_record_ownership($pdo, 'contracts', $contractId);
+
+try {
+    $pdo->beginTransaction();
+    $stmt = $pdo->prepare('
+        SELECT s.*,c.status AS contract_status
+        FROM contract_recurring_services s
+        JOIN contracts c ON c.id=s.contract_id
+        WHERE s.id=? AND s.contract_id=? AND c.contract_type="long_term"
+        FOR UPDATE
+    ');
+    $stmt->execute([$serviceId, $contractId]);
+    $service = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$service) {
+        throw new RuntimeException('Recurring service not found.');
+    }
+
+    $type = 'service_' . $action . ($action === 'end' ? 'ed' : 'd');
+    $summaryVerb = ucfirst($action);
+    $approval = (string)$service['approval_status'];
+    if ($action === 'approve') {
+        $status = ($service['contract_status'] ?? '') === 'active' ? 'active' : (($service['contract_status'] ?? '') === 'paused' ? 'paused' : 'pending');
+        $pdo->prepare('UPDATE contract_recurring_services SET approval_status="approved",status=? WHERE id=?')->execute([$status, $serviceId]);
+        $type = 'service_approved';
+        $approval = 'approved';
+    } elseif ($action === 'pause') {
+        if (($service['status'] ?? '') !== 'active') throw new RuntimeException('Only an active service can be paused.');
+        $pdo->prepare('UPDATE contract_recurring_services SET status="paused" WHERE id=?')->execute([$serviceId]);
+        $type = 'service_paused';
+    } elseif ($action === 'resume') {
+        if (($service['status'] ?? '') !== 'paused' || ($service['approval_status'] ?? '') !== 'approved') throw new RuntimeException('Only an approved paused service can be resumed.');
+        if (($service['contract_status'] ?? '') !== 'active') throw new RuntimeException('Resume the long-term contract before resuming an individual service.');
+        $pdo->prepare('UPDATE contract_recurring_services SET status="active" WHERE id=?')->execute([$serviceId]);
+        $type = 'service_resumed';
+    } else {
+        $pdo->prepare('UPDATE contract_recurring_services SET status="ended",effective_until=COALESCE(effective_until,CURDATE()),next_invoice_date=NULL WHERE id=?')->execute([$serviceId]);
+        $type = 'service_ended';
+    }
+
+    $updatedStmt = $pdo->prepare('SELECT * FROM contract_recurring_services WHERE id=?');
+    $updatedStmt->execute([$serviceId]);
+    $updated = $updatedStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    pa_recurring_service_record_amendment(
+        $pdo, $contractId, $serviceId, $type, $approval, date('Y-m-d'),
+        $summaryVerb . ' recurring service: ' . (string)$service['name'],
+        pa_recurring_service_snapshot($service), pa_recurring_service_snapshot($updated), null,
+        (int)($_SESSION['user']['id'] ?? 0) ?: null
+    );
+    pa_recurring_service_sync_contract_next_date($pdo, $contractId);
+    $pdo->commit();
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) $pdo->rollBack();
+    header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode($e->getMessage()) . '#recurring-services');
+    exit;
+}
+
+$generationResult = '';
+if ($action === 'approve' && ($service['contract_status'] ?? '') === 'active' && !empty($service['next_invoice_date']) && $service['next_invoice_date'] <= date('Y-m-d')) {
+    $contractStmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term"');
+    $contractStmt->execute([$contractId]);
+    $contract = $contractStmt->fetch(PDO::FETCH_ASSOC);
+    if ($contract) {
+        $invoiceId = generate_recurring_invoice($pdo, $contract, $appConfig);
+        if ($invoiceId !== null) {
+            $sent = recurring_invoice_send_on_generate_if_enabled($pdo, $invoiceId, $appConfig);
+            $generationResult = '&service_invoice_generated=1' . ($sent ? '&service_invoice_sent=1' : '');
+        }
+    }
+}
+header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_updated=1' . $generationResult . '#recurring-services');
+exit;

--- a/src/controllers/contract/long_term_recurring_service_save.php
+++ b/src/controllers/contract/long_term_recurring_service_save.php
@@ -1,0 +1,198 @@
+<?php
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../config/app.php';
+require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/upload_validator.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
+require_once __DIR__ . '/../../utils/recurring_billing.php';
+
+$contractId = (int)($_POST['contract_id'] ?? 0);
+$serviceId = max(0, (int)($_POST['service_id'] ?? 0));
+if ($contractId <= 0) {
+    header('Location: /?page=contract/long-term-contracts-list&error=' . urlencode('Invalid contract.'));
+    exit;
+}
+require_record_ownership($pdo, 'contracts', $contractId);
+
+$name = trim((string)($_POST['name'] ?? ''));
+$description = trim((string)($_POST['description'] ?? ''));
+$amount = round((float)($_POST['amount'] ?? 0), 2);
+$intervalCount = max(1, (int)($_POST['billing_interval_count'] ?? 1));
+$intervalUnit = strtolower((string)($_POST['billing_interval_unit'] ?? 'month'));
+$effectiveFrom = trim((string)($_POST['effective_from'] ?? date('Y-m-d')));
+$effectiveUntil = trim((string)($_POST['effective_until'] ?? '')) ?: null;
+$nextInvoiceDate = trim((string)($_POST['next_invoice_date'] ?? $effectiveFrom));
+$approved = !empty($_POST['client_approved']);
+$prorationAmount = round(max(0, (float)($_POST['proration_amount'] ?? 0)), 2);
+$prorationDescription = trim((string)($_POST['proration_description'] ?? ''));
+$sendProration = !empty($_POST['send_proration']);
+$userId = (int)($_SESSION['user']['id'] ?? 0) ?: null;
+
+if ($name === '' || $amount <= 0) {
+    header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode('Service name and a positive recurring amount are required.'));
+    exit;
+}
+if (!in_array($intervalUnit, ['day', 'week', 'month', 'year'], true)) {
+    $intervalUnit = 'month';
+}
+foreach ([$effectiveFrom, $nextInvoiceDate] as $requiredDate) {
+    if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $requiredDate) !== 1) {
+        header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode('Effective and next invoice dates are required.'));
+        exit;
+    }
+}
+if ($effectiveUntil !== null && (preg_match('/^\d{4}-\d{2}-\d{2}$/', $effectiveUntil) !== 1 || $effectiveUntil < $effectiveFrom)) {
+    header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode('The service end date must be on or after its effective date.'));
+    exit;
+}
+if ($effectiveUntil !== null && $nextInvoiceDate > $effectiveUntil) {
+    header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode('The next invoice date must fall within the service effective dates.'));
+    exit;
+}
+if ($prorationAmount > 0 && !$approved) {
+    header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode('Client approval is required before generating a prorated invoice.'));
+    exit;
+}
+
+$storedAddendum = null;
+$storedAddendumPath = null;
+if (!empty($_FILES['signed_addendum']) && (int)($_FILES['signed_addendum']['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_NO_FILE) {
+    $uploadError = null;
+    $uploadDir = __DIR__ . '/../../uploads/contract_amendments';
+    $storedAddendum = validate_and_store_upload(
+        $_FILES['signed_addendum'],
+        ['application/pdf' => 'pdf'],
+        15 * 1024 * 1024,
+        $uploadDir,
+        $uploadError,
+        ['reject_archives' => true, 'require_pdf_header' => true, 'reject_pdf_active_content' => true]
+    );
+    if ($storedAddendum === null) {
+        header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode($uploadError ?: 'Could not upload the signed addendum.'));
+        exit;
+    }
+    $storedAddendumPath = $uploadDir . DIRECTORY_SEPARATOR . $storedAddendum;
+    $approved = true;
+}
+$addendumUrl = $storedAddendum === null ? null : '/?page=serve-upload&file=' . rawurlencode('contract_amendments/' . $storedAddendum);
+
+$prorationInvoiceId = null;
+try {
+    $pdo->beginTransaction();
+    $contractStmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term" FOR UPDATE');
+    $contractStmt->execute([$contractId]);
+    $contract = $contractStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$contract || ($contract['pricing_type'] ?? '') !== 'per_invoice') {
+        throw new RuntimeException('Recurring services require a per-invoice long-term contract.');
+    }
+
+    $oldService = null;
+    if ($serviceId > 0) {
+        $serviceStmt = $pdo->prepare('SELECT * FROM contract_recurring_services WHERE id=? AND contract_id=? FOR UPDATE');
+        $serviceStmt->execute([$serviceId, $contractId]);
+        $oldService = $serviceStmt->fetch(PDO::FETCH_ASSOC);
+        if (!$oldService || ($oldService['status'] ?? '') === 'ended') {
+            throw new RuntimeException('Recurring service not found or already ended.');
+        }
+    }
+
+    $approvalStatus = $approved ? 'approved' : 'pending';
+    $contractStatus = strtolower((string)$contract['status']);
+    $serviceStatus = !$approved ? 'pending' : ($contractStatus === 'active' ? 'active' : ($contractStatus === 'paused' ? 'paused' : 'pending'));
+    if ($oldService) {
+        $pdo->prepare('
+            UPDATE contract_recurring_services
+            SET name=?,description=?,amount=?,billing_interval_count=?,billing_interval_unit=?,
+                effective_from=?,effective_until=?,next_invoice_date=?,status=?,approval_status=?
+            WHERE id=? AND contract_id=?
+        ')->execute([
+            substr($name, 0, 190), $description ?: null, $amount, $intervalCount, $intervalUnit,
+            $effectiveFrom, $effectiveUntil, $nextInvoiceDate, $serviceStatus, $approvalStatus,
+            $serviceId, $contractId,
+        ]);
+    } else {
+        $pdo->prepare('
+            INSERT INTO contract_recurring_services
+                (contract_id,name,description,amount,billing_interval_count,billing_interval_unit,
+                 effective_from,effective_until,next_invoice_date,status,approval_status,is_base,created_by)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,0,?)
+        ')->execute([
+            $contractId, substr($name, 0, 190), $description ?: null, $amount, $intervalCount,
+            $intervalUnit, $effectiveFrom, $effectiveUntil, $nextInvoiceDate, $serviceStatus,
+            $approvalStatus, $userId,
+        ]);
+        $serviceId = (int)$pdo->lastInsertId();
+    }
+
+    $serviceStmt = $pdo->prepare('SELECT * FROM contract_recurring_services WHERE id=?');
+    $serviceStmt->execute([$serviceId]);
+    $newService = $serviceStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    pa_recurring_service_record_amendment(
+        $pdo,
+        $contractId,
+        $serviceId,
+        $oldService ? 'service_updated' : 'service_added',
+        $approvalStatus,
+        $effectiveFrom,
+        ($oldService ? 'Recurring service updated: ' : 'Recurring service added: ') . $name,
+        $oldService ? pa_recurring_service_snapshot($oldService) : null,
+        pa_recurring_service_snapshot($newService),
+        $addendumUrl,
+        $userId
+    );
+
+    if (!empty($newService['is_base'])) {
+        $pdo->prepare('
+            UPDATE contracts
+            SET scope=?,price_per_invoice=?,billing_interval_count=?,billing_interval_unit=?,
+                start_date=?,end_date=?
+            WHERE id=?
+        ')->execute([$description ?: $name, $amount, $intervalCount, $intervalUnit, $effectiveFrom, $effectiveUntil, $contractId]);
+    }
+
+    if ($prorationAmount > 0) {
+        $prorationInvoiceId = generate_recurring_proration_invoice(
+            $pdo, $contractId, $serviceId, $prorationAmount,
+            $prorationDescription ?: 'Prorated charge for ' . $name,
+            $appConfig
+        );
+        pa_recurring_service_record_amendment(
+            $pdo, $contractId, $serviceId, 'proration', 'approved', date('Y-m-d'),
+            'Prorated charge created for ' . $name, null,
+            ['invoice_id' => $prorationInvoiceId, 'subtotal' => $prorationAmount],
+            $addendumUrl, $userId
+        );
+    }
+
+    pa_recurring_service_sync_contract_next_date($pdo, $contractId);
+    $pdo->commit();
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    if ($storedAddendumPath !== null && is_file($storedAddendumPath)) {
+        @unlink($storedAddendumPath);
+    }
+    header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_error=' . urlencode($e->getMessage()));
+    exit;
+}
+
+$sendResult = '';
+if ($prorationInvoiceId !== null && $sendProration) {
+    $sendResult = invoice_send_finalized($pdo, $prorationInvoiceId, $appConfig, 'amendment_proration') ? '&proration_sent=1' : '&proration_send_error=1';
+}
+$scheduledResult = '';
+if ($approved && ($contract['status'] ?? '') === 'active' && $nextInvoiceDate <= date('Y-m-d')) {
+    $freshStmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term"');
+    $freshStmt->execute([$contractId]);
+    $freshContract = $freshStmt->fetch(PDO::FETCH_ASSOC);
+    if ($freshContract) {
+        $scheduledInvoiceId = generate_recurring_invoice($pdo, $freshContract, $appConfig);
+        if ($scheduledInvoiceId !== null) {
+            $emailed = recurring_invoice_send_on_generate_if_enabled($pdo, $scheduledInvoiceId, $appConfig);
+            $scheduledResult = '&service_invoice_generated=1' . ($emailed ? '&service_invoice_sent=1' : '');
+        }
+    }
+}
+header('Location: /?page=contract/long-term-contract-details&id=' . $contractId . '&service_saved=1' . $sendResult . $scheduledResult . '#recurring-services');
+exit;

--- a/src/controllers/public_view/public_contract_action.php
+++ b/src/controllers/public_view/public_contract_action.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../../utils/csrf_sf.php';
 require_once __DIR__ . '/../../utils/contract_billing_start.php';
 require_once __DIR__ . '/../../utils/upload_validator.php';
 require_once __DIR__ . '/../../utils/public_links.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 $submitted = (string)($_POST['_token'] ?? ($_POST['csrf'] ?? ''));
 if (!csrf_sf_is_valid('public_contract_action', $submitted)) {
@@ -97,6 +98,9 @@ try {
         @unlink($storedFile);
       }
       throw new RuntimeException('Contract cannot be uploaded for current status');
+    }
+    if (($contract['contract_type'] ?? '') === 'long_term' && pa_long_term_starts_billing_on_upload($contract)) {
+      pa_recurring_services_activate($pdo, $cid, date('Y-m-d'));
     }
     pa_public_link_terminalize($pdo, 'contract', $cid, 'signed');
     $pdo->commit();

--- a/src/controllers/public_view/public_contract_sign.php
+++ b/src/controllers/public_view/public_contract_sign.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../../utils/notifications.php';
 require_once __DIR__ . '/../../utils/upload_validator.php';
 require_once __DIR__ . '/../../utils/contract_billing_start.php';
 require_once __DIR__ . '/../../utils/public_links.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 // Verify CSRF
 $submitted = (string)($_POST['_token'] ?? ($_POST['csrf'] ?? ''));
@@ -80,7 +81,7 @@ try {
     }
     
     // Build allowed MIME → extension map for signed contracts.
-    $allowedMap = ['application/pdf' => 'pdf', 'image/jpeg' => 'jpg', 'image/png' => 'png',
+    $allowedMap = ['application/pdf' => 'pdf', 'image/jpeg' => ['jpg', 'jpeg'], 'image/png' => 'png',
                    'image/gif' => 'gif', 'image/webp' => 'webp'];
 
     // Centralized validation, malware scan, and secure storage.
@@ -138,6 +139,10 @@ try {
             @unlink($storedFile);
         }
         throw new Exception('This contract has already been signed or is no longer pending');
+    }
+
+    if (($contract['contract_type'] ?? '') === 'long_term' && pa_long_term_starts_billing_on_upload($contract)) {
+        pa_recurring_services_activate($pdo, $contractId, date('Y-m-d'));
     }
 
     pa_public_link_terminalize($pdo, 'contract', $contractId, 'signed');

--- a/src/controllers/public_view/public_quote_action.php
+++ b/src/controllers/public_view/public_quote_action.php
@@ -13,6 +13,7 @@ if (!rate_limit_check($pdo, 'public_quote_action', 30, 60)) {
 }
 require_once __DIR__ . '/../../config/app.php';
 require_once __DIR__ . '/../../utils/csrf_sf.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 require_once __DIR__ . '/../../utils/mailer.php';
 require_once __DIR__ . '/../../utils/smtp.php';
 require_once __DIR__ . '/../../utils/project_billing.php';
@@ -115,6 +116,9 @@ try {
              $quoteCreator
            ]);
         $contract_id = (int)$pdo->lastInsertId();
+        if ($quoteType === 'long_term' && ($quote['pricing_type'] ?? '') === 'per_invoice') {
+          pa_recurring_service_ensure_base($pdo, $contract_id);
+        }
 
         $ci = $pdo->prepare('INSERT INTO contract_items (contract_id, item, description, quantity, unit_price, line_total, billing_unit) VALUES (?,?,?,?,?,?,?)');
         foreach ($qitems as $it) {

--- a/src/controllers/quote/quote_approve.php
+++ b/src/controllers/quote/quote_approve.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../../utils/project_billing.php';
 require_once __DIR__ . '/../../config/app.php';
 require_once __DIR__ . '/../../utils/acl.php';
 require_once __DIR__ . '/../../utils/public_links.php';
+require_once __DIR__ . '/../../utils/recurring_services.php';
 
 // Auto-create settings (default to true/on when not explicitly set)
 $autoCreateContract = !isset($appConfig['quote_auto_create_contract']) || !empty($appConfig['quote_auto_create_contract']);
@@ -95,6 +96,9 @@ try {
             $quoteCreator
           ]);
       $contract_id = (int)$pdo->lastInsertId();
+      if ($quoteType === 'long_term' && ($quote['pricing_type'] ?? '') === 'per_invoice') {
+        pa_recurring_service_ensure_base($pdo, $contract_id);
+      }
 
       if (!empty($qitems)) {
         $ci = $pdo->prepare('INSERT INTO contract_items (contract_id, item, description, quantity, unit_price, line_total, billing_unit) VALUES (?,?,?,?,?,?,?)');

--- a/src/controllers/stripe/stripe_webhook.php
+++ b/src/controllers/stripe/stripe_webhook.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../../services/StripeService.php';
 require_once __DIR__ . '/../../utils/notifications.php';
 require_once __DIR__ . '/../../utils/webhook_logger.php';
 require_once __DIR__ . '/../../utils/public_links.php';
+require_once __DIR__ . '/../../utils/invoice_lifecycle.php';
 
 // Get raw POST body for signature verification
 $endpointName = 'stripe-webhook-legacy';
@@ -264,12 +265,7 @@ function handleCheckoutSessionCompleted($pdo, $session) {
             pa_public_link_terminalize($pdo, 'invoice', $invoiceId, 'paid');
             
             // Mark linked contract as completed if exists
-            $co = $pdo->prepare('SELECT contract_id FROM invoices WHERE id = ?');
-            $co->execute([$invoiceId]);
-            $contractId = (int)$co->fetchColumn();
-            if ($contractId > 0) {
-                $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')->execute(['completed', $contractId]);
-            }
+            invoice_complete_linked_contract_if_eligible($pdo, $invoiceId);
         }
         
         $pdo->commit();
@@ -352,16 +348,11 @@ function handlePaymentIntentSucceeded($pdo, $paymentIntent) {
             $pdo->prepare('UPDATE invoices SET status = ? WHERE id = ?')->execute([$status, $invoiceId]);
         }
         
-        // If paid, revoke public links and complete contract
+        // If paid, revoke public links and complete only a one-time contract.
         if ($status === 'paid') {
             pa_public_link_terminalize($pdo, 'invoice', $invoiceId, 'paid');
             
-            $co = $pdo->prepare('SELECT contract_id FROM invoices WHERE id = ?');
-            $co->execute([$invoiceId]);
-            $contractId = (int)$co->fetchColumn();
-            if ($contractId > 0) {
-                $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')->execute(['completed', $contractId]);
-            }
+            invoice_complete_linked_contract_if_eligible($pdo, $invoiceId);
         }
         
         $pdo->commit();

--- a/src/controllers/webhook/stripe_checkout_completed.php
+++ b/src/controllers/webhook/stripe_checkout_completed.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../../utils/notifications.php';
 require_once __DIR__ . '/../../utils/stripe_financial_events.php';
 require_once __DIR__ . '/../../utils/stripe_payment_accounting.php';
 require_once __DIR__ . '/../../utils/public_links.php';
+require_once __DIR__ . '/../../utils/invoice_lifecycle.php';
 
 function handleCheckoutSessionCompleted($pdo, $session) {
     $metadata = $session['metadata'] ?? [];
@@ -118,13 +119,7 @@ function handleCheckoutSessionCompleted($pdo, $session) {
         if ($status === 'paid') {
             pa_public_link_terminalize($pdo, 'invoice', $invoiceId, 'paid');
             
-            // Mark linked contract as completed if exists
-            $co = $pdo->prepare('SELECT contract_id FROM invoices WHERE id = ?');
-            $co->execute([$invoiceId]);
-            $contractId = (int)$co->fetchColumn();
-            if ($contractId > 0) {
-                $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')->execute(['completed', $contractId]);
-            }
+            invoice_complete_linked_contract_if_eligible($pdo, $invoiceId);
         }
         
         $pdo->commit();

--- a/src/controllers/webhook/stripe_payment_succeeded.php
+++ b/src/controllers/webhook/stripe_payment_succeeded.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../../utils/notifications.php';
 require_once __DIR__ . '/../../utils/stripe_financial_events.php';
 require_once __DIR__ . '/../../utils/stripe_payment_accounting.php';
 require_once __DIR__ . '/../../utils/public_links.php';
+require_once __DIR__ . '/../../utils/invoice_lifecycle.php';
 
 function handlePaymentIntentSucceeded($pdo, $paymentIntent) {
     $metadata = $paymentIntent['metadata'] ?? [];
@@ -154,16 +155,10 @@ function handlePaymentIntentSucceeded($pdo, $paymentIntent) {
         $pdo->prepare('UPDATE invoices SET status=?,amount_paid=?,balance_due=GREATEST(total-?,0),stripe_session_id=NULL,stripe_checkout_expires_at=NULL WHERE id=?')
             ->execute([$status, $paid, $paid, $invoiceId]);
         
-        // If paid, revoke public links and complete contract
+        // If paid, revoke public links and complete only a one-time contract.
         if ($status === 'paid') {
             pa_public_link_terminalize($pdo, 'invoice', $invoiceId, 'paid');
-            
-            $co = $pdo->prepare('SELECT contract_id FROM invoices WHERE id = ?');
-            $co->execute([$invoiceId]);
-            $contractId = (int)$co->fetchColumn();
-            if ($contractId > 0) {
-                $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')->execute(['completed', $contractId]);
-            }
+            invoice_complete_linked_contract_if_eligible($pdo, $invoiceId);
         }
         
         $pdo->commit();

--- a/src/cron/auto_terminate_contracts.php
+++ b/src/cron/auto_terminate_contracts.php
@@ -6,6 +6,7 @@
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../config/app.php';
 require_once __DIR__ . '/../utils/cron_state.php';
+require_once __DIR__ . '/../utils/recurring_services.php';
 
 $logPrefix = '[auto_terminate_contracts]';
 $jobName = 'auto_terminate_contracts';
@@ -36,8 +37,9 @@ try {
     
     foreach ($ltContracts as $contract) {
         try {
-            $pdo->prepare('UPDATE contracts SET status=?, next_invoice_date=NULL WHERE id=? AND contract_type="long_term"')
+            $pdo->prepare('UPDATE contracts SET status=?, next_invoice_date=NULL, completed_at=COALESCE(completed_at,NOW()) WHERE id=? AND contract_type="long_term"')
                 ->execute(['completed', $contract['id']]);
+            pa_recurring_services_end($pdo, (int)$contract['id'], (string)$contract['end_date']);
             $terminatedCount++;
             @error_log("$logPrefix Auto-terminated long-term contract LTC-{$contract['doc_number']} (end date: {$contract['end_date']})");
         } catch (Throwable $e) {
@@ -58,7 +60,7 @@ try {
     
     foreach ($odContracts as $contract) {
         try {
-            $pdo->prepare('UPDATE contracts SET status=? WHERE id=? AND contract_type="on_demand"')
+            $pdo->prepare('UPDATE contracts SET status=?, completed_at=COALESCE(completed_at,NOW()) WHERE id=? AND contract_type="on_demand"')
                 ->execute(['completed', $contract['id']]);
             $terminatedCount++;
             @error_log("$logPrefix Auto-terminated on-demand contract ODC-{$contract['doc_number']} (end date: {$contract['end_date']})");

--- a/src/cron/backup_database.php
+++ b/src/cron/backup_database.php
@@ -81,11 +81,6 @@ function backup_database_run(array $argv = []): int
     $backupVerified = false;
 
     try {
-        if ($scheduledRun && empty($appConfig['cron_enabled'])) {
-            cron_state_mark_success($pdo, $jobName, 'Cron disabled');
-            return 0;
-        }
-
         backup_database_ensure_directories([$backupDir, $dailyDir, $weeklyDir, $monthlyDir]);
 
         if ($scheduledRun) {

--- a/src/cron/generate_recurring_invoices.php
+++ b/src/cron/generate_recurring_invoices.php
@@ -49,6 +49,7 @@ try {
         $invoiceId = generate_recurring_invoice($pdo, $contract, $appConfig);
         if ($invoiceId !== null) {
             $invoicesGenerated++;
+            recurring_invoice_send_on_generate_if_enabled($pdo, $invoiceId, $appConfig);
         } elseif ($invoiceId === null) {
             // A null can also mean idempotency guard tripped or no invoice needed.
             // Track actual errors through helper logging rather than here.

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -123,6 +123,8 @@ function page_permission_map(): array
         'long-term-contract-pause'    => 'contracts.edit',
         'long-term-contract-resume'   => 'contracts.edit',
         'long-term-contract-terminate' => 'contracts.void',
+        'long-term-recurring-service-save' => 'contracts.edit',
+        'long-term-recurring-service-action' => 'contracts.edit',
         'on-demand-contract-activate'  => 'contracts.edit',
         'on-demand-contract-pause'     => 'contracts.edit',
         'on-demand-contract-resume'    => 'contracts.edit',

--- a/src/utils/audit_middleware.php
+++ b/src/utils/audit_middleware.php
@@ -98,6 +98,8 @@ function audit_sensitive_map(): array
             'contract-sign'                  => ['contract.sign', 'contract'],
             'contract/contract-complete'     => ['contract.complete', 'contract'],
             'contract-complete'              => ['contract.complete', 'contract'],
+            'long-term-recurring-service-save' => ['contract.recurring_service_save', 'contract'],
+            'long-term-recurring-service-action' => ['contract.recurring_service_action', 'contract'],
 
             // Email
             'email-send'                     => ['email.send', 'email'],

--- a/src/utils/invoice_lifecycle.php
+++ b/src/utils/invoice_lifecycle.php
@@ -194,6 +194,38 @@ function invoice_refresh_payment_totals(PDO $pdo, int $invoiceId, bool $revokePa
     ];
 }
 
+/**
+ * Complete the linked contract only when the paid invoice belongs to a
+ * one-time contract. Long-term and on-demand contracts represent an ongoing
+ * service relationship; paying one invoice must never end that relationship.
+ */
+function invoice_complete_linked_contract_if_eligible(PDO $pdo, int $invoiceId): bool
+{
+    $stmt = $pdo->prepare('
+        SELECT c.id, c.contract_type, c.status
+        FROM invoices i
+        JOIN contracts c ON c.id = i.contract_id
+        WHERE i.id = ?
+        LIMIT 1
+    ');
+    $stmt->execute([$invoiceId]);
+    $contract = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$contract || strtolower((string)$contract['contract_type']) !== 'regular') {
+        return false;
+    }
+
+    $update = $pdo->prepare('
+        UPDATE contracts
+        SET status = "completed", completed_at = COALESCE(completed_at, NOW())
+        WHERE id = ?
+          AND contract_type = "regular"
+          AND status NOT IN ("completed", "cancelled", "denied", "void")
+    ');
+    $update->execute([(int)$contract['id']]);
+    return $update->rowCount() === 1;
+}
+
 function invoice_record_locked_payment(
     PDO $pdo,
     int $invoiceId,
@@ -275,8 +307,7 @@ function invoice_record_locked_payment(
 
         $totals = invoice_refresh_payment_totals($pdo, $invoiceId);
         if ($completeContractWhenPaid && $totals['status'] === 'paid' && !empty($invoice['contract_id'])) {
-            $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')
-                ->execute(['completed', (int)$invoice['contract_id']]);
+            invoice_complete_linked_contract_if_eligible($pdo, $invoiceId);
         }
 
         if ($ownsTransaction) {
@@ -429,7 +460,13 @@ function invoice_send_finalized(PDO $pdo, int $invoiceId, array $appConfig, stri
         $body .= $contentLinksHtml;
     }
 
-    [$ok, $error] = EmailService::sendEmail($to, $subject, $body);
+    $emailSender = $appConfig['_email_sender'] ?? null;
+    if (is_callable($emailSender)) {
+        $delivery = $emailSender($to, $subject, $body, ['invoice_id' => $invoiceId, 'notification_type' => $notificationType]);
+        [$ok, $error] = is_array($delivery) ? $delivery : [(bool)$delivery, ''];
+    } else {
+        [$ok, $error] = EmailService::sendEmail($to, $subject, $body);
+    }
     if (!$ok) {
         $pdo->prepare('DELETE FROM invoice_notifications WHERE invoice_id=? AND notification_type=? AND sent_at IS NULL')
             ->execute([$invoiceId, $notificationType]);

--- a/src/utils/recurring_billing.php
+++ b/src/utils/recurring_billing.php
@@ -1,6 +1,8 @@
 <?php
 // src/utils/recurring_billing.php
 // Idempotent helper for generating a single long-term recurring invoice.
+require_once __DIR__ . '/recurring_services.php';
+require_once __DIR__ . '/invoice_lifecycle.php';
 
 function recurring_invoice_send_on_generate_if_enabled(PDO $pdo, ?int $invoiceId, array $appConfig): bool
 {
@@ -8,7 +10,6 @@ function recurring_invoice_send_on_generate_if_enabled(PDO $pdo, ?int $invoiceId
         return false;
     }
 
-    require_once __DIR__ . '/invoice_lifecycle.php';
     return invoice_send_finalized($pdo, $invoiceId, $appConfig, 'on_generate');
 }
 
@@ -48,10 +49,25 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
         // Calculate invoice amount
         $subtotal = 0;
         $items = [];
+        $dueServices = [];
+        $usesServiceSchedules = false;
 
         if ($contract['pricing_type'] === 'per_invoice') {
-            // Simple per-invoice pricing - recurring amount
-            $subtotal = (float)$contract['price_per_invoice'];
+            $usesServiceSchedules = pa_recurring_services_exist($pdo, (int)$contractId);
+            if ($usesServiceSchedules) {
+                $dueServices = pa_recurring_services_due($pdo, (int)$contractId, $today);
+                if (!$dueServices) {
+                    pa_recurring_service_sync_contract_next_date($pdo, (int)$contractId);
+                    $pdo->commit();
+                    return null;
+                }
+                foreach ($dueServices as $service) {
+                    $subtotal += max(0.0, (float)$service['amount']);
+                }
+            } else {
+                // Compatibility fallback for a database awaiting the service-schedule migration.
+                $subtotal = (float)$contract['price_per_invoice'];
+            }
         } elseif ($contract['pricing_type'] === 'fixed_total') {
             // Fixed total - divide total by invoice_count
             $invoiceCount = (int)($contract['invoice_count'] ?? 1);
@@ -98,7 +114,7 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
 
             if ($contractInvoicesGenerated >= $invoiceCount) {
                 // All invoices generated - mark as completed
-                $pdo->prepare('UPDATE contracts SET status=?, next_invoice_date=NULL WHERE id=? AND contract_type="long_term"')
+                $pdo->prepare('UPDATE contracts SET status=?, next_invoice_date=NULL, completed_at=COALESCE(completed_at,NOW()) WHERE id=? AND contract_type="long_term"')
                     ->execute(['completed', $contractId]);
                 @error_log("$logPrefix Contract LTC-{$contract['doc_number']} all {$invoiceCount} invoices generated, marked as completed");
                 $pdo->commit();
@@ -113,8 +129,8 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
             INSERT INTO invoices (
                 contract_id, client_id, project_id, project_code, organization_id, created_by, invoice_type,
                 discount_type, discount_value, tax_percent,
-                subtotal, total, status, due_date, finalized_at, finalization_source, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), "recurring_schedule", NOW())
+                subtotal, total, balance_due, status, due_date, finalized_at, finalization_source, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), "recurring_schedule", NOW())
         ');
 
         $insertInvoice->execute([
@@ -129,6 +145,7 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
             $discountValue,
             $contract['tax_percent'],
             $subtotal,
+            $total,
             $total,
             'unpaid',
             $dueDate
@@ -148,17 +165,31 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
 
         // Add invoice items
         if ($contract['pricing_type'] === 'per_invoice') {
-            // Single line item for recurring service
-            $billingInterval = $contract['billing_interval_count'] . ' ' . ucfirst($contract['billing_interval_unit']);
-            if ($contract['billing_interval_count'] > 1) $billingInterval .= 's';
-
-            $description = 'Recurring service fee (' . strtolower($billingInterval) . ')';
-            if (!empty($contract['scope'])) {
-                $description .= ' - ' . substr($contract['scope'], 0, 100);
+            $itemInsert = $pdo->prepare('INSERT INTO invoice_items (invoice_id, item, description, quantity, unit_price, line_total) VALUES (?,?,?,?,?,?)');
+            if ($usesServiceSchedules) {
+                foreach ($dueServices as $service) {
+                    $serviceName = trim((string)$service['name']) ?: 'Recurring service';
+                    $serviceDescription = trim((string)($service['description'] ?? ''));
+                    $interval = max(1, (int)$service['billing_interval_count']) . ' ' . ucfirst((string)$service['billing_interval_unit']);
+                    if ((int)$service['billing_interval_count'] > 1) {
+                        $interval .= 's';
+                    }
+                    $description = 'Billed every ' . strtolower($interval);
+                    if ($serviceDescription !== '') {
+                        $description .= ' — ' . $serviceDescription;
+                    }
+                    $amount = max(0.0, (float)$service['amount']);
+                    $itemInsert->execute([$invoiceId, $serviceName, $description, 1, $amount, $amount]);
+                }
+            } else {
+                $billingInterval = $contract['billing_interval_count'] . ' ' . ucfirst($contract['billing_interval_unit']);
+                if ($contract['billing_interval_count'] > 1) $billingInterval .= 's';
+                $description = 'Recurring service fee (' . strtolower($billingInterval) . ')';
+                if (!empty($contract['scope'])) {
+                    $description .= ' - ' . substr($contract['scope'], 0, 100);
+                }
+                $itemInsert->execute([$invoiceId, 'Recurring service', $description, 1, $subtotal, $subtotal]);
             }
-
-            $pdo->prepare('INSERT INTO invoice_items (invoice_id, description, quantity, unit_price, line_total) VALUES (?,?,?,?,?)')
-                ->execute([$invoiceId, $description, 1, $total, $total]);
         } elseif ($contract['pricing_type'] === 'fixed_total') {
             // For fixed_total, show items proportionally divided
             $invoiceCount = (int)($contract['invoice_count'] ?? 1);
@@ -183,7 +214,35 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
             }
         }
 
-        // Calculate next invoice date
+        $newTotalInvoiced = (float)$contract['total_invoiced'] + $total;
+        $newInvoicesGenerated = (int)($contract['invoices_generated'] ?? 0) + 1;
+
+        if ($usesServiceSchedules) {
+            foreach ($dueServices as $service) {
+                $serviceNextDate = pa_recurring_service_next_date(
+                    (string)$service['next_invoice_date'],
+                    (int)$service['billing_interval_count'],
+                    (string)$service['billing_interval_unit'],
+                    (string)$service['effective_from']
+                );
+                $serviceStatus = 'active';
+                if (!empty($service['effective_until']) && $serviceNextDate > (string)$service['effective_until']) {
+                    $serviceNextDate = null;
+                    $serviceStatus = 'ended';
+                }
+                $pdo->prepare('UPDATE contract_recurring_services SET next_invoice_date=?,last_invoice_date=?,status=? WHERE id=? AND contract_id=?')
+                    ->execute([$serviceNextDate, $today, $serviceStatus, (int)$service['id'], $contractId]);
+            }
+            pa_recurring_service_sync_contract_next_date($pdo, (int)$contractId);
+            $pdo->prepare('UPDATE contracts SET last_invoice_date=?,total_invoiced=?,invoices_generated=? WHERE id=? AND contract_type="long_term"')
+                ->execute([$today, $newTotalInvoiced, $newInvoicesGenerated, $contractId]);
+
+            $pdo->commit();
+            @error_log("$logPrefix Generated recurring-service invoice {$invoiceId} for contract LTC-{$contract['doc_number']} (\${$total})");
+            return $invoiceId;
+        }
+
+        // Calculate next invoice date for legacy/fixed-total schedules.
         $currentDate = $contract['next_invoice_date'];
         $intervalCount = (int)$contract['billing_interval_count'];
         $intervalUnit = $contract['billing_interval_unit'];
@@ -199,15 +258,11 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
             }
         }
 
-        // Update contract
-        $newTotalInvoiced = (float)$contract['total_invoiced'] + $total;
-        $newInvoicesGenerated = (int)($contract['invoices_generated'] ?? 0) + 1;
-
         if ($shouldContinue) {
             $pdo->prepare('UPDATE contracts SET next_invoice_date=?, last_invoice_date=?, total_invoiced=?, invoices_generated=? WHERE id=? AND contract_type="long_term"')
                 ->execute([$nextDate, $today, $newTotalInvoiced, $newInvoicesGenerated, $contractId]);
         } else {
-            $pdo->prepare('UPDATE contracts SET status=?, next_invoice_date=NULL, last_invoice_date=?, total_invoiced=?, invoices_generated=? WHERE id=? AND contract_type="long_term"')
+            $pdo->prepare('UPDATE contracts SET status=?, next_invoice_date=NULL, last_invoice_date=?, total_invoiced=?, invoices_generated=?, completed_at=COALESCE(completed_at,NOW()) WHERE id=? AND contract_type="long_term"')
                 ->execute(['completed', $today, $newTotalInvoiced, $newInvoicesGenerated, $contractId]);
         }
 
@@ -220,5 +275,98 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
         if ($pdo->inTransaction()) $pdo->rollBack();
         @error_log("$logPrefix Error processing contract {$contract['id']}: " . $e->getMessage());
         return null;
+    }
+}
+
+function generate_recurring_proration_invoice(
+    PDO $pdo,
+    int $contractId,
+    int $serviceId,
+    float $subtotal,
+    string $description,
+    array $appConfig
+): ?int {
+    if ($subtotal <= 0) {
+        return null;
+    }
+    $ownsTransaction = !$pdo->inTransaction();
+    if ($ownsTransaction) {
+        $pdo->beginTransaction();
+    }
+    try {
+        $stmt = $pdo->prepare('
+            SELECT c.*,s.name AS service_name
+            FROM contracts c
+            JOIN contract_recurring_services s ON s.contract_id=c.id
+            WHERE c.id=? AND s.id=? AND c.contract_type="long_term"
+            FOR UPDATE
+        ');
+        $stmt->execute([$contractId, $serviceId]);
+        $contract = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$contract) {
+            throw new RuntimeException('Recurring service not found for proration.');
+        }
+
+        $discount = 0.0;
+        if (($contract['discount_type'] ?? 'none') === 'percent') {
+            $discount = max(0, min(100, (float)$contract['discount_value'])) * $subtotal / 100;
+        } elseif (($contract['discount_type'] ?? 'none') === 'fixed') {
+            $discount = min($subtotal, max(0, (float)$contract['discount_value']));
+        }
+        $taxable = max(0, $subtotal - $discount);
+        $tax = max(0, (float)$contract['tax_percent']) * $taxable / 100;
+        $total = max(0, $taxable + $tax);
+        $dueDate = date('Y-m-d', strtotime('+' . max(0, (int)($appConfig['net_terms_days'] ?? 30)) . ' days'));
+
+        $insert = $pdo->prepare('
+            INSERT INTO invoices
+                (contract_id,client_id,project_id,project_code,organization_id,created_by,invoice_type,
+                 discount_type,discount_value,tax_percent,subtotal,total,balance_due,status,due_date,
+                 finalized_at,finalization_source,generated_at,created_at)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,NOW(),"amendment_proration",NOW(),NOW())
+        ');
+        $insert->execute([
+            $contractId,
+            (int)$contract['client_id'],
+            !empty($contract['project_id']) ? (int)$contract['project_id'] : null,
+            $contract['project_code'] ?? null,
+            !empty($contract['organization_id']) ? (int)$contract['organization_id'] : null,
+            !empty($contract['created_by']) ? (int)$contract['created_by'] : null,
+            'long_term',
+            $contract['discount_type'] ?? 'none',
+            (float)($contract['discount_value'] ?? 0),
+            (float)($contract['tax_percent'] ?? 0),
+            $subtotal,
+            $total,
+            $total,
+            'unpaid',
+            $dueDate,
+        ]);
+        $invoiceId = (int)$pdo->lastInsertId();
+        $maxDoc = (int)$pdo->query('SELECT COALESCE(MAX(doc_number),0) FROM invoices WHERE invoice_type="long_term"')->fetchColumn();
+        $pdo->prepare('UPDATE invoices SET doc_number=? WHERE id=?')->execute([$maxDoc + 1, $invoiceId]);
+
+        $lineDescription = trim($description) !== '' ? trim($description) : 'Prorated recurring service charge';
+        $pdo->prepare('INSERT INTO invoice_items (invoice_id,item,description,quantity,unit_price,line_total) VALUES (?,?,?,?,?,?)')
+            ->execute([$invoiceId, (string)$contract['service_name'], $lineDescription, 1, $subtotal, $subtotal]);
+
+        if (!empty($contract['project_id'])) {
+            require_once __DIR__ . '/project_billing.php';
+            if (project_uses_monthly_invoice_billing($pdo, (int)$contract['project_id'])) {
+                $pdo->prepare('UPDATE invoices SET collection_mode="project_aggregate" WHERE id=?')->execute([$invoiceId]);
+            }
+        }
+
+        $pdo->prepare('UPDATE contracts SET total_invoiced=total_invoiced+?,invoices_generated=invoices_generated+1,last_invoice_date=? WHERE id=?')
+            ->execute([$total, date('Y-m-d'), $contractId]);
+        if ($ownsTransaction) {
+            $pdo->commit();
+        }
+        return $invoiceId;
+    } catch (Throwable $e) {
+        if ($ownsTransaction && $pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
     }
 }

--- a/src/utils/recurring_services.php
+++ b/src/utils/recurring_services.php
@@ -1,0 +1,275 @@
+<?php
+declare(strict_types=1);
+
+function pa_recurring_service_snapshot(array $service): array
+{
+    return [
+        'name' => (string)($service['name'] ?? ''),
+        'description' => $service['description'] ?? null,
+        'amount' => (float)($service['amount'] ?? 0),
+        'billing_interval_count' => (int)($service['billing_interval_count'] ?? 1),
+        'billing_interval_unit' => (string)($service['billing_interval_unit'] ?? 'month'),
+        'effective_from' => $service['effective_from'] ?? null,
+        'effective_until' => $service['effective_until'] ?? null,
+        'next_invoice_date' => $service['next_invoice_date'] ?? null,
+        'status' => (string)($service['status'] ?? 'pending'),
+        'approval_status' => (string)($service['approval_status'] ?? 'pending'),
+    ];
+}
+
+function pa_recurring_service_record_amendment(
+    PDO $pdo,
+    int $contractId,
+    ?int $serviceId,
+    string $type,
+    string $approvalStatus,
+    string $effectiveDate,
+    string $summary,
+    ?array $oldValues,
+    ?array $newValues,
+    ?string $signedDocumentPath,
+    ?int $createdBy
+): int {
+    $allowedTypes = ['service_added', 'service_updated', 'service_approved', 'service_paused', 'service_resumed', 'service_ended', 'proration'];
+    if (!in_array($type, $allowedTypes, true)) {
+        throw new InvalidArgumentException('Invalid amendment type.');
+    }
+    if (!in_array($approvalStatus, ['pending', 'approved', 'rejected'], true)) {
+        $approvalStatus = 'pending';
+    }
+
+    $stmt = $pdo->prepare('
+        INSERT INTO contract_amendments
+            (contract_id, recurring_service_id, amendment_type, approval_status, effective_date,
+             summary, old_values, new_values, signed_document_path, approved_at, created_by)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, IF(? = "approved", NOW(), NULL), ?)
+    ');
+    $stmt->execute([
+        $contractId,
+        $serviceId,
+        $type,
+        $approvalStatus,
+        $effectiveDate,
+        substr($summary, 0, 500),
+        $oldValues === null ? null : json_encode($oldValues, JSON_UNESCAPED_SLASHES),
+        $newValues === null ? null : json_encode($newValues, JSON_UNESCAPED_SLASHES),
+        $signedDocumentPath,
+        $approvalStatus,
+        $createdBy,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function pa_recurring_service_contract_status(array $contract): string
+{
+    return match (strtolower((string)($contract['status'] ?? 'pending'))) {
+        'active' => 'active',
+        'paused' => 'paused',
+        'completed', 'cancelled', 'denied', 'void' => 'ended',
+        default => 'pending',
+    };
+}
+
+function pa_recurring_service_ensure_base(PDO $pdo, int $contractId): ?int
+{
+    $existing = $pdo->prepare('SELECT id FROM contract_recurring_services WHERE contract_id=? AND is_base=1 ORDER BY id LIMIT 1');
+    $existing->execute([$contractId]);
+    $existingId = (int)($existing->fetchColumn() ?: 0);
+    if ($existingId > 0) {
+        return $existingId;
+    }
+
+    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term" AND pricing_type="per_invoice" LIMIT 1');
+    $stmt->execute([$contractId]);
+    $contract = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$contract) {
+        return null;
+    }
+
+    $name = trim((string)($contract['scope'] ?? '')) ?: 'Recurring service';
+    $effectiveFrom = (string)($contract['start_date'] ?: date('Y-m-d', strtotime((string)($contract['created_at'] ?? 'now'))));
+    $insert = $pdo->prepare('
+        INSERT INTO contract_recurring_services
+            (contract_id,name,description,amount,billing_interval_count,billing_interval_unit,
+             effective_from,effective_until,next_invoice_date,last_invoice_date,status,
+             approval_status,is_base,created_by)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,1,?)
+    ');
+    $insert->execute([
+        $contractId,
+        substr($name, 0, 190),
+        $contract['scope'] ?? null,
+        (float)($contract['price_per_invoice'] ?? 0),
+        max(1, (int)($contract['billing_interval_count'] ?? 1)),
+        (string)($contract['billing_interval_unit'] ?? 'month'),
+        $effectiveFrom,
+        $contract['end_date'] ?: null,
+        $contract['next_invoice_date'] ?: null,
+        $contract['last_invoice_date'] ?: null,
+        pa_recurring_service_contract_status($contract),
+        'approved',
+        !empty($contract['created_by']) ? (int)$contract['created_by'] : null,
+    ]);
+    return (int)$pdo->lastInsertId();
+}
+
+function pa_recurring_service_sync_base(PDO $pdo, int $contractId): void
+{
+    $stmt = $pdo->prepare('SELECT * FROM contracts WHERE id=? AND contract_type="long_term" AND pricing_type="per_invoice" LIMIT 1');
+    $stmt->execute([$contractId]);
+    $contract = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$contract) {
+        return;
+    }
+    $baseId = pa_recurring_service_ensure_base($pdo, $contractId);
+    if ($baseId === null) {
+        return;
+    }
+    $name = trim((string)($contract['scope'] ?? '')) ?: 'Recurring service';
+    $pdo->prepare('
+        UPDATE contract_recurring_services
+        SET name=?, description=?, amount=?, billing_interval_count=?, billing_interval_unit=?,
+            effective_from=?, effective_until=?, next_invoice_date=?
+        WHERE id=? AND contract_id=? AND is_base=1
+    ')->execute([
+        substr($name, 0, 190),
+        $contract['scope'] ?? null,
+        (float)($contract['price_per_invoice'] ?? 0),
+        max(1, (int)($contract['billing_interval_count'] ?? 1)),
+        (string)($contract['billing_interval_unit'] ?? 'month'),
+        (string)($contract['start_date'] ?: date('Y-m-d')),
+        $contract['end_date'] ?: null,
+        $contract['next_invoice_date'] ?: null,
+        $baseId,
+        $contractId,
+    ]);
+}
+
+function pa_recurring_service_sync_contract_next_date(PDO $pdo, int $contractId): ?string
+{
+    $contractStmt = $pdo->prepare('SELECT status FROM contracts WHERE id=? AND contract_type="long_term" LIMIT 1');
+    $contractStmt->execute([$contractId]);
+    $contractStatus = strtolower((string)($contractStmt->fetchColumn() ?: 'pending'));
+    $scheduleStatus = $contractStatus === 'paused' ? 'paused' : 'active';
+    $stmt = $pdo->prepare('
+        SELECT MIN(next_invoice_date)
+        FROM contract_recurring_services
+        WHERE contract_id=?
+          AND status=?
+          AND approval_status="approved"
+          AND next_invoice_date IS NOT NULL
+          AND (effective_until IS NULL OR next_invoice_date<=effective_until)
+    ');
+    $stmt->execute([$contractId, $scheduleStatus]);
+    $nextDate = $stmt->fetchColumn();
+    $nextDate = $nextDate !== false && $nextDate !== null ? (string)$nextDate : null;
+    $pdo->prepare('UPDATE contracts SET next_invoice_date=? WHERE id=? AND contract_type="long_term"')
+        ->execute([$nextDate, $contractId]);
+    return $nextDate;
+}
+
+function pa_recurring_services_activate(PDO $pdo, int $contractId, ?string $baseNextDate = null): void
+{
+    pa_recurring_service_ensure_base($pdo, $contractId);
+    if ($baseNextDate !== null) {
+        $pdo->prepare('UPDATE contract_recurring_services SET next_invoice_date=? WHERE contract_id=? AND is_base=1')
+            ->execute([$baseNextDate, $contractId]);
+    }
+    $pdo->prepare('
+        UPDATE contract_recurring_services
+        SET status="active"
+        WHERE contract_id=? AND approval_status="approved" AND status IN ("pending","paused")
+    ')->execute([$contractId]);
+    pa_recurring_service_sync_contract_next_date($pdo, $contractId);
+}
+
+function pa_recurring_services_pause(PDO $pdo, int $contractId): void
+{
+    $pdo->prepare('UPDATE contract_recurring_services SET status="paused" WHERE contract_id=? AND status="active"')
+        ->execute([$contractId]);
+}
+
+function pa_recurring_services_resume(PDO $pdo, int $contractId): void
+{
+    $pdo->prepare('UPDATE contract_recurring_services SET status="active" WHERE contract_id=? AND status="paused" AND approval_status="approved"')
+        ->execute([$contractId]);
+    pa_recurring_service_sync_contract_next_date($pdo, $contractId);
+}
+
+function pa_recurring_services_end(PDO $pdo, int $contractId, string $effectiveDate): void
+{
+    $pdo->prepare('
+        UPDATE contract_recurring_services
+        SET status="ended", effective_until=COALESCE(effective_until,?), next_invoice_date=NULL
+        WHERE contract_id=? AND status<>"ended"
+    ')->execute([$effectiveDate, $contractId]);
+}
+
+function pa_recurring_services_due(PDO $pdo, int $contractId, string $throughDate): array
+{
+    $stmt = $pdo->prepare('
+        SELECT *
+        FROM contract_recurring_services
+        WHERE contract_id=?
+          AND status="active"
+          AND approval_status="approved"
+          AND next_invoice_date IS NOT NULL
+          AND next_invoice_date<=?
+          AND effective_from<=?
+          AND (effective_until IS NULL OR next_invoice_date<=effective_until)
+          AND next_invoice_date = (
+              SELECT MIN(due.next_invoice_date)
+              FROM contract_recurring_services due
+              WHERE due.contract_id=contract_recurring_services.contract_id
+                AND due.status="active"
+                AND due.approval_status="approved"
+                AND due.next_invoice_date IS NOT NULL
+                AND due.next_invoice_date<=?
+                AND due.effective_from<=?
+                AND (due.effective_until IS NULL OR due.next_invoice_date<=due.effective_until)
+          )
+        ORDER BY next_invoice_date,id
+        FOR UPDATE
+    ');
+    $stmt->execute([$contractId, $throughDate, $throughDate, $throughDate, $throughDate]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function pa_recurring_services_exist(PDO $pdo, int $contractId): bool
+{
+    $stmt = $pdo->prepare('SELECT 1 FROM contract_recurring_services WHERE contract_id=? LIMIT 1');
+    $stmt->execute([$contractId]);
+    return $stmt->fetchColumn() !== false;
+}
+
+function pa_recurring_service_next_date(string $currentDate, int $intervalCount, string $intervalUnit, ?string $anchorDate = null): string
+{
+    $intervalCount = max(1, $intervalCount);
+    if (!in_array($intervalUnit, ['day', 'week', 'month', 'year'], true)) {
+        $intervalUnit = 'month';
+    }
+    $date = DateTimeImmutable::createFromFormat('!Y-m-d', $currentDate);
+    if (!$date) {
+        throw new InvalidArgumentException('Invalid recurring service date.');
+    }
+    $anchor = $anchorDate ? DateTimeImmutable::createFromFormat('!Y-m-d', $anchorDate) : null;
+    if (!$anchor) {
+        $anchor = $date;
+    }
+    if ($intervalUnit === 'month') {
+        $monthIndex = ((int)$date->format('Y') * 12) + ((int)$date->format('n') - 1) + $intervalCount;
+        $targetYear = intdiv($monthIndex, 12);
+        $targetMonth = ($monthIndex % 12) + 1;
+        $first = new DateTimeImmutable(sprintf('%04d-%02d-01', $targetYear, $targetMonth));
+        $targetDay = min((int)$anchor->format('j'), (int)$first->modify('last day of this month')->format('j'));
+        return $first->setDate($targetYear, $targetMonth, $targetDay)->format('Y-m-d');
+    }
+    if ($intervalUnit === 'year') {
+        $targetYear = (int)$date->format('Y') + $intervalCount;
+        $targetMonth = (int)$anchor->format('n');
+        $first = new DateTimeImmutable(sprintf('%04d-%02d-01', $targetYear, $targetMonth));
+        $targetDay = min((int)$anchor->format('j'), (int)$first->modify('last day of this month')->format('j'));
+        return $first->setDate($targetYear, $targetMonth, $targetDay)->format('Y-m-d');
+    }
+    return $date->modify('+' . $intervalCount . ' ' . $intervalUnit)->format('Y-m-d');
+}

--- a/src/utils/stripe_reconciliation_import.php
+++ b/src/utils/stripe_reconciliation_import.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../services/PaymentProcessorImportService.php';
 require_once __DIR__ . '/stripe_financial_events.php';
 require_once __DIR__ . '/stripe_payment_accounting.php';
 require_once __DIR__ . '/public_links.php';
+require_once __DIR__ . '/invoice_lifecycle.php';
 
 function stripe_reconcile_payment_intents(
     PDO $pdo,
@@ -134,12 +135,7 @@ function stripe_reconcile_payment_intents(
             if ($newStatus === 'paid') {
                 pa_public_link_terminalize($pdo, 'invoice', $invoiceId, 'paid');
 
-                $coStmt = $pdo->prepare('SELECT contract_id FROM invoices WHERE id = ?');
-                $coStmt->execute([$invoiceId]);
-                $contractId = (int)$coStmt->fetchColumn();
-                if ($contractId > 0) {
-                    $pdo->prepare('UPDATE contracts SET status = ? WHERE id = ?')->execute(['completed', $contractId]);
-                }
+                invoice_complete_linked_contract_if_eligible($pdo, $invoiceId);
             }
 
             $pdo->commit();

--- a/src/views/pages/contract/contracts-edit.php
+++ b/src/views/pages/contract/contracts-edit.php
@@ -16,6 +16,16 @@ if (!$contract) {
   return;
 }
 $isLongTermContract = ($contract['contract_type'] ?? 'regular') === 'long_term';
+$baseRecurringService = null;
+if ($isLongTermContract) {
+  try {
+    $baseServiceStmt = $pdo->prepare('SELECT * FROM contract_recurring_services WHERE contract_id=? AND is_base=1 ORDER BY id LIMIT 1');
+    $baseServiceStmt->execute([$id]);
+    $baseRecurringService = $baseServiceStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+  } catch (Throwable $e) {
+    $baseRecurringService = null;
+  }
+}
 $items = $pdo->prepare('SELECT * FROM contract_items WHERE contract_id=?');
 $items->execute([$id]);
 $items = $items->fetchAll(PDO::FETCH_ASSOC);
@@ -191,11 +201,11 @@ try {
 
     <?php if ($isLongTermContract): ?>
       <?php
-        $intervalCount = max(1, (int)($contract['billing_interval_count'] ?? 1));
+        $intervalCount = max(1, (int)($baseRecurringService['billing_interval_count'] ?? $contract['billing_interval_count'] ?? 1));
         $intervalCountOptions = array_values(array_unique(array_merge([1, 2, 3, 6, 12], [$intervalCount])));
         sort($intervalCountOptions);
-        $intervalUnit = in_array((string)($contract['billing_interval_unit'] ?? 'month'), ['day', 'week', 'month', 'year'], true)
-          ? (string)$contract['billing_interval_unit']
+        $intervalUnit = in_array((string)($baseRecurringService['billing_interval_unit'] ?? $contract['billing_interval_unit'] ?? 'month'), ['day', 'week', 'month', 'year'], true)
+          ? (string)($baseRecurringService['billing_interval_unit'] ?? $contract['billing_interval_unit'])
           : 'month';
         $pricingType = in_array((string)($contract['pricing_type'] ?? 'per_invoice'), ['per_invoice', 'fixed_total'], true)
           ? (string)$contract['pricing_type']
@@ -208,7 +218,7 @@ try {
       <div id="longTermEditFields" style="border:1px solid #e5e7eb;border-radius:8px;padding:16px;background:#f9fafb">
         <h3 style="margin:0 0 8px;color:#374151;font-size:16px">Recurring Billing Settings</h3>
         <p style="margin:0 0 12px;color:#6b7280;font-size:13px;line-height:1.45">
-          Changes here apply to future recurring invoices. Existing invoices and payments are left as-is.
+          Changes here apply to the base recurring service and future invoices. Manage additional services and their independent schedules from the contract details page. Existing invoices and payments are left as-is.
         </p>
 
         <div style="display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(210px,1fr))">
@@ -229,7 +239,7 @@ try {
           </label>
           <label>
             <div>Next Invoice Date</div>
-            <input type="date" name="next_invoice_date" value="<?php echo htmlspecialchars((string)($contract['next_invoice_date'] ?? '')); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+            <input type="date" name="next_invoice_date" value="<?php echo htmlspecialchars((string)($baseRecurringService['next_invoice_date'] ?? $contract['next_invoice_date'] ?? '')); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
           </label>
         </div>
 
@@ -291,7 +301,7 @@ try {
         <div id="perInvoiceEditFieldCo" style="<?php echo $pricingType === 'per_invoice' ? '' : 'display:none'; ?>;margin-top:12px">
           <label>
             <div>Amount Per Invoice</div>
-            <input id="pricePerInvoiceEditCo" type="number" step="0.01" min="0" name="price_per_invoice" value="<?php echo htmlspecialchars((string)($contract['price_per_invoice'] ?? $contract['subtotal'] ?? 0)); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
+            <input id="pricePerInvoiceEditCo" type="number" step="0.01" min="0" name="price_per_invoice" value="<?php echo htmlspecialchars((string)($baseRecurringService['amount'] ?? $contract['price_per_invoice'] ?? $contract['subtotal'] ?? 0)); ?>" style="width:100%;padding:10px;border-radius:8px;border:1px solid #ddd">
           </label>
         </div>
 

--- a/src/views/pages/contract/long-term-contract-details.php
+++ b/src/views/pages/contract/long-term-contract-details.php
@@ -24,6 +24,22 @@ try {
     $latestLongTermInvoice = null;
 }
 
+$recurringServices = [];
+$contractAmendments = [];
+if (!defined('PDF_MODE') && !defined('PUBLIC_VIEW')) {
+    try {
+        $serviceStmt = $pdo->prepare('SELECT * FROM contract_recurring_services WHERE contract_id=? ORDER BY is_base DESC,status="ended",effective_from,id');
+        $serviceStmt->execute([$id]);
+        $recurringServices = $serviceStmt->fetchAll(PDO::FETCH_ASSOC);
+        $amendmentStmt = $pdo->prepare('SELECT a.*,s.name AS service_name FROM contract_amendments a LEFT JOIN contract_recurring_services s ON s.id=a.recurring_service_id WHERE a.contract_id=? ORDER BY a.created_at DESC,a.id DESC LIMIT 50');
+        $amendmentStmt->execute([$id]);
+        $contractAmendments = $amendmentStmt->fetchAll(PDO::FETCH_ASSOC);
+    } catch (Throwable $e) {
+        $recurringServices = [];
+        $contractAmendments = [];
+    }
+}
+
 $signatures = [];
 try {
     $sigStmt = $pdo->prepare('SELECT * FROM contract_signatures WHERE contract_id = ? ORDER BY display_order, id');
@@ -156,6 +172,27 @@ $isOngoing = empty($contract['end_date']);
         <a href="/?page=invoice/invoice-details&id=<?php echo (int)$latestLongTermInvoice['id']; ?>" class="btn btn-sm">Latest Invoice</a>
       <?php endif; ?>
     <?php endif; ?>
+    <a href="/?page=invoice/recurring-invoices-list&status=all&contract_id=<?php echo (int)$id; ?>#invoice-history" class="btn btn-sm">Invoice History</a>
+    <?php if ($contractStatus === 'active'): ?>
+      <form method="post" action="/?page=long-term-contract-pause" style="display:inline">
+        <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+        <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
+        <button type="submit" class="btn btn-sm">Pause Billing</button>
+      </form>
+    <?php elseif ($contractStatus === 'paused'): ?>
+      <form method="post" action="/?page=long-term-contract-resume" style="display:inline">
+        <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+        <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
+        <button type="submit" class="btn btn-sm">Resume Billing</button>
+      </form>
+    <?php endif; ?>
+    <?php if (in_array($contractStatus, ['pending', 'active', 'paused'], true)): ?>
+      <form method="post" action="/?page=long-term-contract-terminate" style="display:inline" onsubmit="return confirm('Terminate this long-term contract? Future recurring invoices will stop.');">
+        <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+        <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
+        <button type="submit" class="btn btn-sm">Terminate</button>
+      </form>
+    <?php endif; ?>
     <?php if (!in_array($contractStatus, ['cancelled', 'completed', 'void'], true)): ?>
       <form method="post" action="/?page=contract/contract-void" onsubmit="return confirm('Void this contract and linked invoices?')" style="display:inline">
         <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
@@ -198,6 +235,125 @@ $isOngoing = empty($contract['end_date']);
   <?php if (!empty($_GET['date_updated'])): ?>
     <div class="no-print" style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#dbeafe;color:#1e3a8a;border:1px solid #93c5fd">Document date updated successfully.</div>
   <?php endif; ?>
+  <?php if (!empty($_GET['service_saved']) || !empty($_GET['service_updated'])): ?>
+    <div class="no-print" style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#166534;border:1px solid #86efac">Recurring service schedule updated.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['service_invoice_generated'])): ?>
+    <div class="no-print" style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#dbeafe;color:#1e3a8a;border:1px solid #93c5fd">The service was due, so its recurring invoice was generated immediately<?php echo !empty($_GET['service_invoice_sent']) ? ' and emailed automatically' : ''; ?>.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['proration_sent'])): ?>
+    <div class="no-print" style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#166534;border:1px solid #86efac">The prorated invoice was generated and emailed.</div>
+  <?php elseif (!empty($_GET['proration_send_error'])): ?>
+    <div class="no-print" style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#fff7ed;color:#9a3412;border:1px solid #fdba74">The prorated invoice was generated, but email delivery failed. Open Invoice History to send it manually.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['service_error'])): ?>
+    <div class="no-print" style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#fff1f2;color:#9f1239;border:1px solid #fda4af"><?php echo htmlspecialchars((string)$_GET['service_error']); ?></div>
+  <?php endif; ?>
+
+  <div id="recurring-services" class="no-print" style="margin:18px 0;padding:18px;background:#f8fafc;border:1px solid #cbd5e1;border-radius:10px;scroll-margin-top:20px">
+    <div style="display:flex;justify-content:space-between;gap:16px;align-items:flex-start;flex-wrap:wrap;margin-bottom:14px">
+      <div>
+        <h3 style="margin:0 0 4px;font-size:18px">Recurring Services &amp; Amendments</h3>
+        <div style="font-size:13px;color:#64748b;max-width:760px">Each approved service keeps its own amount, frequency, and effective dates. Services due on the same date appear as separate lines on one invoice; different schedules generate independently.</div>
+      </div>
+      <a href="/?page=invoice/recurring-invoices-list&status=all&contract_id=<?php echo (int)$id; ?>#invoice-history" class="btn btn-sm">View Invoice History</a>
+    </div>
+
+    <?php if (($contract['pricing_type'] ?? '') !== 'per_invoice'): ?>
+      <div style="padding:12px;background:#fff7ed;border:1px solid #fdba74;border-radius:8px;color:#9a3412">Independent recurring services are available for recurring-amount contracts. Convert this fixed-total schedule through Edit Billing before adding services.</div>
+    <?php else: ?>
+      <div style="overflow:auto;margin-bottom:16px">
+        <table style="width:100%;border-collapse:collapse;background:#fff;border:1px solid #e2e8f0;border-radius:8px">
+          <thead><tr style="text-align:left;border-bottom:1px solid #e2e8f0"><th style="padding:9px">Service</th><th style="padding:9px">Billing</th><th style="padding:9px">Effective</th><th style="padding:9px">Next invoice</th><th style="padding:9px">State</th><th style="padding:9px">Actions</th></tr></thead>
+          <tbody>
+            <?php if (!$recurringServices): ?>
+              <tr><td colspan="6" style="padding:14px;text-align:center;color:#64748b">No service schedules found. Saving the base billing terms or adding a service will create one.</td></tr>
+            <?php else: ?>
+              <?php foreach ($recurringServices as $service): ?>
+                <?php
+                  $serviceStatus = (string)$service['status'];
+                  $approvalStatus = (string)$service['approval_status'];
+                  $intervalText = max(1, (int)$service['billing_interval_count']) . ' ' . (string)$service['billing_interval_unit'];
+                  if ((int)$service['billing_interval_count'] > 1) $intervalText .= 's';
+                ?>
+                <tr style="border-top:1px solid #f1f5f9;<?php echo $serviceStatus === 'ended' ? 'opacity:.65;' : ''; ?>">
+                  <td style="padding:9px"><strong><?php echo htmlspecialchars((string)$service['name']); ?></strong><?php if (!empty($service['is_base'])): ?> <span style="font-size:11px;padding:2px 5px;background:#e0e7ff;color:#3730a3;border-radius:4px">Base</span><?php endif; ?><div style="font-size:12px;color:#64748b"><?php echo htmlspecialchars((string)($service['description'] ?? '')); ?></div></td>
+                  <td style="padding:9px"><strong>$<?php echo number_format((float)$service['amount'], 2); ?></strong><div style="font-size:12px;color:#64748b">Every <?php echo htmlspecialchars($intervalText); ?></div></td>
+                  <td style="padding:9px;white-space:nowrap"><?php echo date('M j, Y', strtotime((string)$service['effective_from'])); ?><?php if (!empty($service['effective_until'])): ?><div style="font-size:12px;color:#64748b">through <?php echo date('M j, Y', strtotime((string)$service['effective_until'])); ?></div><?php endif; ?></td>
+                  <td style="padding:9px;white-space:nowrap"><?php echo !empty($service['next_invoice_date']) ? date('M j, Y', strtotime((string)$service['next_invoice_date'])) : '—'; ?></td>
+                  <td style="padding:9px;text-transform:capitalize"><?php echo htmlspecialchars($serviceStatus); ?><div style="font-size:12px;color:<?php echo $approvalStatus === 'approved' ? '#166534' : '#9a3412'; ?>"><?php echo htmlspecialchars($approvalStatus); ?></div></td>
+                  <td style="padding:9px;white-space:nowrap">
+                    <?php if ($approvalStatus !== 'approved' && $serviceStatus !== 'ended'): ?>
+                      <form method="post" action="/?page=long-term-recurring-service-action" style="display:inline"><input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="contract_id" value="<?php echo (int)$id; ?>"><input type="hidden" name="service_id" value="<?php echo (int)$service['id']; ?>"><input type="hidden" name="service_action" value="approve"><button class="btn btn-sm" type="submit">Approve</button></form>
+                    <?php endif; ?>
+                    <?php if ($serviceStatus === 'active'): ?>
+                      <form method="post" action="/?page=long-term-recurring-service-action" style="display:inline"><input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="contract_id" value="<?php echo (int)$id; ?>"><input type="hidden" name="service_id" value="<?php echo (int)$service['id']; ?>"><input type="hidden" name="service_action" value="pause"><button class="btn btn-sm" type="submit">Pause</button></form>
+                    <?php elseif ($serviceStatus === 'paused' && $contractStatus === 'active'): ?>
+                      <form method="post" action="/?page=long-term-recurring-service-action" style="display:inline"><input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="contract_id" value="<?php echo (int)$id; ?>"><input type="hidden" name="service_id" value="<?php echo (int)$service['id']; ?>"><input type="hidden" name="service_action" value="resume"><button class="btn btn-sm" type="submit">Resume</button></form>
+                    <?php endif; ?>
+                    <?php if ($serviceStatus !== 'ended'): ?>
+                      <form method="post" action="/?page=long-term-recurring-service-action" style="display:inline" onsubmit="return confirm('End this recurring service? Future charges for this service will stop.');"><input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="contract_id" value="<?php echo (int)$id; ?>"><input type="hidden" name="service_id" value="<?php echo (int)$service['id']; ?>"><input type="hidden" name="service_action" value="end"><button class="btn btn-sm" type="submit">End</button></form>
+                    <?php endif; ?>
+                  </td>
+                </tr>
+                <?php if ($serviceStatus !== 'ended'): ?>
+                  <tr><td colspan="6" style="padding:0 9px 10px;background:#fff"><details><summary style="cursor:pointer;font-size:12px;color:#2563eb">Edit service terms / attach addendum</summary>
+                    <form method="post" action="/?page=long-term-recurring-service-save" enctype="multipart/form-data" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:10px;padding:12px 0 2px">
+                      <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="contract_id" value="<?php echo (int)$id; ?>"><input type="hidden" name="service_id" value="<?php echo (int)$service['id']; ?>">
+                      <label style="display:grid;gap:4px;font-size:12px">Service name<input name="name" required value="<?php echo htmlspecialchars((string)$service['name']); ?>" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+                      <label style="display:grid;gap:4px;font-size:12px">Amount<input type="number" name="amount" min="0.01" step="0.01" required value="<?php echo htmlspecialchars(number_format((float)$service['amount'], 2, '.', '')); ?>" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+                      <label style="display:grid;gap:4px;font-size:12px">Every<input type="number" name="billing_interval_count" min="1" required value="<?php echo (int)$service['billing_interval_count']; ?>" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+                      <label style="display:grid;gap:4px;font-size:12px">Frequency<select name="billing_interval_unit" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"><?php foreach (['day','week','month','year'] as $unit): ?><option value="<?php echo $unit; ?>" <?php echo $service['billing_interval_unit'] === $unit ? 'selected' : ''; ?>><?php echo ucfirst($unit); ?></option><?php endforeach; ?></select></label>
+                      <label style="display:grid;gap:4px;font-size:12px">Effective from<input type="date" name="effective_from" required value="<?php echo htmlspecialchars((string)$service['effective_from']); ?>" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+                      <label style="display:grid;gap:4px;font-size:12px">Effective until<input type="date" name="effective_until" value="<?php echo htmlspecialchars((string)($service['effective_until'] ?? '')); ?>" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+                      <label style="display:grid;gap:4px;font-size:12px">Next invoice<input type="date" name="next_invoice_date" required value="<?php echo htmlspecialchars((string)($service['next_invoice_date'] ?: date('Y-m-d'))); ?>" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+                      <label style="display:grid;gap:4px;font-size:12px">Signed addendum (PDF)<input type="file" name="signed_addendum" accept="application/pdf,.pdf" style="font-size:12px"></label>
+                      <label style="display:flex;align-items:center;gap:6px;font-size:12px"><input type="checkbox" name="client_approved" value="1" <?php echo $approvalStatus === 'approved' ? 'checked' : ''; ?>> Client approved</label>
+                      <label style="display:grid;gap:4px;font-size:12px;grid-column:1/-1">Description<input name="description" value="<?php echo htmlspecialchars((string)($service['description'] ?? '')); ?>" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+                      <div style="grid-column:1/-1"><button type="submit" class="btn btn-sm">Save Service Amendment</button></div>
+                    </form>
+                  </details></td></tr>
+                <?php endif; ?>
+              <?php endforeach; ?>
+            <?php endif; ?>
+          </tbody>
+        </table>
+      </div>
+
+      <details style="background:#fff;border:1px solid #bfdbfe;border-radius:8px;padding:12px" <?php echo !$recurringServices ? 'open' : ''; ?>><summary style="cursor:pointer;font-weight:700;color:#1d4ed8">Add a recurring service</summary>
+        <form method="post" action="/?page=long-term-recurring-service-save" enctype="multipart/form-data" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin-top:14px">
+          <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>"><input type="hidden" name="contract_id" value="<?php echo (int)$id; ?>">
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">Service name<input name="name" required placeholder="Advertising management" style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">Recurring amount<input type="number" name="amount" min="0.01" step="0.01" required placeholder="500.00" style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">Every<input type="number" name="billing_interval_count" min="1" value="1" required style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">Frequency<select name="billing_interval_unit" style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"><option value="month">Month</option><option value="year">Year</option><option value="week">Week</option><option value="day">Day</option></select></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">Effective from<input type="date" name="effective_from" value="<?php echo date('Y-m-d'); ?>" required style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">Effective until<input type="date" name="effective_until" style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">First full invoice<input type="date" name="next_invoice_date" value="<?php echo date('Y-m-d'); ?>" required style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600">Signed addendum (PDF)<input type="file" name="signed_addendum" accept="application/pdf,.pdf" style="font-size:12px"></label>
+          <label style="display:grid;gap:4px;font-size:12px;font-weight:600;grid-column:1/-1">Description<input name="description" placeholder="Campaign management, optimization, and monthly reporting" style="padding:9px;border:1px solid #cbd5e1;border-radius:6px"></label>
+          <div style="grid-column:1/-1;padding:10px;background:#f8fafc;border-radius:7px;display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:10px">
+            <label style="display:flex;align-items:center;gap:7px;font-size:13px"><input type="checkbox" name="client_approved" value="1"> Client approved this amendment</label>
+            <label style="display:grid;gap:4px;font-size:12px">Optional prorated subtotal<input type="number" name="proration_amount" min="0" step="0.01" placeholder="0.00" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+            <label style="display:grid;gap:4px;font-size:12px">Proration description<input name="proration_description" placeholder="Partial first month" style="padding:8px;border:1px solid #cbd5e1;border-radius:6px"></label>
+            <label style="display:flex;align-items:center;gap:7px;font-size:13px"><input type="checkbox" name="send_proration" value="1"> Email prorated invoice now</label>
+          </div>
+          <div style="grid-column:1/-1"><button type="submit" class="btn btn-sm btn-success">Add Recurring Service</button></div>
+        </form>
+      </details>
+    <?php endif; ?>
+
+    <?php if ($contractAmendments): ?>
+      <details style="margin-top:14px"><summary style="cursor:pointer;font-weight:700">Amendment history (<?php echo count($contractAmendments); ?>)</summary>
+        <div style="display:grid;gap:7px;margin-top:10px">
+          <?php foreach ($contractAmendments as $amendment): ?>
+            <div style="padding:9px 11px;background:#fff;border:1px solid #e2e8f0;border-radius:7px;font-size:13px"><strong><?php echo htmlspecialchars((string)$amendment['summary']); ?></strong><div style="color:#64748b;margin-top:2px"><?php echo date('M j, Y g:i A', strtotime((string)$amendment['created_at'])); ?> · effective <?php echo date('M j, Y', strtotime((string)$amendment['effective_date'])); ?> · <?php echo htmlspecialchars((string)$amendment['approval_status']); ?><?php if (!empty($amendment['signed_document_path'])): ?> · <a href="<?php echo htmlspecialchars((string)$amendment['signed_document_path']); ?>" target="_blank" rel="noopener">Signed addendum</a><?php endif; ?></div></div>
+          <?php endforeach; ?>
+        </div>
+      </details>
+    <?php endif; ?>
+  </div>
+
   <div class="no-print" style="padding:8px 12px;background:#f3f4f6;border-radius:6px;margin-bottom:8px;font-size:13px;color:#374151">
     <strong>Created:</strong> <?php echo !empty($contract['created_at']) ? date('M j, Y g:i A', strtotime($contract['created_at'])) : 'N/A'; ?>
     <span style="margin:0 8px">|</span>

--- a/src/views/pages/contract/long-term-contracts-list.php
+++ b/src/views/pages/contract/long-term-contracts-list.php
@@ -42,7 +42,7 @@ $offset = ($pageN - 1) * $per;
 $sqlCount = 'SELECT COUNT(*) FROM contracts ltc LEFT JOIN clients c ON c.id=ltc.client_id'.($where?' WHERE '.implode(' AND ',$where):'');
 $stc=$pdo->prepare($sqlCount);$stc->execute($p);$total=(int)$stc->fetchColumn();
 
-$sql="SELECT ltc.id, ltc.doc_number, ltc.project_code, ltc.status, ltc.total, ltc.deposit_type, ltc.deposit_amount, ltc.deposit_paid, ltc.start_date, ltc.end_date, ltc.billing_interval_count, ltc.billing_interval_unit, ltc.pricing_type, ltc.price_per_invoice, ltc.total_invoiced, ltc.next_invoice_date, ltc.last_invoice_date, ltc.invoices_generated, ltc.signed_pdf_path, c.name client, c.id AS client_id, (SELECT i.id FROM invoices i WHERE i.contract_id=ltc.id AND i.invoice_type=\"long_term\" ORDER BY i.created_at DESC, i.id DESC LIMIT 1) AS latest_invoice_id, (SELECT i.sent_at FROM invoices i WHERE i.contract_id=ltc.id AND i.invoice_type=\"long_term\" ORDER BY i.created_at DESC, i.id DESC LIMIT 1) AS latest_invoice_sent_at FROM contracts ltc LEFT JOIN clients c ON c.id=ltc.client_id";
+$sql="SELECT ltc.id, ltc.doc_number, ltc.project_code, ltc.status, ltc.total, ltc.deposit_type, ltc.deposit_amount, ltc.deposit_paid, ltc.start_date, ltc.end_date, ltc.billing_interval_count, ltc.billing_interval_unit, ltc.pricing_type, ltc.price_per_invoice, ltc.total_invoiced, ltc.next_invoice_date, ltc.last_invoice_date, ltc.invoices_generated, ltc.signed_pdf_path, c.name client, c.id AS client_id, (SELECT i.id FROM invoices i WHERE i.contract_id=ltc.id AND i.invoice_type=\"long_term\" ORDER BY i.created_at DESC, i.id DESC LIMIT 1) AS latest_invoice_id, (SELECT i.sent_at FROM invoices i WHERE i.contract_id=ltc.id AND i.invoice_type=\"long_term\" ORDER BY i.created_at DESC, i.id DESC LIMIT 1) AS latest_invoice_sent_at, (SELECT COUNT(*) FROM contract_recurring_services rs WHERE rs.contract_id=ltc.id AND rs.status<>\"ended\") AS recurring_service_count, (SELECT COALESCE(SUM(rs.amount),0) FROM contract_recurring_services rs WHERE rs.contract_id=ltc.id AND rs.status IN (\"active\",\"paused\") AND rs.approval_status=\"approved\" AND rs.next_invoice_date=ltc.next_invoice_date) AS next_service_amount FROM contracts ltc LEFT JOIN clients c ON c.id=ltc.client_id";
 if($where){$sql.=' WHERE '.implode(' AND ',$where);} 
 $sql.=" ORDER BY ltc.created_at DESC LIMIT $per OFFSET $offset";
 $st=$pdo->prepare($sql);$st->execute($p);$rows=$st->fetchAll();
@@ -157,10 +157,14 @@ $clients=$pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archive
   
   $billingText = $r['billing_interval_count'] . ' ' . ucfirst($r['billing_interval_unit']);
   if ($r['billing_interval_count'] > 1) $billingText .= 's';
+  if ((int)($r['recurring_service_count'] ?? 0) > 1) {
+    $billingText = (int)$r['recurring_service_count'] . ' service schedules';
+  }
   
   $amountText = '';
   if ($r['pricing_type'] === 'per_invoice') {
-    $amountText = '$' . number_format((float)$r['price_per_invoice'], 2) . '/inv';
+    $nextAmount = (float)($r['next_service_amount'] ?? 0);
+    $amountText = '$' . number_format($nextAmount > 0 ? $nextAmount : (float)$r['price_per_invoice'], 2) . ' next';
   } else {
     $amountText = '$' . number_format((float)$r['total'], 2) . ' total';
   }
@@ -179,6 +183,7 @@ $clients=$pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archive
             <td style="padding:10px"><?php echo $r['next_invoice_date'] ? date('M j, Y', strtotime($r['next_invoice_date'])) : ($r['status'] === 'active' ? 'Manual start' : '—'); ?></td>
             <td style="padding:10px;display:flex;flex-wrap:wrap;gap:8px;align-items:center">
               <a href="/?page=contract/long-term-contract-details&id=<?php echo (int)$r['id']; ?>" style="padding:6px 10px;border:1px solid #ddd;border-radius:8px;background:#fff; font-size: small;">View</a>
+              <a href="/?page=invoice/recurring-invoices-list&status=all&contract_id=<?php echo (int)$r['id']; ?>#invoice-history" style="padding:6px 10px;border:1px solid #ddd;border-radius:8px;background:#fff;font-size:small;">Invoices</a>
               <?php if (in_array($r['status'], ['pending', 'active', 'paused'], true)): ?>
                 <a href="/?page=contract/contracts-edit&id=<?php echo (int)$r['id']; ?>" style="padding:6px 10px;border:1px solid #bfdbfe;border-radius:8px;background:#eff6ff;color:#1d4ed8;text-decoration:none;font-size:small">Edit Billing</a>
               <?php endif; ?>

--- a/src/views/pages/invoice/recurring-invoices-list.php
+++ b/src/views/pages/invoice/recurring-invoices-list.php
@@ -9,6 +9,14 @@ require_once __DIR__ . '/../../../utils/acl.php';
 $client_id = isset($_GET['client_id']) ? (int)$_GET['client_id'] : 0;
 $client_name = trim($_GET['client'] ?? '');
 $status = $_GET['status'] ?? 'active';
+$invoice_status = strtolower(trim((string)($_GET['invoice_status'] ?? 'all')));
+$allowedInvoiceStatuses = ['all', 'draft', 'sent', 'unpaid', 'partial', 'paid', 'overdue', 'cancelled', 'void'];
+if (!in_array($invoice_status, $allowedInvoiceStatuses, true)) {
+    $invoice_status = 'all';
+}
+$history_contract_id = max(0, (int)($_GET['contract_id'] ?? 0));
+$history_page = max(1, (int)($_GET['history_page'] ?? 1));
+$history_per_page = 25;
 $project_code = trim($_GET['project_code'] ?? '');
 $min_price = isset($_GET['min_price']) && $_GET['min_price'] !== '' ? (float)$_GET['min_price'] : null;
 $max_price = isset($_GET['max_price']) && $_GET['max_price'] !== '' ? (float)$_GET['max_price'] : null;
@@ -25,6 +33,7 @@ if ($status !== '' && $status !== 'all') {
 if($project_code!==''){ $where[]='ltc.project_code LIKE ?'; $p[] = $project_code.'%'; }
 if($min_price !== null){ $where[]='ltc.price_per_invoice >= ?'; $p[] = $min_price; }
 if($max_price !== null){ $where[]='ltc.price_per_invoice <= ?'; $p[] = $max_price; }
+if($history_contract_id > 0){ $where[]='ltc.id=?'; $p[] = $history_contract_id; }
 
 [$scopeWhere, $scopeParams] = scope_clause($pdo, 'ltc', (int)$_SESSION['user']['id']);
 if ($scopeWhere !== '') {
@@ -32,7 +41,10 @@ if ($scopeWhere !== '') {
     $p = array_merge($p, $scopeParams);
 }
 
-$sql = "SELECT ltc.id, ltc.doc_number, ltc.project_code, ltc.status, ltc.billing_interval_count, ltc.billing_interval_unit, ltc.pricing_type, ltc.price_per_invoice, ltc.total, ltc.total_invoiced, ltc.next_invoice_date, ltc.last_invoice_date, ltc.start_date, ltc.end_date, c.name client_name, c.id AS client_id 
+$sql = "SELECT ltc.id, ltc.doc_number, ltc.project_code, ltc.status, ltc.billing_interval_count, ltc.billing_interval_unit, ltc.pricing_type, ltc.price_per_invoice, ltc.total, ltc.total_invoiced, ltc.next_invoice_date, ltc.last_invoice_date, ltc.start_date, ltc.end_date, c.name client_name, c.id AS client_id,
+               (SELECT COUNT(*) FROM invoices ih WHERE ih.contract_id=ltc.id AND ih.invoice_type=\"long_term\") AS invoice_history_count,
+               (SELECT COUNT(*) FROM contract_recurring_services rs WHERE rs.contract_id=ltc.id AND rs.status<>\"ended\") AS recurring_service_count,
+               (SELECT COALESCE(SUM(rs.amount),0) FROM contract_recurring_services rs WHERE rs.contract_id=ltc.id AND rs.status IN (\"active\",\"paused\") AND rs.approval_status=\"approved\" AND rs.next_invoice_date=ltc.next_invoice_date) AS next_service_amount
         FROM contracts ltc 
         LEFT JOIN clients c ON c.id=ltc.client_id";
 
@@ -45,9 +57,48 @@ $sql .= ' ORDER BY ltc.next_invoice_date ASC, ltc.id DESC';
 $stmt = $pdo->prepare($sql);
 $stmt->execute($p);
 $contracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+// Invoice history is intentionally independent of the contract-status filter:
+// paid invoices remain visible after a schedule is paused or completed.
+$historyWhere = ['i.invoice_type="long_term"'];
+$historyParams = [];
+if ($client_id > 0) { $historyWhere[] = 'i.client_id=?'; $historyParams[] = $client_id; }
+elseif ($client_name !== '') { $historyWhere[] = 'c.name LIKE ?'; $historyParams[] = '%' . $client_name . '%'; }
+if ($project_code !== '') { $historyWhere[] = 'i.project_code LIKE ?'; $historyParams[] = $project_code . '%'; }
+if ($history_contract_id > 0) { $historyWhere[] = 'i.contract_id=?'; $historyParams[] = $history_contract_id; }
+if ($invoice_status !== 'all') { $historyWhere[] = 'i.status=?'; $historyParams[] = $invoice_status; }
+
+[$historyScopeWhere, $historyScopeParams] = scope_clause($pdo, 'i', (int)$_SESSION['user']['id']);
+if ($historyScopeWhere !== '') {
+    $historyWhere[] = trim($historyScopeWhere);
+    $historyParams = array_merge($historyParams, $historyScopeParams);
+}
+
+$historyFrom = ' FROM invoices i LEFT JOIN clients c ON c.id=i.client_id LEFT JOIN contracts ltc ON ltc.id=i.contract_id';
+$historyWhereSql = ' WHERE ' . implode(' AND ', $historyWhere);
+$historyCountStmt = $pdo->prepare('SELECT COUNT(*)' . $historyFrom . $historyWhereSql);
+$historyCountStmt->execute($historyParams);
+$historyTotal = (int)$historyCountStmt->fetchColumn();
+$historyLastPage = max(1, (int)ceil($historyTotal / $history_per_page));
+$history_page = min($history_page, $historyLastPage);
+$historyOffset = ($history_page - 1) * $history_per_page;
+
+$historySql = 'SELECT i.id,i.doc_number,i.contract_id,i.project_code,i.status,i.total,i.amount_paid,i.balance_due,i.due_date,i.sent_at,i.paid_at,i.created_at,
+                      c.name AS client_name,c.id AS client_id,ltc.doc_number AS contract_doc_number'
+    . $historyFrom . $historyWhereSql
+    . ' ORDER BY i.created_at DESC,i.id DESC LIMIT ? OFFSET ?';
+$historyStmt = $pdo->prepare($historySql);
+$historyBindIndex = 1;
+foreach ($historyParams as $historyParam) {
+    $historyStmt->bindValue($historyBindIndex++, $historyParam);
+}
+$historyStmt->bindValue($historyBindIndex++, $history_per_page, PDO::PARAM_INT);
+$historyStmt->bindValue($historyBindIndex, $historyOffset, PDO::PARAM_INT);
+$historyStmt->execute();
+$invoiceHistory = $historyStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <section>
-  <h2>Recurring Billing Schedule</h2>
+  <h2>Recurring Billing</h2>
   
   <!-- <div style="margin:16px 0;padding:12px;background:#fef3c7;border:1px solid #fbbf24;border-radius:8px">
     <div style="font-weight:600;margin-bottom:4px;color:#92400e">Automatic Invoice Generation</div>
@@ -102,6 +153,7 @@ $contracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
   echo render_template('components/document-filter.html.twig', $filterConfig);
   ?>
 
+  <h3 style="margin:20px 0 10px;font-size:18px">Billing Schedules</h3>
   <div style="overflow:auto">
     <table style="width:100%;border-collapse:collapse;background:#fff;border-radius:8px;box-shadow:0 6px 18px rgba(11,18,32,0.06)">
       <thead>
@@ -114,12 +166,13 @@ $contracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <th style="padding:10px">Last Invoice</th>
           <th style="padding:10px">Next Invoice</th>
           <th style="padding:10px">Progress</th>
+          <th style="padding:10px">Actions</th>
         </tr>
       </thead>
       <tbody>
         <?php if (empty($contracts)): ?>
           <tr>
-            <td colspan="8" style="padding:20px;text-align:center;color:#6b7280">No recurring billing contracts found.</td>
+            <td colspan="9" style="padding:20px;text-align:center;color:#6b7280">No recurring billing contracts found.</td>
           </tr>
         <?php else: ?>
           <?php foreach ($contracts as $ltc): ?>
@@ -129,12 +182,16 @@ $contracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
               
               $amountText = '';
               if ($ltc['pricing_type'] === 'per_invoice') {
-                $amountText = '$' . number_format((float)$ltc['price_per_invoice'], 2);
+                $nextAmount = (float)($ltc['next_service_amount'] ?? 0);
+                $amountText = '$' . number_format($nextAmount > 0 ? $nextAmount : (float)$ltc['price_per_invoice'], 2) . ' next';
               } else {
                 $amountText = '$' . number_format((float)$ltc['total'], 2) . ' total';
               }
               
               $isOngoing = empty($ltc['end_date']);
+              if ((int)($ltc['recurring_service_count'] ?? 0) > 1) {
+                $billingInterval = (int)$ltc['recurring_service_count'] . ' service schedules';
+              }
               $nextDate = $ltc['next_invoice_date'] ? date('M j, Y', strtotime($ltc['next_invoice_date'])) : '—';
               $lastDate = $ltc['last_invoice_date'] ? date('M j, Y', strtotime($ltc['last_invoice_date'])) : 'Not yet';
               
@@ -185,11 +242,106 @@ $contracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <?php endif; ?>
               </td>
               <td style="padding:10px"><?php echo htmlspecialchars($progressText); ?></td>
+              <td style="padding:10px;white-space:nowrap">
+                <a href="/?page=invoice/recurring-invoices-list&status=all&contract_id=<?php echo (int)$ltc['id']; ?>#invoice-history" style="font-size:13px;color:#2563eb;text-decoration:none">
+                  View invoices (<?php echo (int)$ltc['invoice_history_count']; ?>)
+                </a>
+              </td>
             </tr>
           <?php endforeach; ?>
         <?php endif; ?>
       </tbody>
     </table>
+  </div>
+
+  <div id="invoice-history" style="margin-top:28px;scroll-margin-top:20px">
+    <div style="display:flex;justify-content:space-between;align-items:flex-end;gap:16px;flex-wrap:wrap;margin-bottom:10px">
+      <div>
+        <h3 style="margin:0 0 4px;font-size:18px">Recurring Invoice History</h3>
+        <div style="font-size:13px;color:#6b7280">
+          <?php echo number_format($historyTotal); ?> invoice<?php echo $historyTotal === 1 ? '' : 's'; ?>, including paid and completed billing periods.
+          <?php if ($history_contract_id > 0): ?> Filtered to LTC-<?php echo (int)($contracts[0]['doc_number'] ?? $history_contract_id); ?>.<?php endif; ?>
+        </div>
+      </div>
+      <form method="get" action="/" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
+        <input type="hidden" name="page" value="invoice/recurring-invoices-list">
+        <?php if ($client_id > 0): ?><input type="hidden" name="client_id" value="<?php echo $client_id; ?>"><?php endif; ?>
+        <?php if ($client_name !== ''): ?><input type="hidden" name="client" value="<?php echo htmlspecialchars($client_name); ?>"><?php endif; ?>
+        <?php if ($project_code !== ''): ?><input type="hidden" name="project_code" value="<?php echo htmlspecialchars($project_code); ?>"><?php endif; ?>
+        <?php if ($history_contract_id > 0): ?><input type="hidden" name="contract_id" value="<?php echo $history_contract_id; ?>"><?php endif; ?>
+        <input type="hidden" name="status" value="<?php echo htmlspecialchars($status); ?>">
+        <label style="display:grid;gap:4px;font-size:12px;font-weight:600;color:#374151">
+          Invoice status
+          <select name="invoice_status" style="padding:7px 9px;border:1px solid #d1d5db;border-radius:7px;background:#fff" onchange="this.form.submit()">
+            <?php foreach ($allowedInvoiceStatuses as $invoiceStatusOption): ?>
+              <option value="<?php echo htmlspecialchars($invoiceStatusOption); ?>" <?php echo $invoice_status === $invoiceStatusOption ? 'selected' : ''; ?>><?php echo htmlspecialchars(ucfirst($invoiceStatusOption)); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </label>
+        <?php if ($history_contract_id > 0): ?>
+          <a href="/?page=invoice/recurring-invoices-list&status=<?php echo urlencode($status); ?>&invoice_status=<?php echo urlencode($invoice_status); ?>#invoice-history" style="padding:7px 10px;border:1px solid #d1d5db;border-radius:7px;background:#fff;text-decoration:none;color:#374151;font-size:13px">All contracts</a>
+        <?php endif; ?>
+      </form>
+    </div>
+
+    <div style="overflow:auto">
+      <table style="width:100%;border-collapse:collapse;background:#fff;border-radius:8px;box-shadow:0 6px 18px rgba(11,18,32,0.06)">
+        <thead>
+          <tr style="text-align:left;border-bottom:1px solid #eee">
+            <th style="padding:10px">Invoice</th>
+            <th style="padding:10px">Contract</th>
+            <th style="padding:10px">Client</th>
+            <th style="padding:10px">Issued</th>
+            <th style="padding:10px">Due</th>
+            <th style="padding:10px">Status</th>
+            <th style="padding:10px;text-align:right">Total</th>
+            <th style="padding:10px;text-align:right">Paid</th>
+            <th style="padding:10px;text-align:right">Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if (!$invoiceHistory): ?>
+            <tr><td colspan="9" style="padding:20px;text-align:center;color:#6b7280">No recurring invoices match these filters.</td></tr>
+          <?php else: ?>
+            <?php foreach ($invoiceHistory as $historyInvoice): ?>
+              <?php
+                $historyStatus = strtolower((string)$historyInvoice['status']);
+                $historyPaid = (float)$historyInvoice['amount_paid'];
+                $historyBalance = in_array($historyStatus, ['paid', 'cancelled', 'void'], true)
+                  ? max(0.0, (float)$historyInvoice['balance_due'])
+                  : max(0.0, (float)$historyInvoice['total'] - $historyPaid);
+                $historyRowStyle = $historyStatus === 'paid' ? 'background:#f0fdf4;' : (in_array($historyStatus, ['unpaid', 'partial', 'overdue', 'sent'], true) ? 'background:#fffbeb;' : '');
+              ?>
+              <tr style="border-top:1px solid #f3f4f6;<?php echo $historyRowStyle; ?>">
+                <td style="padding:10px;font-weight:600"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$historyInvoice['id']; ?>" style="color:#2563eb;text-decoration:none">I-<?php echo (int)($historyInvoice['doc_number'] ?? $historyInvoice['id']); ?></a></td>
+                <td style="padding:10px"><a href="/?page=contract/long-term-contract-details&id=<?php echo (int)$historyInvoice['contract_id']; ?>" style="color:inherit;text-decoration:none">LTC-<?php echo (int)($historyInvoice['contract_doc_number'] ?? $historyInvoice['contract_id']); ?></a></td>
+                <td style="padding:10px"><a href="/?page=client/clients-list&selected_client_id=<?php echo (int)$historyInvoice['client_id']; ?>"><?php echo htmlspecialchars((string)$historyInvoice['client_name']); ?></a></td>
+                <td style="padding:10px;white-space:nowrap"><?php echo !empty($historyInvoice['created_at']) ? date('M j, Y', strtotime((string)$historyInvoice['created_at'])) : '—'; ?></td>
+                <td style="padding:10px;white-space:nowrap"><?php echo !empty($historyInvoice['due_date']) ? date('M j, Y', strtotime((string)$historyInvoice['due_date'])) : '—'; ?></td>
+                <td style="padding:10px;text-transform:capitalize"><?php echo htmlspecialchars($historyStatus); ?></td>
+                <td style="padding:10px;text-align:right">$<?php echo number_format((float)$historyInvoice['total'], 2); ?></td>
+                <td style="padding:10px;text-align:right">$<?php echo number_format($historyPaid, 2); ?></td>
+                <td style="padding:10px;text-align:right;font-weight:600">$<?php echo number_format($historyBalance, 2); ?></td>
+              </tr>
+            <?php endforeach; ?>
+          <?php endif; ?>
+        </tbody>
+      </table>
+    </div>
+
+    <?php if ($historyLastPage > 1): ?>
+      <?php
+        $historyQuery = $_GET;
+        $historyQuery['page'] = 'invoice/recurring-invoices-list';
+        unset($historyQuery['history_page']);
+        $historyBase = '/?' . http_build_query($historyQuery);
+      ?>
+      <div style="display:flex;justify-content:flex-end;align-items:center;gap:8px;margin-top:12px">
+        <?php if ($history_page > 1): ?><a href="<?php echo htmlspecialchars($historyBase . '&history_page=' . ($history_page - 1)); ?>#invoice-history" style="padding:6px 10px;border:1px solid #d1d5db;border-radius:7px;background:#fff;text-decoration:none">Previous</a><?php endif; ?>
+        <span style="font-size:13px;color:#6b7280">Page <?php echo $history_page; ?> of <?php echo $historyLastPage; ?></span>
+        <?php if ($history_page < $historyLastPage): ?><a href="<?php echo htmlspecialchars($historyBase . '&history_page=' . ($history_page + 1)); ?>#invoice-history" style="padding:6px 10px;border:1px solid #d1d5db;border-radius:7px;background:#fff;text-decoration:none">Next</a><?php endif; ?>
+      </div>
+    <?php endif; ?>
   </div>
 
   <div style="margin-top:20px;padding:16px;background:#f9fafb;border:1px solid #e5e7eb;border-radius:8px">
@@ -198,7 +350,8 @@ $contracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
       <li><strong>Active contracts</strong> automatically generate invoices on their scheduled date</li>
       <li><strong>Pending contracts</strong> must be activated before invoicing begins</li>
       <li><strong>Paused contracts</strong> skip billing until resumed</li>
-      <li><strong>Completed contracts</strong> have finished their billing cycle</li>
+      <li><strong>Completed contracts</strong> have reached an end date, finished a fixed-total schedule, or were explicitly terminated</li>
+      <li>Paying a recurring invoice does not complete its long-term contract</li>
       <li>Invoices are generated daily by the system at 2:00 AM</li>
       <li>Fixed-total contracts complete automatically when fully invoiced</li>
     </ul>

--- a/tests/Payments/PaymentIntegrityTest.php
+++ b/tests/Payments/PaymentIntegrityTest.php
@@ -106,6 +106,26 @@ final class PaymentIntegrityTest extends TestCase
         self::assertSame('completed', (string)$status->fetchColumn());
     }
 
+    public function testFullPaymentDoesNotCompleteAnOngoingLongTermContract(): void
+    {
+        $orgId = $this->insertOrganization();
+        $clientId = $this->insertClient($orgId);
+        $contractId = $this->insertContract($orgId, $clientId, 'long_term', 'active');
+        $invoiceId = $this->insertInvoice($orgId, $clientId, 120.00, $contractId, 'long_term');
+
+        $result = invoice_record_locked_payment($this->pdo, $invoiceId, 120.00, 'check', 'LT-1001', null, [
+            'organization_id' => $orgId,
+            'complete_contract_when_paid' => true,
+            'source' => 'test',
+        ]);
+        $this->ids['payments'][] = (int)$result['payment_id'];
+
+        self::assertSame('paid', $result['status']);
+        $status = $this->pdo->prepare('SELECT status FROM contracts WHERE id = ?');
+        $status->execute([$contractId]);
+        self::assertSame('active', (string)$status->fetchColumn(), 'A recurring installment must not complete its long-term contract.');
+    }
+
     public function testDepositControllersUseCentralizedPaymentGuardrails(): void
     {
         $deposit = (string)file_get_contents(dirname(__DIR__, 2) . '/src/controllers/contract/contract_deposit_received.php');
@@ -141,21 +161,21 @@ final class PaymentIntegrityTest extends TestCase
         return $this->remember('clients', (int)$this->pdo->lastInsertId());
     }
 
-    private function insertContract(int $orgId, int $clientId): int
+    private function insertContract(int $orgId, int $clientId, string $contractType = 'regular', string $status = 'pending'): int
     {
-        $stmt = $this->pdo->prepare('INSERT INTO contracts (client_id, organization_id, status, total, deposit_type, deposit_amount, deposit_paid) VALUES (?, ?, "pending", 100, "none", 0, 0)');
-        $stmt->execute([$clientId, $orgId]);
+        $stmt = $this->pdo->prepare('INSERT INTO contracts (client_id, organization_id, status, contract_type, total, deposit_type, deposit_amount, deposit_paid) VALUES (?, ?, ?, ?, 100, "none", 0, 0)');
+        $stmt->execute([$clientId, $orgId, $status, $contractType]);
         return $this->remember('contracts', (int)$this->pdo->lastInsertId());
     }
 
-    private function insertInvoice(int $orgId, int $clientId, float $total, ?int $contractId = null): int
+    private function insertInvoice(int $orgId, int $clientId, float $total, ?int $contractId = null, string $invoiceType = 'regular'): int
     {
         $stmt = $this->pdo->prepare('
             INSERT INTO invoices
-                (client_id, contract_id, organization_id, status, subtotal, total, amount_paid, balance_due, finalized_at, collection_mode)
-            VALUES (?, ?, ?, "unpaid", ?, ?, 0, ?, NOW(), "direct")
+                (client_id, contract_id, organization_id, invoice_type, status, subtotal, total, amount_paid, balance_due, finalized_at, collection_mode)
+            VALUES (?, ?, ?, ?, "unpaid", ?, ?, 0, ?, NOW(), "direct")
         ');
-        $stmt->execute([$clientId, $contractId, $orgId, $total, $total, $total]);
+        $stmt->execute([$clientId, $contractId, $orgId, $invoiceType, $total, $total, $total]);
         return $this->remember('invoices', (int)$this->pdo->lastInsertId());
     }
 

--- a/tests/Workflows/FinancialSchedulingTest.php
+++ b/tests/Workflows/FinancialSchedulingTest.php
@@ -44,6 +44,8 @@ final class FinancialSchedulingTest extends TestCase
         $backup = file_get_contents($this->root . '/src/cron/backup_database.php');
         $backupPage = file_get_contents($this->root . '/src/views/pages/settings/backup.php');
         $entrypoint = file_get_contents($this->root . '/cron/entrypoint.sh');
+        $crontab = file_get_contents($this->root . '/cron/crontab');
+        $trueNasCompose = file_get_contents($this->root . '/docker-compose.truenas.yml');
 
         self::assertStringContainsString('ADD COLUMN updated_at', (string)$migration);
         self::assertStringContainsString('cron_state_ensure_schema', (string)$state);
@@ -53,12 +55,17 @@ final class FinancialSchedulingTest extends TestCase
         self::assertStringContainsString('backup_database_today_artifacts', (string)$backup);
         self::assertStringContainsString('$currentHour < $backupHour', (string)$backup);
         self::assertStringContainsString('Waiting for configured backup window', (string)$backup);
-        self::assertStringContainsString('cron_state_mark_success($pdo, $jobName, \'Cron disabled\')', (string)$backup);
+        self::assertStringNotContainsString("empty(\$appConfig['cron_enabled'])", (string)$backup);
         self::assertStringContainsString('The configured backup time has passed today; cron will catch up on the next hourly check', (string)$backupPage);
         self::assertStringContainsString("the next hourly check creates today's missing backup", (string)$backupPage);
+        self::assertStringContainsString('PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', (string)$crontab);
+        self::assertStringContainsString("printf 'export %s=%q\\n'", (string)$entrypoint);
         self::assertStringContainsString("config_key='timezone'", (string)$entrypoint);
         self::assertStringContainsString('/etc/localtime', (string)$entrypoint);
+        self::assertStringContainsString('backup_database.php --scheduled', (string)$entrypoint);
         self::assertStringContainsString('stripe_reconciliation.php --startup', (string)$entrypoint);
+        self::assertStringContainsString('project-alpha:cron-latest', (string)$trueNasCompose);
+        self::assertStringNotContainsString('cron-0.5.0-rc1', (string)$trueNasCompose);
     }
 
     public function testManualBackupUsesInlineRunnerWithVisibleFailurePath(): void

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -295,6 +295,16 @@ final class ProjectWorkflowUiTest extends TestCase
         $ltDetails = file_get_contents($this->root . '/src/views/pages/contract/long-term-contract-details.php');
         $ltList = file_get_contents($this->root . '/src/views/pages/contract/long-term-contracts-list.php');
         $recurringList = file_get_contents($this->root . '/src/views/pages/invoice/recurring-invoices-list.php');
+        $recurringBilling = file_get_contents($this->root . '/src/utils/recurring_billing.php');
+        $invoiceLifecycle = file_get_contents($this->root . '/src/utils/invoice_lifecycle.php');
+        $stripePayment = file_get_contents($this->root . '/src/controllers/webhook/stripe_payment_succeeded.php');
+        $stripeCheckout = file_get_contents($this->root . '/src/controllers/webhook/stripe_checkout_completed.php');
+        $stripeReconciliation = file_get_contents($this->root . '/src/utils/stripe_reconciliation_import.php');
+        $recurringServices = file_get_contents($this->root . '/src/utils/recurring_services.php');
+        $recurringServiceMigration = file_get_contents($this->root . '/database/migrations/0029_long_term_recurring_services.sql');
+        $recurringServiceSave = file_get_contents($this->root . '/src/controllers/contract/long_term_recurring_service_save.php');
+        $router = file_get_contents($this->root . '/public/index.php');
+        $recurringCron = file_get_contents($this->root . '/src/cron/generate_recurring_invoices.php');
 
         self::assertStringContainsString("billing_start_mode ENUM('on_upload','manual')", (string)$baseline);
         self::assertStringContainsString('ADD COLUMN billing_start_mode', (string)$migration);
@@ -322,6 +332,24 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('invoices_generated', (string)$ltList);
         self::assertStringContainsString('latest_invoice_id', (string)$ltList);
         self::assertStringContainsString('Edit billing', (string)$recurringList);
+        self::assertStringContainsString('Recurring Invoice History', (string)$recurringList);
+        self::assertStringContainsString('i.invoice_type="long_term"', (string)$recurringList);
+        self::assertStringContainsString('invoice_status', (string)$recurringList);
+        self::assertStringContainsString('balance_due, status, due_date', (string)$recurringBilling);
+        self::assertStringContainsString('invoice_complete_linked_contract_if_eligible', (string)$invoiceLifecycle);
+        self::assertStringContainsString("contract_type']) !== 'regular'", (string)$invoiceLifecycle);
+        foreach ([$stripePayment, $stripeCheckout, $stripeReconciliation] as $paymentPath) {
+            self::assertStringContainsString('invoice_complete_linked_contract_if_eligible($pdo, $invoiceId)', (string)$paymentPath);
+            self::assertStringNotContainsString("execute(['completed', \$contractId])", (string)$paymentPath);
+        }
+        self::assertStringContainsString('CREATE TABLE IF NOT EXISTS contract_recurring_services', (string)$recurringServiceMigration);
+        self::assertStringContainsString('CREATE TABLE IF NOT EXISTS contract_amendments', (string)$recurringServiceMigration);
+        self::assertStringContainsString('pa_recurring_services_due', (string)$recurringServices);
+        self::assertStringContainsString('generate_recurring_proration_invoice', (string)$recurringServiceSave);
+        self::assertStringContainsString('signed_addendum', (string)$recurringServiceSave);
+        self::assertStringContainsString('Recurring Services &amp; Amendments', (string)$ltDetails);
+        self::assertStringContainsString('long-term-recurring-service-save', (string)$router);
+        self::assertStringContainsString('recurring_invoice_send_on_generate_if_enabled($pdo, $invoiceId, $appConfig)', (string)$recurringCron);
     }
 
     public function testInvoiceAndContractNumbersArePerDocumentType(): void
@@ -461,6 +489,7 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('ensure_activity_log_table($pdo)', (string)$notifications);
         self::assertStringContainsString('PHP_VERSION_ID < 80500', (string)$dropbox);
         self::assertStringContainsString('validate_and_store_upload', (string)$publicSign);
+        self::assertStringContainsString("'image/jpeg' => ['jpg', 'jpeg']", (string)$publicSign);
         self::assertStringNotContainsString('finfo_close', (string)$publicSign);
     }
 
@@ -475,7 +504,7 @@ final class ProjectWorkflowUiTest extends TestCase
         $securityHeaders = file_get_contents($this->root . '/src/utils/security_headers.php');
 
         self::assertStringContainsString('invoice_ensure_payments_schema($pdo)', (string)$paymentController);
-        self::assertStringContainsString("'organization_id' => $organization_id", (string)$paymentController);
+        self::assertStringContainsString("'organization_id' => \$organization_id", (string)$paymentController);
         self::assertStringContainsString('function invoice_ensure_payments_schema', (string)$invoiceLifecycle);
         self::assertStringContainsString('ALTER TABLE payments ADD COLUMN {$column}', (string)$invoiceLifecycle);
         self::assertStringContainsString('$taxAmount = null;', (string)$expenseHandler);

--- a/tests/Workflows/RecurringServicesTest.php
+++ b/tests/Workflows/RecurringServicesTest.php
@@ -1,0 +1,155 @@
+<?php
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/src/migrations/migration_lib.php';
+require_once dirname(__DIR__, 2) . '/src/utils/recurring_billing.php';
+
+use PHPUnit\Framework\TestCase;
+
+final class RecurringServicesTest extends TestCase
+{
+    private PDO $pdo;
+    private array $ids = [];
+
+    protected function setUp(): void
+    {
+        try {
+            $this->pdo = migration_connection();
+            $exists = $this->pdo->query("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema=DATABASE() AND table_name='contract_recurring_services'")->fetchColumn();
+            if ((int)$exists !== 1) {
+                $this->markTestSkipped('Recurring service migration is not applied.');
+            }
+        } catch (Throwable $error) {
+            $this->markTestSkipped('MySQL backend unavailable: ' . $error->getMessage());
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (!isset($this->pdo)) return;
+        foreach (array_reverse($this->ids['invoices'] ?? []) as $invoiceId) {
+            $this->pdo->prepare('DELETE FROM invoice_notifications WHERE invoice_id=?')->execute([$invoiceId]);
+            $this->pdo->prepare('DELETE FROM public_links WHERE document_type="invoice" AND document_id=?')->execute([$invoiceId]);
+        }
+        foreach (array_reverse($this->ids['invoice_notifications'] ?? []) as $id) $this->pdo->prepare('DELETE FROM invoice_notifications WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['public_links'] ?? []) as $id) $this->pdo->prepare('DELETE FROM public_links WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['invoice_items'] ?? []) as $id) $this->pdo->prepare('DELETE FROM invoice_items WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['invoices'] ?? []) as $id) $this->pdo->prepare('DELETE FROM invoices WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['contract_amendments'] ?? []) as $id) $this->pdo->prepare('DELETE FROM contract_amendments WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['services'] ?? []) as $id) $this->pdo->prepare('DELETE FROM contract_recurring_services WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['contracts'] ?? []) as $id) $this->pdo->prepare('DELETE FROM contracts WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['clients'] ?? []) as $id) $this->pdo->prepare('DELETE FROM clients WHERE id=?')->execute([$id]);
+        foreach (array_reverse($this->ids['organizations'] ?? []) as $id) $this->pdo->prepare('DELETE FROM organizations WHERE id=?')->execute([$id]);
+    }
+
+    public function testIndependentAddonScheduleGeneratesAndAutomaticallyEmailsInvoice(): void
+    {
+        $today = date('Y-m-d');
+        $annualDate = date('Y-m-d', strtotime('+6 months'));
+        $orgId = $this->remember('organizations', $this->insert('INSERT INTO organizations (name) VALUES (?)', ['Recurring Services ' . bin2hex(random_bytes(3))]));
+        $clientId = $this->remember('clients', $this->insert('INSERT INTO clients (name,email,organization_id) VALUES (?,?,?)', ['Recurring Client', 'recurring@example.invalid', $orgId]));
+        $contractId = $this->remember('contracts', $this->insert('
+            INSERT INTO contracts
+                (client_id,organization_id,status,contract_type,pricing_type,price_per_invoice,
+                 billing_interval_count,billing_interval_unit,start_date,next_invoice_date,
+                 signed_pdf_path,total_invoiced,invoices_generated,subtotal,total)
+            VALUES (?,? ,"active","long_term","per_invoice",1200,1,"year",?,?,"signed.pdf",0,0,1200,1200)
+        ', [$clientId, $orgId, $today, $today]));
+
+        $hostingId = $this->remember('services', $this->insert('
+            INSERT INTO contract_recurring_services
+                (contract_id,name,amount,billing_interval_count,billing_interval_unit,effective_from,next_invoice_date,status,approval_status,is_base)
+            VALUES (?,"Website Hosting",1200,1,"year",?, ?,"active","approved",1)
+        ', [$contractId, $today, $annualDate]));
+        $adsId = $this->remember('services', $this->insert('
+            INSERT INTO contract_recurring_services
+                (contract_id,name,description,amount,billing_interval_count,billing_interval_unit,effective_from,next_invoice_date,status,approval_status,is_base)
+            VALUES (?,"Advertising Management","Campaign optimization",500,1,"month",?, ?,"active","approved",0)
+        ', [$contractId, $today, $today]));
+
+        $contractStmt = $this->pdo->prepare('SELECT * FROM contracts WHERE id=?');
+        $contractStmt->execute([$contractId]);
+        $contract = $contractStmt->fetch(PDO::FETCH_ASSOC);
+        $deliveries = [];
+        $config = [
+            'net_terms_days' => 14,
+            'invoice_auto_email_on_generate' => 1,
+            'app_host' => 'https://example.invalid',
+            '_email_sender' => static function (string $to, string $subject, string $body, array $context) use (&$deliveries): array {
+                $deliveries[] = compact('to', 'subject', 'body', 'context');
+                return [true, ''];
+            },
+        ];
+
+        $invoiceId = generate_recurring_invoice($this->pdo, $contract, $config);
+        self::assertNotNull($invoiceId);
+        $this->remember('invoices', (int)$invoiceId);
+        $itemIds = $this->pdo->prepare('SELECT id FROM invoice_items WHERE invoice_id=?');
+        $itemIds->execute([$invoiceId]);
+        foreach ($itemIds->fetchAll(PDO::FETCH_COLUMN) as $itemId) $this->remember('invoice_items', (int)$itemId);
+
+        $invoiceStmt = $this->pdo->prepare('SELECT status,subtotal,total,balance_due,finalized_at,sent_at FROM invoices WHERE id=?');
+        $invoiceStmt->execute([$invoiceId]);
+        $invoice = $invoiceStmt->fetch(PDO::FETCH_ASSOC);
+        self::assertSame('unpaid', $invoice['status']);
+        self::assertEqualsWithDelta(500.0, (float)$invoice['subtotal'], 0.005);
+        self::assertEqualsWithDelta((float)$invoice['total'], (float)$invoice['balance_due'], 0.005);
+        self::assertNotEmpty($invoice['finalized_at']);
+
+        $lineStmt = $this->pdo->prepare('SELECT item,line_total FROM invoice_items WHERE invoice_id=?');
+        $lineStmt->execute([$invoiceId]);
+        $lines = $lineStmt->fetchAll(PDO::FETCH_ASSOC);
+        self::assertCount(1, $lines);
+        self::assertSame('Advertising Management', $lines[0]['item']);
+        self::assertEqualsWithDelta(500.0, (float)$lines[0]['line_total'], 0.005);
+
+        $hostingStmt = $this->pdo->prepare('SELECT next_invoice_date FROM contract_recurring_services WHERE id=?');
+        $hostingStmt->execute([$hostingId]);
+        self::assertSame($annualDate, (string)$hostingStmt->fetchColumn(), 'The annual hosting schedule must not move when the monthly ads invoice is generated.');
+        $adsStmt = $this->pdo->prepare('SELECT next_invoice_date FROM contract_recurring_services WHERE id=?');
+        $adsStmt->execute([$adsId]);
+        self::assertSame(date('Y-m-d', strtotime($today . ' +1 month')), (string)$adsStmt->fetchColumn());
+
+        self::assertTrue(recurring_invoice_send_on_generate_if_enabled($this->pdo, $invoiceId, $config));
+        self::assertCount(1, $deliveries);
+        self::assertSame('recurring@example.invalid', $deliveries[0]['to']);
+        self::assertSame((int)$invoiceId, (int)$deliveries[0]['context']['invoice_id']);
+        self::assertStringContainsString('Invoice I-', $deliveries[0]['subject']);
+
+        $notificationStmt = $this->pdo->prepare('SELECT id,sent_at FROM invoice_notifications WHERE invoice_id=? AND notification_type="on_generate"');
+        $notificationStmt->execute([$invoiceId]);
+        $notification = $notificationStmt->fetch(PDO::FETCH_ASSOC);
+        self::assertNotEmpty($notification['sent_at']);
+        $this->remember('invoice_notifications', (int)$notification['id']);
+        $linkStmt = $this->pdo->prepare('SELECT id,expire_when_paid,revoked FROM public_links WHERE document_type="invoice" AND document_id=?');
+        $linkStmt->execute([$invoiceId]);
+        $link = $linkStmt->fetch(PDO::FETCH_ASSOC);
+        self::assertSame(1, (int)$link['expire_when_paid']);
+        self::assertSame(0, (int)$link['revoked']);
+        $this->remember('public_links', (int)$link['id']);
+
+        self::assertTrue(recurring_invoice_send_on_generate_if_enabled($this->pdo, $invoiceId, $config));
+        self::assertCount(1, $deliveries, 'Automatic delivery must be idempotent.');
+    }
+
+    public function testMonthlyAndAnnualSchedulesKeepTheirCalendarAnchor(): void
+    {
+        self::assertSame('2026-02-28', pa_recurring_service_next_date('2026-01-31', 1, 'month', '2026-01-31'));
+        self::assertSame('2026-03-31', pa_recurring_service_next_date('2026-02-28', 1, 'month', '2026-01-31'));
+        self::assertSame('2025-02-28', pa_recurring_service_next_date('2024-02-29', 1, 'year', '2024-02-29'));
+        self::assertSame('2028-02-29', pa_recurring_service_next_date('2027-02-28', 1, 'year', '2024-02-29'));
+    }
+
+    private function insert(string $sql, array $params): int
+    {
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    private function remember(string $bucket, int $id): int
+    {
+        $this->ids[$bucket][] = $id;
+        return $id;
+    }
+}


### PR DESCRIPTION
## What changed

- Keep open-ended long-term contracts active after individual invoices are paid.
- Add independent recurring service schedules, amendments, proration support, invoice history, and lifecycle controls.
- Repair public contract `.jpeg` upload acceptance.
- Generate and auto-send due recurring invoices idempotently.
- Repair scheduled backups by giving cron the PHP executable path, safely exporting its environment, and running a startup catch-up check.
- Add migrations 0028 and 0029 plus TrueNAS and CI deployment safeguards.

## Root causes

Long-term contract completion was incorrectly coupled to invoice payment, recurring services had only one aggregate schedule, paid recurring invoices were hidden from the primary workflow, and the cron daemon could not find `/usr/local/bin/php`. Cron environment assignments were also not safely exported to child PHP processes.

## Validation

- Full PHPUnit suite: 122 tests, 1,388 assertions, with one pre-existing skipped Wisconsin fixture.
- Migration files validated and migrations 0028 and 0029 applied successfully in the local integration database.
- A real scheduled-style backup was created and recorded successfully.
- A second backup run recognized the existing daily backup without duplication.
- Recurring service generation and automatic-send behavior were verified with an idempotent test transport.
