### PR TITLE
Complete invoice and recurring billing workflows

### DIFF
--- a/database/baseline.sql
+++ b/database/baseline.sql
@@ -920,6 +920,10 @@ CREATE TABLE IF NOT EXISTS invoices (
     weather_pending TINYINT(1) NOT NULL DEFAULT 0,
     estimated_completion VARCHAR(200) NULL,
     paid_at TIMESTAMP NULL,
+    voided_at TIMESTAMP NULL,
+    voided_by INT NULL,
+    void_reason VARCHAR(500) NULL,
+    void_previous_status VARCHAR(32) NULL,
     sent_at TIMESTAMP NULL,
     finalized_at TIMESTAMP NULL,
     finalized_by INT NULL,
@@ -948,6 +952,7 @@ CREATE TABLE IF NOT EXISTS invoices (
     INDEX idx_invoices_doc_number (doc_number),
     INDEX idx_invoices_project_code (project_code),
     INDEX idx_invoices_due_date (due_date),
+    INDEX idx_invoices_voided_at (voided_at),
     INDEX idx_invoices_auto_pay_attempt (last_auto_pay_attempt),
     CONSTRAINT fk_invoices_contract FOREIGN KEY (contract_id) REFERENCES contracts(id) ON DELETE SET NULL,
     CONSTRAINT fk_invoices_quote FOREIGN KEY (quote_id) REFERENCES quotes(id) ON DELETE SET NULL,
@@ -1042,7 +1047,10 @@ CREATE TABLE IF NOT EXISTS payments (
     stripe_session_id VARCHAR(255) NULL,
     stripe_payment_intent_id VARCHAR(255) NULL,
     auto_pay_attempt TINYINT(1) NOT NULL DEFAULT 0,
-    status ENUM('succeeded', 'failed', 'pending') NOT NULL DEFAULT 'succeeded',
+    status ENUM('succeeded', 'failed', 'pending', 'reversed') NOT NULL DEFAULT 'succeeded',
+    reversed_at TIMESTAMP NULL,
+    reversed_by INT NULL,
+    reversal_reason VARCHAR(500) NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX idx_payments_client (client_id),
@@ -1056,6 +1064,29 @@ CREATE TABLE IF NOT EXISTS payments (
     CONSTRAINT fk_payments_invoice FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE SET NULL,
     CONSTRAINT fk_payments_project_payment FOREIGN KEY (project_invoice_payment_id) REFERENCES project_invoice_payments(id) ON DELETE SET NULL,
     CONSTRAINT fk_payments_contract FOREIGN KEY (contract_id) REFERENCES contracts(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- PAYMENT ALLOCATION CORRECTIONS
+CREATE TABLE IF NOT EXISTS payment_corrections (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    moved_payment_id INT NULL,
+    reversed_payment_id INT NULL,
+    source_invoice_id INT NULL,
+    target_invoice_id INT NULL,
+    corrected_by INT NULL,
+    source_voided TINYINT(1) NOT NULL DEFAULT 0,
+    reason VARCHAR(500) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_payment_corrections_moved (moved_payment_id),
+    INDEX idx_payment_corrections_reversed (reversed_payment_id),
+    INDEX idx_payment_corrections_source (source_invoice_id),
+    INDEX idx_payment_corrections_target (target_invoice_id),
+    INDEX idx_payment_corrections_created (created_at),
+    CONSTRAINT fk_payment_correction_moved FOREIGN KEY (moved_payment_id) REFERENCES payments(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_reversed FOREIGN KEY (reversed_payment_id) REFERENCES payments(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_source FOREIGN KEY (source_invoice_id) REFERENCES invoices(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_target FOREIGN KEY (target_invoice_id) REFERENCES invoices(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_user FOREIGN KEY (corrected_by) REFERENCES users(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- PAYMENT INTENTS

--- a/database/migrations/0030_invoice_void_workflow.sql
+++ b/database/migrations/0030_invoice_void_workflow.sql
@@ -1,0 +1,37 @@
+-- Add durable metadata for individually voided invoices.
+-- The invoice row and amounts remain intact for accounting and audit history.
+
+SET @invoice_voided_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'invoices' AND column_name = 'voided_at'
+);
+SET @sql := IF(@invoice_voided_at_exists = 0, 'ALTER TABLE invoices ADD COLUMN voided_at TIMESTAMP NULL AFTER paid_at', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @invoice_voided_by_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'invoices' AND column_name = 'voided_by'
+);
+SET @sql := IF(@invoice_voided_by_exists = 0, 'ALTER TABLE invoices ADD COLUMN voided_by INT NULL AFTER voided_at', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @invoice_void_reason_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'invoices' AND column_name = 'void_reason'
+);
+SET @sql := IF(@invoice_void_reason_exists = 0, 'ALTER TABLE invoices ADD COLUMN void_reason VARCHAR(500) NULL AFTER voided_by', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @invoice_void_previous_status_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'invoices' AND column_name = 'void_previous_status'
+);
+SET @sql := IF(@invoice_void_previous_status_exists = 0, 'ALTER TABLE invoices ADD COLUMN void_previous_status VARCHAR(32) NULL AFTER void_reason', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @invoice_voided_at_index_exists := (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = DATABASE() AND table_name = 'invoices' AND index_name = 'idx_invoices_voided_at'
+);
+SET @sql := IF(@invoice_voided_at_index_exists = 0, 'ALTER TABLE invoices ADD INDEX idx_invoices_voided_at (voided_at)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/database/migrations/0031_payment_allocation_corrections.sql
+++ b/database/migrations/0031_payment_allocation_corrections.sql
@@ -1,0 +1,49 @@
+-- Preserve accounting corrections without misclassifying them as refunds.
+-- A reversed payment is a mistaken local entry; it does not imply money was
+-- returned to the client or that a processor refund occurred.
+
+ALTER TABLE payments
+    MODIFY COLUMN status ENUM('succeeded','failed','pending','reversed') NOT NULL DEFAULT 'succeeded';
+
+SET @payment_reversed_at_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'payments' AND column_name = 'reversed_at'
+);
+SET @sql := IF(@payment_reversed_at_exists = 0, 'ALTER TABLE payments ADD COLUMN reversed_at TIMESTAMP NULL AFTER status', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @payment_reversed_by_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'payments' AND column_name = 'reversed_by'
+);
+SET @sql := IF(@payment_reversed_by_exists = 0, 'ALTER TABLE payments ADD COLUMN reversed_by INT NULL AFTER reversed_at', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @payment_reversal_reason_exists := (
+    SELECT COUNT(*) FROM information_schema.columns
+    WHERE table_schema = DATABASE() AND table_name = 'payments' AND column_name = 'reversal_reason'
+);
+SET @sql := IF(@payment_reversal_reason_exists = 0, 'ALTER TABLE payments ADD COLUMN reversal_reason VARCHAR(500) NULL AFTER reversed_by', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS payment_corrections (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    moved_payment_id INT NULL,
+    reversed_payment_id INT NULL,
+    source_invoice_id INT NULL,
+    target_invoice_id INT NULL,
+    corrected_by INT NULL,
+    source_voided TINYINT(1) NOT NULL DEFAULT 0,
+    reason VARCHAR(500) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_payment_corrections_moved (moved_payment_id),
+    INDEX idx_payment_corrections_reversed (reversed_payment_id),
+    INDEX idx_payment_corrections_source (source_invoice_id),
+    INDEX idx_payment_corrections_target (target_invoice_id),
+    INDEX idx_payment_corrections_created (created_at),
+    CONSTRAINT fk_payment_correction_moved FOREIGN KEY (moved_payment_id) REFERENCES payments(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_reversed FOREIGN KEY (reversed_payment_id) REFERENCES payments(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_source FOREIGN KEY (source_invoice_id) REFERENCES invoices(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_target FOREIGN KEY (target_invoice_id) REFERENCES invoices(id) ON DELETE SET NULL,
+    CONSTRAINT fk_payment_correction_user FOREIGN KEY (corrected_by) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/docs/workflows/documents.md
+++ b/docs/workflows/documents.md
@@ -45,3 +45,9 @@ Clients can use public document links to approve or deny quotes, upload signed c
 
 Document detail pages show the current public-link state so PA users can tell whether a client link is accessible, redirected, or unavailable.
 
+## Voiding an Invoice
+
+Use **Void Invoice** on an invoice detail page when an unpaid invoice was created by mistake. A reason is required. Voiding preserves the invoice and its totals for audit history, sets its collectible balance to zero, revokes client and payment links, and releases any attached time entries so they can be billed correctly later.
+
+Paid and partially paid invoices cannot be voided; use the refund or credit process instead. Invoices already included in a project aggregate invoice also cannot be voided individually. Re-enabling a void invoice restores it to draft or unpaid, but old public links remain revoked so a new link must be created before resending.
+

--- a/docs/workflows/recurring-billing.md
+++ b/docs/workflows/recurring-billing.md
@@ -43,7 +43,22 @@ The contract lifecycle and each invoice lifecycle are independent:
 
 The **Recurring Billing** page shows both the active schedules and a filterable history of every generated recurring invoice, including paid invoices.
 
+Selecting **View history** on a billing schedule filters that history to the selected long-term contract and scrolls directly to the matching invoices. An unpaid recurring invoice created by mistake can be opened from **View / Actions** and voided without pausing, completing, or advancing the underlying contract schedule.
+
+Invoice display numbers are type-specific while preserving the existing numeric sequence: regular invoices use `I-#`, long-term recurring invoices use `LTI-#`, and on-demand invoices use `ODI-#`. Existing records are not renumbered; the prefix is derived from `invoice_type` everywhere the invoice is displayed, emailed, downloaded, or sent to Stripe.
+
 ## Manual Recovery
 
 If a long-term contract is active but an invoice was not generated when expected, use the long-term contract details page to review the schedule and generate or send the needed invoice.
+
+If a temporary one-off invoice was paid before the delayed recurring invoice appeared, do not record a refund unless money is actually being returned to the client. Open **Payments**, choose **Correct allocation** on the real payment, select the recurring invoice, and select any duplicate manual cash/check entry to reverse. PA will:
+
+- keep the original Stripe transaction and processor identifiers;
+- move that payment to the selected recurring invoice;
+- mark the duplicate manual entry as reversed rather than refunded or deleted;
+- refresh the balances and paid dates on both invoices;
+- optionally retain the accidental source invoice as void; and
+- leave the long-term contract active.
+
+Processor-backed refunds must be initiated in Stripe and are synchronized into PA by Stripe webhook events. The local **Record refund** action is limited to payments whose money was returned outside a connected processor.
 

--- a/public/assets/js/time-tracking.js
+++ b/public/assets/js/time-tracking.js
@@ -284,7 +284,8 @@
             (data.invoices || []).forEach(function (invoice) {
                 const option = document.createElement('option');
                 option.value = String(invoice.id || '');
-                option.textContent = 'I-' + (invoice.doc_number || invoice.id) + (invoice.project_code ? ' / Job ' + invoice.project_code : '');
+                const invoicePrefix = invoice.invoice_type === 'long_term' ? 'LTI-' : (invoice.invoice_type === 'on_demand' ? 'ODI-' : 'I-');
+                option.textContent = invoicePrefix + (invoice.doc_number || invoice.id) + (invoice.project_code ? ' / Job ' + invoice.project_code : '');
                 option.setAttribute('data-project-code', invoice.project_code || '');
                 option.setAttribute('data-project-id', invoice.project_id || '');
                 option.setAttribute('data-contract-id', invoice.contract_id || '');

--- a/public/assets/navigation.js
+++ b/public/assets/navigation.js
@@ -124,7 +124,9 @@ function buildUrlFromPageString(page) {
         return u.href;
     }
 
-    const [pagePart, rest] = page.split('&', 2);
+    const separatorIndex = page.indexOf('&');
+    const pagePart = separatorIndex >= 0 ? page.slice(0, separatorIndex) : page;
+    const rest = separatorIndex >= 0 ? page.slice(separatorIndex + 1) : '';
     u.searchParams.set('page', pagePart);
 
     if (rest) {
@@ -270,8 +272,28 @@ async function executePageScripts(scripts) {
     }
 }
 
-async function navigateToPage(page, updateHistory = true) {
+function scrollToPageHash(targetHash) {
+    if (!targetHash || targetHash === '#') return;
+    let targetId = targetHash.slice(1);
+    try {
+        targetId = decodeURIComponent(targetId);
+    } catch (error) {
+        return;
+    }
+    requestAnimationFrame(() => {
+        const target = document.getElementById(targetId);
+        if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+}
+
+async function navigateToPage(page, updateHistory = true, targetHash = '') {
     if (page === currentPage && !page.includes('selected_client_id')) {
+        if (targetHash) {
+            const samePageUrl = new URL(window.location.href);
+            samePageUrl.hash = targetHash;
+            if (updateHistory) history.pushState({ page }, '', samePageUrl.href);
+            scrollToPageHash(targetHash);
+        }
         return; // Already on this page
     }
 
@@ -294,7 +316,9 @@ async function navigateToPage(page, updateHistory = true) {
 
         if (content === null) {
             // Fallback to full page reload using canonical builder
-            window.location.href = buildUrlFromPageString(page);
+            const fallbackUrl = new URL(buildUrlFromPageString(page));
+            fallbackUrl.hash = targetHash;
+            window.location.href = fallbackUrl.href;
             return;
         }
 
@@ -311,8 +335,9 @@ async function navigateToPage(page, updateHistory = true) {
             // Update browser history before page scripts run so initializers see the new URL.
             if (updateHistory) {
                 // Use same URL builder so history uses the canonical query string
-                const absolute = buildUrlFromPageString(page);
-                const rel = absolute.replace(window.location.origin, '');
+                const historyUrl = new URL(buildUrlFromPageString(page));
+                historyUrl.hash = targetHash;
+                const rel = historyUrl.href.replace(window.location.origin, '');
                 history.pushState({ page }, '', rel);
             }
 
@@ -328,12 +353,15 @@ async function navigateToPage(page, updateHistory = true) {
 
             // Keep the legacy event for older scripts while new page scripts use ProjectAlpha.registerPage.
             dispatchPageLoaded(page);
+            scrollToPageHash(targetHash);
         }
 
     } catch (error) {
         console.error('Navigation error:', error);
         // Fallback to full page reload
-        window.location.href = buildUrlFromPageString(page);
+        const fallbackUrl = new URL(buildUrlFromPageString(page));
+        fallbackUrl.hash = targetHash;
+        window.location.href = fallbackUrl.href;
     }
 }
 
@@ -419,13 +447,13 @@ function handleNavigation(event) {
 
     const fullPage = additionalParams ? `${pageName}&${additionalParams}` : pageName;
 
-    navigateToPage(fullPage);
+    navigateToPage(fullPage, true, linkUrl.hash);
 }
 
 // Handle browser back/forward buttons
 function handlePopState(event) {
     const page = event.state?.page || getCurrentPage();
-    navigateToPage(page, false); // Don't update history since this is from history
+    navigateToPage(page, false, window.location.hash); // Don't update history since this is from history
 }
 
 function getDocumentFilterStorageKey(buttonOrPanel) {

--- a/public/index.php
+++ b/public/index.php
@@ -747,6 +747,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'invoice/invoices-mark-paid',
         'invoice/invoice-finalize',
         'invoice/invoice-reopen',
+        'invoice/invoice-void',
+        'invoice/invoice-reenable',
         'invoice/email-send',
         'payments/payments-create',
 
@@ -1101,12 +1103,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/../src/controllers/invoice/invoice_reopen.php';
         exit;
     }
+    if ($page === 'invoice/invoice-void') {
+        require_once __DIR__ . '/../src/controllers/invoice/invoice_void.php';
+        exit;
+    }
+    if ($page === 'invoice/invoice-reenable') {
+        require_once __DIR__ . '/../src/controllers/invoice/invoice_reenable.php';
+        exit;
+    }
     if ($page === 'payments/payments-create') {
         require_once __DIR__ . '/../src/controllers/payments_create.php';
         exit;
     }
     if ($page === 'payments/payment-refund') {
         require_once __DIR__ . '/../src/controllers/payments_refund.php';
+        exit;
+    }
+    if ($page === 'payments/payment-correct') {
+        require_once __DIR__ . '/../src/controllers/payments_correct.php';
         exit;
     }
     if ($page === 'quote/quotes-update' || $page === 'quotes-update') {

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -4,6 +4,8 @@
 // Secrets (Stripe keys, SMTP password, encryption key) are loaded from environment variables
 // or .env file first; non-sensitive settings come from settings.json.
 
+require_once __DIR__ . '/../utils/invoice_numbers.php';
+
 $settingsPrimary = '/var/www/config/settings.json';
 $settingsProject = __DIR__ . '/../../config/settings.json';
 $settingsPublic  = __DIR__ . '/../../public/assets/settings.json';

--- a/src/controllers/api/invoices_list.php
+++ b/src/controllers/api/invoices_list.php
@@ -21,7 +21,7 @@ if ($scopeWhere !== '') {
 }
 $whereSQL = !empty($where) ? 'WHERE ' . implode(' AND ', $where) : '';
 
-$sql = "SELECT i.id, i.doc_number, i.client_id, i.total, i.status, i.balance, i.created_at, i.updated_at FROM invoices i {$whereSQL} ORDER BY i.updated_at DESC LIMIT ?";
+$sql = "SELECT i.id, i.doc_number, i.invoice_type, i.client_id, i.total, i.status, i.balance, i.created_at, i.updated_at FROM invoices i {$whereSQL} ORDER BY i.updated_at DESC LIMIT ?";
 $params[] = $limit;
 
 $stmt = $pdo->prepare($sql);

--- a/src/controllers/contract/on_demand_invoice_generate.php
+++ b/src/controllers/contract/on_demand_invoice_generate.php
@@ -203,9 +203,10 @@ try {
                     $host = rtrim(($appConfig['app_host'] ?? ''), '/');
                     if ($host !== '') { $link = $host . $link; }
 
-                    $subject = sprintf('Invoice I-%s has been generated', $docNumber);
+                    $invoiceLabel = pa_invoice_label($docNumber, 'on_demand');
+                    $subject = sprintf('Invoice %s has been generated', $invoiceLabel);
                     $body = '<p>Dear ' . htmlspecialchars($client['name'] ?? '') . ',</p>';
-                    $body .= '<p>A new invoice <strong>I-' . htmlspecialchars((string)$docNumber) . '</strong> for <strong>$' . number_format($total, 2) . '</strong> has been generated';
+                    $body .= '<p>A new invoice <strong>' . htmlspecialchars($invoiceLabel) . '</strong> for <strong>$' . number_format($total, 2) . '</strong> has been generated';
                     if (!empty($dueDate)) {
                         $body .= ', due on <strong>' . htmlspecialchars($dueDate) . '</strong>';
                     }
@@ -217,9 +218,9 @@ try {
                     if ($ok) {
                         $insNotif = $pdo->prepare('INSERT IGNORE INTO invoice_notifications (invoice_id, notification_type, sent_at) VALUES (?,?,NOW())');
                         $insNotif->execute([$invoiceId, 'on_generate']);
-                        @error_log("[on_demand_invoice_generate] Sent on-generate email for invoice I-" . $docNumber);
+                        @error_log("[on_demand_invoice_generate] Sent on-generate email for invoice " . $invoiceLabel);
                     } else {
-                        @error_log("[on_demand_invoice_generate] Failed to send on-generate email for invoice I-" . $docNumber . ": $err");
+                        @error_log("[on_demand_invoice_generate] Failed to send on-generate email for invoice " . $invoiceLabel . ": $err");
                     }
                 }
             }

--- a/src/controllers/document_reenable_handler.php
+++ b/src/controllers/document_reenable_handler.php
@@ -3,6 +3,7 @@
 // Re-enable (un-void) voided/cancelled documents and restore related documents
 
 require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../utils/invoice_lifecycle.php';
 
 // CSRF is already verified by the router (index.php)
 // No need to verify again here
@@ -70,27 +71,8 @@ try {
             break;
 
         case 'invoice':
-            // Re-enable invoice (change from void back to unpaid)
-            $st = $pdo->prepare('SELECT * FROM invoices WHERE id=? FOR UPDATE');
-            $st->execute([$id]);
-            $doc = $st->fetch(PDO::FETCH_ASSOC);
-            if (!$doc) throw new Exception('Invoice not found');
-            
-            // Only allow re-enabling void invoices
-            if ($doc['status'] !== 'void') {
-                throw new Exception('Only void invoices can be re-enabled');
-            }
-            
-            // Update status to unpaid and refresh document_date
-            $pdo->prepare("UPDATE invoices SET status='unpaid', document_date=CURRENT_TIMESTAMP, document_date_updated_at=CURRENT_TIMESTAMP WHERE id=?")
-                ->execute([$id]);
-            
-            // Un-revoke public links
-            try {
-                $pdo->prepare('UPDATE public_links SET revoked=0, redirect=NULL WHERE document_type="invoice" AND document_id=? AND revoked=1')
-                    ->execute([$id]);
-            } catch (Throwable $_e) { /* ignore */ }
-            
+            // Backward-compatible route; invoice pages use invoice/invoice-reenable.
+            invoice_reenable_void($pdo, $id);
             $redirectPage = 'invoice/invoice-details';
             break;
 

--- a/src/controllers/email_send.php
+++ b/src/controllers/email_send.php
@@ -26,6 +26,7 @@ if (!in_array($type, ['quote','contract','invoice'], true) || $id <= 0) {
 $ownershipTable = ['quote' => 'quotes', 'contract' => 'contracts', 'invoice' => 'invoices'][$type];
 require_record_ownership($pdo, $ownershipTable, $id);
 
+$invoiceLabel = '';
 try {
   if ($type === 'quote') {
     $st = $pdo->prepare('SELECT q.id, q.doc_number, q.project_code, q.status, c.email, c.name FROM quotes q JOIN clients c ON c.id=q.client_id WHERE q.id=?');
@@ -44,12 +45,13 @@ try {
     $subject = 'Contract C-' . $docnum . ' for ' . $clientName;
     $baseView = '/?page=contract-print&id='.$id;
   } else { // invoice
-    $st = $pdo->prepare('SELECT i.id, i.doc_number, i.project_code, i.status, c.email, c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.id=?');
+    $st = $pdo->prepare('SELECT i.id, i.doc_number, i.invoice_type, i.project_code, i.status, c.email, c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.id=?');
     $st->execute([$id]);
     $row = $st->fetch(PDO::FETCH_ASSOC);
     $docnum = (string)($row['doc_number'] ?? $row['id'] ?? '');
     $clientName = (string)($row['name'] ?? 'client');
-    $subject = 'Invoice I-' . $docnum . ' for ' . $clientName;
+    $invoiceLabel = pa_invoice_label_from_row($row ?: ['id' => $id]);
+    $subject = 'Invoice ' . $invoiceLabel . ' for ' . $clientName;
     $baseView = '/?page=invoice-print&id='.$id;
   }
 
@@ -266,8 +268,11 @@ try {
             // ignore canvas failures and continue sending without header/footer
           }
           $pdfBinary = $dompdf->output();
-          $prefix = $type === 'quote' ? 'quote_Q-' : ($type === 'contract' ? 'contract_C-' : 'invoice_I-');
-          $filename = $prefix . ($docnum ?: $id) . '.pdf';
+          $filename = $type === 'quote'
+            ? 'quote_Q-' . ($docnum ?: $id) . '.pdf'
+            : ($type === 'contract'
+              ? 'contract_C-' . ($docnum ?: $id) . '.pdf'
+              : 'invoice_' . $invoiceLabel . '.pdf');
           $attachments[] = ['filename'=>$filename, 'content'=>$pdfBinary, 'mime'=>'application/pdf'];
         }
       } catch (Throwable $e) {

--- a/src/controllers/financial/audit_export.php
+++ b/src/controllers/financial/audit_export.php
@@ -129,7 +129,7 @@ try {
         
         if ($accountingBasis === 'cash') {
             $invoiceQuery = "
-                SELECT i.id,i.doc_number,i.client_id,c.name AS client_name,i.project_code,
+                SELECT i.id,i.doc_number,i.invoice_type,i.client_id,c.name AS client_name,i.project_code,
                        i.subtotal,i.tax_percent,i.tax_amount AS tax,i.tax_county,i.discount_value,
                        i.total,i.status,MIN(p.payment_date) AS report_date,i.created_at,i.due_date,
                        SUM(GREATEST(p.amount-p.refunded_amount-p.disputed_amount,0)) AS amount_paid,
@@ -148,6 +148,7 @@ try {
             SELECT 
                 i.id,
                 i.doc_number,
+                i.invoice_type,
                 i.client_id,
                 c.name as client_name,
                 i.project_code,
@@ -280,7 +281,7 @@ try {
             csv_write_row($fp, [
                 substr($inv['report_date'] ?? $inv['created_at'] ?? '', 0, 10),
                 $inv['client_name'] ?? '',
-                $inv['doc_number'] ?? $inv['id'],
+                pa_invoice_label_from_row($inv),
                 'Invoice',
                 ucfirst($inv['status'] ?? ''),
                 number_format((float)($inv['tax_percent'] ?? 0), 2) . '%',

--- a/src/controllers/invoice/invoice_pdf.php
+++ b/src/controllers/invoice/invoice_pdf.php
@@ -43,7 +43,7 @@ if (!defined('PUBLIC_VIEW')) {
 if ($id <= 0) { http_response_code(400); echo 'Invalid id'; exit; }
 
 // Fetch document_date from the database
-$stmt = $pdo->prepare('SELECT document_date FROM invoices WHERE id=?');
+$stmt = $pdo->prepare('SELECT document_date,doc_number,invoice_type FROM invoices WHERE id=?');
 $stmt->execute([$id]);
 $doc = $stmt->fetch(PDO::FETCH_ASSOC);
 $documentDate = $doc && !empty($doc['document_date']) ? date('m/d/Y', strtotime($doc['document_date'])) : date('m/d/Y');
@@ -87,7 +87,7 @@ $canvas->page_text($w - 140, 22, $pageText, $font, 10, [0,0,0]);
 $h = $canvas->get_height();
 $canvas->page_text(54, $h - 30, 'Powered by Project-Alpha', $font, 10, [0,0,0]);
 
-$filename = 'invoice_I-' . ($id) . '.pdf';
+$filename = 'invoice_' . pa_invoice_label($doc['doc_number'] ?? null, $doc['invoice_type'] ?? 'regular', $id) . '.pdf';
 header('Content-Type: application/pdf');
 header('Content-Disposition: inline; filename="' . $filename . '"');
 $dompdf->stream($filename, ['Attachment' => false]);

--- a/src/controllers/invoice/invoice_reenable.php
+++ b/src/controllers/invoice/invoice_reenable.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/invoice_lifecycle.php';
+require_once __DIR__ . '/../../utils/audit.php';
+
+$id = (int)($_POST['id'] ?? 0);
+if ($id <= 0) {
+    header('Location: /?page=invoice/invoices-list&error=' . urlencode('Invalid invoice.'));
+    exit;
+}
+require_record_ownership($pdo, 'invoices', $id);
+
+try {
+    $result = invoice_reenable_void($pdo, $id);
+    audit_log($pdo, 'invoice.reenable', 'invoice', $id, [
+        'restored_status' => $result['restored_status'],
+        'previous_void_reason' => $result['reason'],
+        'user_id' => (int)($_SESSION['user']['id'] ?? 0),
+    ]);
+    header('Location: /?page=invoice/invoice-details&id=' . $id . '&reenabled=1');
+} catch (Throwable $e) {
+    header('Location: /?page=invoice/invoice-details&id=' . $id . '&error=' . urlencode($e->getMessage()));
+}
+exit;

--- a/src/controllers/invoice/invoice_void.php
+++ b/src/controllers/invoice/invoice_void.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../config/app.php';
+require_once __DIR__ . '/../../utils/acl.php';
+require_once __DIR__ . '/../../utils/invoice_lifecycle.php';
+require_once __DIR__ . '/../../utils/audit.php';
+
+$id = (int)($_POST['id'] ?? 0);
+if ($id <= 0) {
+    header('Location: /?page=invoice/invoices-list&error=' . urlencode('Invalid invoice.'));
+    exit;
+}
+require_record_ownership($pdo, 'invoices', $id);
+
+$reason = trim((string)($_POST['reason'] ?? ''));
+$userId = (int)($_SESSION['user']['id'] ?? 0) ?: null;
+
+try {
+    $result = invoice_void($pdo, $id, $appConfig, $reason, $userId);
+    audit_log($pdo, 'invoice.void', 'invoice', $id, [
+        'reason' => $result['reason'],
+        'previous_status' => $result['previous_status'],
+        'user_id' => $userId,
+    ]);
+    header('Location: /?page=invoice/invoice-details&id=' . $id . '&voided=1');
+} catch (Throwable $e) {
+    header('Location: /?page=invoice/invoice-details&id=' . $id . '&error=' . urlencode($e->getMessage()));
+}
+exit;

--- a/src/controllers/invoice/notifications-list.php
+++ b/src/controllers/invoice/notifications-list.php
@@ -57,7 +57,7 @@ $totalPages = (int)ceil($totalCount / $perPage);
 // Fetch notifications with invoice details
 $sql = "
     SELECT n.id, n.invoice_id, n.notification_type, n.sent_at, 
-           i.doc_number, i.total, i.status, i.due_date,
+           i.doc_number, i.invoice_type, i.total, i.status, i.due_date,
            c.name AS client_name, c.email AS client_email
     FROM invoice_notifications n
     JOIN invoices i ON i.id = n.invoice_id

--- a/src/controllers/payments_correct.php
+++ b/src/controllers/payments_correct.php
@@ -1,0 +1,60 @@
+<?php
+
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../config/app.php';
+require_once __DIR__ . '/../utils/acl.php';
+require_once __DIR__ . '/../utils/audit.php';
+require_once __DIR__ . '/../utils/csrf.php';
+require_once __DIR__ . '/../utils/payment_corrections.php';
+
+csrf_verify_post_or_redirect('payments-list');
+
+$paymentId = (int)($_POST['payment_id'] ?? 0);
+$targetInvoiceId = (int)($_POST['target_invoice_id'] ?? 0);
+$replacementPaymentId = (int)($_POST['replacement_payment_id'] ?? 0) ?: null;
+$voidSource = !empty($_POST['void_source']);
+$reason = trim((string)($_POST['reason'] ?? ''));
+$userId = (int)($_SESSION['user']['id'] ?? 0) ?: null;
+
+$errorUrl = '/?page=payments/payment-correction&payment_id=' . $paymentId;
+if ($paymentId <= 0 || $targetInvoiceId <= 0) {
+    header('Location: ' . $errorUrl . '&error=' . urlencode('Select a payment and target invoice.'));
+    exit;
+}
+
+try {
+    require_record_ownership($pdo, 'payments', $paymentId);
+    require_record_ownership($pdo, 'invoices', $targetInvoiceId);
+    if ($replacementPaymentId) {
+        require_record_ownership($pdo, 'payments', $replacementPaymentId);
+    }
+
+    $result = payment_reallocate_to_invoice(
+        $pdo,
+        $paymentId,
+        $targetInvoiceId,
+        $replacementPaymentId,
+        $voidSource,
+        $appConfig,
+        $reason,
+        $userId
+    );
+
+    audit_log($pdo, 'payment.allocation_corrected', 'payment', $paymentId, [
+        'correction_id' => $result['correction_id'],
+        'source_invoice_id' => $result['source_invoice_id'],
+        'target_invoice_id' => $result['target_invoice_id'],
+        'reversed_payment_id' => $result['reversed_payment_id'],
+        'source_voided' => $result['source_voided'],
+        'reason' => $reason,
+        'processor_action' => 'none',
+    ], $userId);
+
+    header(
+        'Location: /?page=invoice/invoice-details&id=' . (int)$result['target_invoice_id']
+        . '&payment_corrected=1&source_invoice_id=' . (int)$result['source_invoice_id']
+    );
+} catch (Throwable $e) {
+    header('Location: ' . $errorUrl . '&error=' . urlencode($e->getMessage()));
+}
+exit;

--- a/src/controllers/payments_refund.php
+++ b/src/controllers/payments_refund.php
@@ -24,7 +24,9 @@ $pdo->beginTransaction();
 try {
     invoice_ensure_payments_schema($pdo);
     $stmt = $pdo->prepare('
-        SELECT id, invoice_id, amount, refunded_amount, disputed_amount, status
+        SELECT id, invoice_id, amount, refunded_amount, disputed_amount, status,
+               payment_method, processor_provider, processor_payment_id,
+               stripe_payment_intent_id, stripe_session_id
         FROM payments
         WHERE id=?
         FOR UPDATE
@@ -33,6 +35,18 @@ try {
     $payment = $stmt->fetch(PDO::FETCH_ASSOC);
     if (!$payment || strtolower((string)$payment['status']) !== 'succeeded') {
         throw new RuntimeException('Only successful payments can be refunded.');
+    }
+
+    $isProcessorBacked = strtolower((string)$payment['payment_method']) === 'stripe'
+        || trim((string)($payment['processor_provider'] ?? '')) !== ''
+        || trim((string)($payment['processor_payment_id'] ?? '')) !== ''
+        || trim((string)($payment['stripe_payment_intent_id'] ?? '')) !== ''
+        || trim((string)($payment['stripe_session_id'] ?? '')) !== '';
+    if ($isProcessorBacked) {
+        throw new RuntimeException(
+            'Processor-backed payments must be refunded in Stripe. Project Alpha will sync the refund automatically. '
+            . 'If no money should move, use Correct allocation instead.'
+        );
     }
 
     $paidAmount = (float)$payment['amount'];

--- a/src/controllers/public_view/payment_receipt.php
+++ b/src/controllers/public_view/payment_receipt.php
@@ -18,8 +18,9 @@ if (!preg_match('/^[a-f0-9]{64}$/', $token)) {
 }
 
 $stmt = $pdo->prepare(
-    'SELECT r.*,p.payment_date,p.payment_method,p.reference_number,
-            i.doc_number,COALESCE(c.name,ppt.payer_name) AS client_name,COALESCE(c.email,ppt.payer_email) AS client_email
+    'SELECT r.*,p.payment_date,p.payment_method,p.reference_number,p.status AS payment_status,
+            p.refunded_amount,p.disputed_amount,p.reversed_at,p.reversal_reason,
+            i.doc_number,i.invoice_type,COALESCE(c.name,ppt.payer_name) AS client_name,COALESCE(c.email,ppt.payer_email) AS client_email
      FROM payment_receipts r
      JOIN payments p ON p.id=r.payment_id
      LEFT JOIN clients c ON c.id=p.client_id
@@ -50,11 +51,23 @@ $brand = (string)($appConfig['brand_name'] ?? 'Project Alpha');
 <body>
   <div class="actions"><button type="button" onclick="window.print()">Print or Save PDF</button></div>
   <main class="receipt">
+    <?php if (strtolower((string)$receipt['payment_status']) === 'reversed'): ?>
+      <div style="margin:0 0 20px;padding:12px 14px;border:1px solid #fca5a5;background:#fff1f2;color:#881337">
+        <strong>Accounting entry reversed.</strong> This payment record was corrected in Project Alpha and is no longer applied to the invoice. No client refund is implied.<?php if (!empty($receipt['reversal_reason'])): ?><div style="margin-top:5px"><?php echo htmlspecialchars((string)$receipt['reversal_reason']); ?></div><?php endif; ?>
+      </div>
+    <?php elseif ((float)$receipt['refunded_amount'] > 0.005): ?>
+      <div style="margin:0 0 20px;padding:12px 14px;border:1px solid #fcd34d;background:#fffbeb;color:#92400e">
+        <strong><?php echo (float)$receipt['refunded_amount'] + 0.005 >= (float)$receipt['amount'] ? 'Payment refunded in full.' : 'Payment partially refunded.'; ?></strong>
+        A refund of $<?php echo number_format((float)$receipt['refunded_amount'], 2); ?> is recorded for this payment.
+      </div>
+    <?php elseif ((float)$receipt['disputed_amount'] > 0.005): ?>
+      <div style="margin:0 0 20px;padding:12px 14px;border:1px solid #fcd34d;background:#fffbeb;color:#92400e"><strong>Payment disputed.</strong> $<?php echo number_format((float)$receipt['disputed_amount'], 2); ?> is currently excluded from the invoice payment total.</div>
+    <?php endif; ?>
     <div class="top"><div><div class="label">Receipt</div><h1><?php echo htmlspecialchars($receipt['receipt_number']); ?></h1><div><?php echo htmlspecialchars($brand); ?></div></div><div><div class="label">Amount received</div><div class="amount">$<?php echo number_format((float)$receipt['amount'], 2); ?></div></div></div>
     <div class="grid">
       <div><div class="label">Received from</div><div class="value"><?php echo htmlspecialchars($receipt['client_name'] ?: 'Processor payment'); ?></div><div><?php echo htmlspecialchars((string)$receipt['client_email']); ?></div></div>
       <div><div class="label">Payment date</div><div class="value"><?php echo htmlspecialchars(date('F j, Y', strtotime((string)$receipt['payment_date']))); ?></div></div>
-      <div><div class="label">Invoice</div><div class="value"><?php echo !empty($receipt['doc_number']) ? 'I-' . htmlspecialchars((string)$receipt['doc_number']) : 'Not linked'; ?></div></div>
+      <div><div class="label">Invoice</div><div class="value"><?php echo !empty($receipt['invoice_id']) ? htmlspecialchars(pa_invoice_label_from_row($receipt)) : 'Not linked'; ?></div></div>
       <div><div class="label">Payment method</div><div class="value"><?php echo htmlspecialchars(ucwords(str_replace('_', ' ', (string)$receipt['payment_method']))); ?></div></div>
       <?php if (!empty($receipt['reference_number'])): ?><div><div class="label">Reference</div><div class="value"><?php echo htmlspecialchars($receipt['reference_number']); ?></div></div><?php endif; ?>
     </div>

--- a/src/controllers/public_view/public_project.php
+++ b/src/controllers/public_view/public_project.php
@@ -120,7 +120,7 @@ if (!empty($project['public_project_can_view_documents'])) {
 }
 
 if (!empty($project['public_project_can_view_invoices'])) {
-    $invoiceStmt = $pdo->prepare('SELECT id, doc_number, status, total, amount_paid, balance_due, created_at FROM invoices WHERE project_id = ? ORDER BY created_at DESC LIMIT 50');
+    $invoiceStmt = $pdo->prepare('SELECT id, doc_number, invoice_type, status, total, amount_paid, balance_due, created_at FROM invoices WHERE project_id = ? ORDER BY created_at DESC LIMIT 50');
     $invoiceStmt->execute([$projectId]);
     $invoices = $invoiceStmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -141,10 +141,15 @@ $error = (string)($_GET['error'] ?? '');
 $renderDocRow = static function (PDO $pdo, array $appConfig, string $type, array $row, string $label): void {
     $id = (int)$row['id'];
     $url = pa_project_public_document_url($pdo, $type, $id, $appConfig);
+    $documentNumber = $type === 'invoice'
+        ? pa_invoice_label_from_row($row)
+        : ($type === 'project_invoice'
+            ? (string)($row['doc_number'] ?? $id)
+            : '#' . (string)($row['doc_number'] ?? $id));
     ?>
     <div class="pp-row">
       <div>
-        <div class="pp-row-title"><?php echo htmlspecialchars($label . ' #' . (string)($row['doc_number'] ?? $id), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></div>
+        <div class="pp-row-title"><?php echo htmlspecialchars($label . ' ' . $documentNumber, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></div>
         <div class="pp-muted"><?php echo htmlspecialchars(ucfirst((string)($row['status'] ?? '')), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?> · <?php echo htmlspecialchars(date('M j, Y', strtotime((string)($row['created_at'] ?? $row['generated_at'] ?? 'now'))), ENT_QUOTES, 'UTF-8'); ?></div>
       </div>
       <div class="pp-row-actions">

--- a/src/controllers/stripe/stripe_charge.php
+++ b/src/controllers/stripe/stripe_charge.php
@@ -77,13 +77,14 @@ try {
     }
     
     $docNumber = $invoice['doc_number'] ?? $invoiceId;
+    $invoiceLabel = pa_invoice_label_from_row($invoice + ['id' => $invoiceId]);
 
     // Calculate surcharge if applicable
     $surchargeInfo = InvoiceSurcharge::getInfo($amountDue, $appConfig);
     $surchargeAmount = $surchargeInfo['has_surcharge'] ? ($surchargeInfo['client_pays'] ?? 0) : 0;
     $chargeDescription = $surchargeInfo['has_surcharge'] 
-        ? "Invoice I-{$docNumber} - {$invoice['client_name']} (includes $" . number_format($surchargeAmount, 2) . " processing fee)"
-        : "Invoice I-{$docNumber} - {$invoice['client_name']}";
+        ? "Invoice {$invoiceLabel} - {$invoice['client_name']} (includes $" . number_format($surchargeAmount, 2) . " processing fee)"
+        : "Invoice {$invoiceLabel} - {$invoice['client_name']}";
     
     // Build URLs
     $host = $_SERVER['HTTP_HOST'] ?? '';
@@ -106,7 +107,7 @@ try {
     }
     
     $brandName = $appConfig['brand_name'] ?? 'Project Alpha';
-    $description = "Invoice I-{$docNumber} - {$invoice['client_name']}";
+    $description = "Invoice {$invoiceLabel} - {$invoice['client_name']}";
     
     $session = $stripe->createCheckoutSessionWithSurcharge(
         $amountDue,

--- a/src/controllers/stripe/stripe_checkout.php
+++ b/src/controllers/stripe/stripe_checkout.php
@@ -146,7 +146,9 @@ try {
     $baseUrl = $scheme . '://' . $host;
     
     $docNumber = $invoice['doc_number'] ?? $invoiceId;
-    $documentLabel = $documentType === 'project_invoice' ? 'Project invoice PI-' : 'Invoice I-';
+    $documentLabel = $documentType === 'project_invoice'
+        ? 'Project invoice PI-' . $docNumber
+        : 'Invoice ' . pa_invoice_label_from_row($invoice + ['id' => $invoiceId]);
     $successUrl = $baseUrl . '/?page=stripe-success&token=' . rawurlencode($token) . '&session_id={CHECKOUT_SESSION_ID}';
     $cancelUrl = $baseUrl . '/?page=public-doc&token=' . rawurlencode($token) . '&cancelled=1';
     
@@ -157,7 +159,7 @@ try {
     }
     
     $brandName = $appConfig['brand_name'] ?? 'Project Alpha';
-    $description = "{$documentLabel}{$docNumber} from {$brandName}";
+    $description = "{$documentLabel} from {$brandName}";
 
     $expectedCents = (int)round($checkoutTotal * 100);
     $existingSessionId = trim((string)($invoice['stripe_session_id'] ?? ''));

--- a/src/controllers/stripe/stripe_success.php
+++ b/src/controllers/stripe/stripe_success.php
@@ -52,13 +52,13 @@ try {
         }
     }
     
-    $docNumber = $invoice['doc_number'] ?? $invoiceId;
-    $documentPrefix = $isProjectInvoice ? 'PI-' : 'I-';
+    $documentLabel = $isProjectInvoice
+        ? 'PI-' . ($invoice['doc_number'] ?? $invoiceId)
+        : pa_invoice_label_from_row($invoice + ['id' => $invoiceId]);
     
 } catch (Throwable $e) {
     @error_log('[StripeSuccess] Error: ' . $e->getMessage());
-    $docNumber = 'Unknown';
-    $documentPrefix = '';
+    $documentLabel = 'Unknown';
 }
 ?>
 <!DOCTYPE html>
@@ -161,7 +161,7 @@ try {
         <p class="subtitle">Thank you for your payment.</p>
         
         <div class="invoice-ref">
-            <strong>Invoice <?php echo htmlspecialchars($documentPrefix . $docNumber); ?></strong>
+            <strong>Invoice <?php echo htmlspecialchars($documentLabel); ?></strong>
         </div>
         
         <p>Your payment has been submitted successfully. The invoice will update as soon as Stripe confirms it.</p>

--- a/src/controllers/stripe/stripe_webhook.php
+++ b/src/controllers/stripe/stripe_webhook.php
@@ -162,10 +162,10 @@ function handlePaymentFailed($pdo, $appConfig, $paymentIntent) {
             // Get client/invoice details
             $details = '';
             if ($invoiceId) {
-                $dStmt = $pdo->prepare('SELECT i.doc_number, c.name FROM invoices i LEFT JOIN clients c ON c.id = i.client_id WHERE i.id = ?');
+                $dStmt = $pdo->prepare('SELECT i.id,i.doc_number,i.invoice_type,c.name FROM invoices i LEFT JOIN clients c ON c.id = i.client_id WHERE i.id = ?');
                 $dStmt->execute([(int)$invoiceId]);
                 $d = $dStmt->fetch(PDO::FETCH_ASSOC);
-                if ($d) $details = 'Invoice I-' . ($d['doc_number'] ?? $invoiceId) . ' for ' . ($d['name'] ?? 'Unknown');
+                if ($d) $details = 'Invoice ' . pa_invoice_label_from_row($d) . ' for ' . ($d['name'] ?? 'Unknown');
             }
             
             $subject = 'Payment Failed' . ($details ? " — $details" : '');

--- a/src/controllers/webhook/stripe_payment_succeeded.php
+++ b/src/controllers/webhook/stripe_payment_succeeded.php
@@ -34,7 +34,7 @@ function handlePaymentIntentSucceeded($pdo, $paymentIntent) {
             // Also check description for invoice reference
             if (!$invoiceId) {
                 $description = $charge['description'] ?? '';
-                if (preg_match('/Invoice\s+I-(\d+)/i', $description, $matches)) {
+                if (preg_match('/Invoice\s+(?:I|LTI|ODI)-(\d+)/i', $description, $matches)) {
                     $invoiceId = $matches[1];
                 }
             }

--- a/src/cron/generate_recurring_invoices.php
+++ b/src/cron/generate_recurring_invoices.php
@@ -115,7 +115,7 @@ try {
         // 1) 7-day due reminders
         if (!empty($appConfig['invoice_auto_send_due_7days'])) {
             $due7 = date('Y-m-d', strtotime('+7 days'));
-            $stmt = $pdo->prepare("SELECT i.id,i.doc_number,i.total,i.due_date,c.email,c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.due_date = ? AND i.status IN ('unpaid','partial') AND i.finalized_at IS NOT NULL AND i.collection_mode='direct'");
+            $stmt = $pdo->prepare("SELECT i.id,i.doc_number,i.invoice_type,i.total,i.due_date,c.email,c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.due_date = ? AND i.status IN ('unpaid','partial') AND i.finalized_at IS NOT NULL AND i.collection_mode='direct'");
             $stmt->execute([$due7]);
             $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
             foreach ($rows as $inv) {
@@ -135,9 +135,10 @@ try {
 
                 $to = (string)$inv['email'];
                 if ($to === '') continue;
-                $subject = sprintf('Invoice I-%s due %s', $inv['doc_number'] ?? $iid, date('M j, Y', strtotime($inv['due_date'])));
+                $invoiceLabel = pa_invoice_label_from_row($inv + ['id' => $iid]);
+                $subject = sprintf('Invoice %s due %s', $invoiceLabel, date('M j, Y', strtotime($inv['due_date'])));
                 $body = '<p>Dear ' . htmlspecialchars($inv['name'] ?? '') . ',</p>';
-                $body .= '<p>This is a reminder that invoice <strong>I-' . htmlspecialchars($inv['doc_number'] ?? $iid) . '</strong> for <strong>$' . number_format((float)$inv['total'],2) . '</strong> is due on <strong>' . htmlspecialchars($inv['due_date']) . '</strong>.</p>';
+                $body .= '<p>This is a reminder that invoice <strong>' . htmlspecialchars($invoiceLabel) . '</strong> for <strong>$' . number_format((float)$inv['total'],2) . '</strong> is due on <strong>' . htmlspecialchars($inv['due_date']) . '</strong>.</p>';
                 $body .= '<p>You can view this invoice here: <a href="' . htmlspecialchars($link) . '">' . htmlspecialchars($link) . '</a></p>';
                 $body .= '<p>If you have already paid, please disregard this message.</p>';
 
@@ -158,7 +159,7 @@ try {
         // 2) Weekly overdue reminders (at most once per 7 days for each invoice)
         if (!empty($appConfig['invoice_auto_send_overdue_weekly'])) {
             $todayDate = date('Y-m-d');
-            $stmt = $pdo->prepare("SELECT i.id,i.doc_number,i.total,i.due_date,c.email,c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.due_date < ? AND i.status IN ('unpaid','partial') AND i.finalized_at IS NOT NULL AND i.collection_mode='direct'");
+            $stmt = $pdo->prepare("SELECT i.id,i.doc_number,i.invoice_type,i.total,i.due_date,c.email,c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.due_date < ? AND i.status IN ('unpaid','partial') AND i.finalized_at IS NOT NULL AND i.collection_mode='direct'");
             $stmt->execute([$todayDate]);
             $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
             foreach ($rows as $inv) {
@@ -185,9 +186,10 @@ try {
 
                 $to = (string)$inv['email'];
                 if ($to === '') continue;
-                $subject = sprintf('Overdue invoice I-%s', $inv['doc_number'] ?? $iid);
+                $invoiceLabel = pa_invoice_label_from_row($inv + ['id' => $iid]);
+                $subject = sprintf('Overdue invoice %s', $invoiceLabel);
                 $body = '<p>Dear ' . htmlspecialchars($inv['name'] ?? '') . ',</p>';
-                $body .= '<p>This is a reminder that invoice <strong>I-' . htmlspecialchars($inv['doc_number'] ?? $iid) . '</strong> for <strong>$' . number_format((float)$inv['total'],2) . '</strong> became overdue on <strong>' . htmlspecialchars($inv['due_date']) . '</strong>.</p>';
+                $body .= '<p>This is a reminder that invoice <strong>' . htmlspecialchars($invoiceLabel) . '</strong> for <strong>$' . number_format((float)$inv['total'],2) . '</strong> became overdue on <strong>' . htmlspecialchars($inv['due_date']) . '</strong>.</p>';
                 $body .= '<p>Please view and pay the invoice here: <a href="' . htmlspecialchars($link) . '">' . htmlspecialchars($link) . '</a></p>';
                 $body .= '<p>If you have already paid, please disregard this message.</p>';
 
@@ -207,7 +209,7 @@ try {
 
         // 3) Auto-email newly-generated long-term and on-demand invoices (on generation)
         if (!empty($appConfig['invoice_auto_email_on_generate'])) {
-            $stmt = $pdo->prepare("SELECT i.id,i.doc_number,i.total,i.due_date,c.email,c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.invoice_type = 'long_term' AND i.status IN ('unpaid','partial') AND i.finalized_at IS NOT NULL AND i.collection_mode='direct' AND NOT EXISTS (SELECT 1 FROM invoice_notifications n WHERE n.invoice_id=i.id AND n.notification_type='on_generate')");
+            $stmt = $pdo->prepare("SELECT i.id,i.doc_number,i.invoice_type,i.total,i.due_date,c.email,c.name FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.invoice_type = 'long_term' AND i.status IN ('unpaid','partial') AND i.finalized_at IS NOT NULL AND i.collection_mode='direct' AND NOT EXISTS (SELECT 1 FROM invoice_notifications n WHERE n.invoice_id=i.id AND n.notification_type='on_generate')");
             $stmt->execute();
             $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
             foreach ($rows as $inv) {
@@ -220,9 +222,10 @@ try {
                 $host = rtrim(($appConfig['app_host'] ?? ''), '/');
                 if ($host !== '') { $link = $host . $link; }
 
-                $subject = sprintf('Invoice I-%s has been generated', $inv['doc_number'] ?? $iid);
+                $invoiceLabel = pa_invoice_label_from_row($inv + ['id' => $iid]);
+                $subject = sprintf('Invoice %s has been generated', $invoiceLabel);
                 $body = '<p>Dear ' . htmlspecialchars($inv['name'] ?? '') . ',</p>';
-                $body .= '<p>A new invoice <strong>I-' . htmlspecialchars($inv['doc_number'] ?? $iid) . '</strong> for <strong>$' . number_format((float)$inv['total'],2) . '</strong> has been generated';
+                $body .= '<p>A new invoice <strong>' . htmlspecialchars($invoiceLabel) . '</strong> for <strong>$' . number_format((float)$inv['total'],2) . '</strong> has been generated';
                 if (!empty($inv['due_date'])) {
                     $body .= ', due on <strong>' . htmlspecialchars($inv['due_date']) . '</strong>';
                 }

--- a/src/cron/process_audit_schedules.php
+++ b/src/cron/process_audit_schedules.php
@@ -103,7 +103,7 @@ try {
                 if ($accountingBasis === 'cash') {
                     $stmt = $pdo->prepare("
                     SELECT
-                        i.id, i.doc_number, c.name as client_name, i.project_code,
+                        i.id, i.doc_number, i.invoice_type, c.name as client_name, i.project_code,
                         i.subtotal, i.tax_percent, i.tax_amount as tax, i.tax_county,
                         i.discount_value, i.total, i.status, MIN(p.payment_date) AS created_at, i.due_date,
                         SUM(GREATEST(p.amount-p.refunded_amount-p.disputed_amount,0)) as amount_paid,
@@ -119,7 +119,7 @@ try {
                 } else {
                     $stmt = $pdo->prepare("
                     SELECT 
-                        i.id, i.doc_number, c.name as client_name, i.project_code,
+                        i.id, i.doc_number, i.invoice_type, c.name as client_name, i.project_code,
                         i.subtotal, i.tax_percent, i.tax_amount as tax, i.tax_county,
                         i.discount_value, i.total, i.status, COALESCE(i.finalized_at,i.created_at) AS created_at, i.due_date,
                         COALESCE(SUM(CASE WHEN p.status = 'succeeded' THEN p.amount ELSE 0 END), 0) as amount_paid,
@@ -194,7 +194,7 @@ try {
                 csv_write_row($fp, [
                     substr($inv['created_at'] ?? '', 0, 10),
                     $inv['client_name'] ?? '',
-                    $inv['doc_number'] ?? $inv['id'],
+                    pa_invoice_label_from_row($inv),
                     'Invoice',
                     ucfirst($inv['status'] ?? ''),
                     number_format((float)($inv['tax_percent'] ?? 0), 2) . '%',

--- a/src/cron/send_invoice_reminders.php
+++ b/src/cron/send_invoice_reminders.php
@@ -84,7 +84,7 @@ try {
     // 1) 7-day due reminders (sent once per invoice)
     if ($due7Enabled) {
         $stmt = $pdo->prepare("
-            SELECT i.id, i.doc_number, i.total, i.due_date, c.email, c.name 
+            SELECT i.id, i.doc_number, i.invoice_type, i.total, i.due_date, c.email, c.name
             FROM invoices i 
             JOIN clients c ON c.id = i.client_id 
             WHERE i.due_date BETWEEN ? AND ? AND i.status IN ('unpaid', 'partial')
@@ -118,9 +118,10 @@ try {
                 $link = $baseUrl . '/?page=public-doc&type=invoice&token=' . rawurlencode($token);
 
                 // Build email
-                $subject = sprintf('Invoice I-%s due %s', $inv['doc_number'] ?? $iid, date('M j, Y', strtotime($inv['due_date'])));
+                $invoiceLabel = pa_invoice_label_from_row($inv + ['id' => $iid]);
+                $subject = sprintf('Invoice %s due %s', $invoiceLabel, date('M j, Y', strtotime($inv['due_date'])));
                 $body = '<p>Dear ' . htmlspecialchars($inv['name'] ?? 'Valued Client') . ',</p>';
-                $body .= '<p>This is a friendly reminder that invoice <strong>I-' . htmlspecialchars($inv['doc_number'] ?? $iid) . '</strong> ';
+                $body .= '<p>This is a friendly reminder that invoice <strong>' . htmlspecialchars($invoiceLabel) . '</strong> ';
                 $body .= 'for <strong>$' . number_format((float)$inv['total'], 2) . '</strong> is due on <strong>' . htmlspecialchars($inv['due_date']) . '</strong>.</p>';
                 $body .= '<p><a href="' . htmlspecialchars($link) . '">View and pay invoice</a></p>';
                 $body .= '<p>If you have already paid, please disregard this message. Thank you!</p>';
@@ -132,7 +133,7 @@ try {
                     $insn = $pdo->prepare('INSERT IGNORE INTO invoice_notifications (invoice_id, notification_type, sent_at) VALUES (?, ?, NOW())');
                     $insn->execute([$iid, 'due_7']);
                     $remindersSent++;
-                    @error_log("$logPrefix Sent due-7 reminder for invoice I-{$inv['doc_number']} to {$to}");
+                    @error_log("$logPrefix Sent due-7 reminder for invoice {$invoiceLabel} to {$to}");
                 } else {
                     $errors++;
                     @error_log("$logPrefix Failed to send due-7 reminder for invoice {$iid}: {$err}");
@@ -148,7 +149,7 @@ try {
     if ($overdueEnabled) {
         $todayDate = date('Y-m-d');
         $stmt = $pdo->prepare("
-            SELECT i.id, i.doc_number, i.total, i.due_date, c.email, c.name 
+            SELECT i.id, i.doc_number, i.invoice_type, i.total, i.due_date, c.email, c.name
             FROM invoices i 
             JOIN clients c ON c.id = i.client_id 
             WHERE i.due_date < ? AND i.status IN ('unpaid', 'partial')
@@ -194,9 +195,10 @@ try {
                 $link = $baseUrl . '/?page=public-doc&type=invoice&token=' . rawurlencode($token);
 
                 // Build email
-                $subject = sprintf('Action Required: Overdue invoice I-%s', $inv['doc_number'] ?? $iid);
+                $invoiceLabel = pa_invoice_label_from_row($inv + ['id' => $iid]);
+                $subject = sprintf('Action Required: Overdue invoice %s', $invoiceLabel);
                 $body = '<p>Dear ' . htmlspecialchars($inv['name'] ?? 'Valued Client') . ',</p>';
-                $body .= '<p>We noticed that invoice <strong>I-' . htmlspecialchars($inv['doc_number'] ?? $iid) . '</strong> ';
+                $body .= '<p>We noticed that invoice <strong>' . htmlspecialchars($invoiceLabel) . '</strong> ';
                 $body .= 'for <strong>$' . number_format((float)$inv['total'], 2) . '</strong> became overdue on <strong>' . htmlspecialchars($inv['due_date']) . '</strong>.</p>';
                 $body .= '<p>Please review and pay the invoice at your earliest convenience: <a href="' . htmlspecialchars($link) . '">View invoice</a></p>';
                 $body .= '<p>If payment has already been sent, thank you and please disregard this message.</p>';
@@ -208,7 +210,7 @@ try {
                     $insn = $pdo->prepare('INSERT IGNORE INTO invoice_notifications (invoice_id, notification_type, sent_at) VALUES (?, ?, NOW())');
                     $insn->execute([$iid, 'overdue_weekly']);
                     $remindersSent++;
-                    @error_log("$logPrefix Sent overdue-weekly reminder for invoice I-{$inv['doc_number']} to {$to}");
+                    @error_log("$logPrefix Sent overdue-weekly reminder for invoice {$invoiceLabel} to {$to}");
                 } else {
                     $errors++;
                     @error_log("$logPrefix Failed to send overdue-weekly reminder for invoice {$iid}: {$err}");

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -140,6 +140,8 @@ function page_permission_map(): array
         'invoice/invoices-mark-paid' => 'invoices.mark_paid',
         'invoice/invoice-finalize'  => 'invoices.send',
         'invoice/invoice-reopen'    => 'invoices.edit',
+        'invoice/invoice-void'      => 'invoices.void',
+        'invoice/invoice-reenable'  => 'invoices.void',
         'invoice/email-send'        => 'invoices.send',
         'invoices-create'           => 'invoices.create',
         'invoices-edit'             => 'invoices.edit',
@@ -154,6 +156,8 @@ function page_permission_map(): array
         'payments-list'             => 'payments.view',
         'payments/payments-create'  => 'invoices.mark_paid',
         'payments/payment-refund'   => 'invoices.mark_paid',
+        'payments/payment-correction' => 'invoices.mark_paid',
+        'payments/payment-correct'  => 'invoices.mark_paid',
 
         // Clients module
         'client/clients-list'    => 'clients.view',

--- a/src/utils/audit_middleware.php
+++ b/src/utils/audit_middleware.php
@@ -62,8 +62,11 @@ function audit_sensitive_map(): array
             'stripe-webhook-legacy'          => ['payment.stripe_webhook', 'payment'],
             'payments-create'                => ['payment.create', 'payment'],
             'payments/payment-refund'        => ['payment.refund', 'payment'],
+            'payments/payment-correct'       => ['payment.allocation_corrected', 'payment'],
             'invoice/invoices-mark-paid'     => ['invoice.mark_paid', 'invoice'],
             'invoices-mark-paid'             => ['invoice.mark_paid', 'invoice'],
+            'invoice/invoice-void'            => ['invoice.void', 'invoice'],
+            'invoice/invoice-reenable'        => ['invoice.reenable', 'invoice'],
 
             // Security state
             'two-factor-setup'               => ['auth.2fa_setup', 'user'],

--- a/src/utils/invoice_lifecycle.php
+++ b/src/utils/invoice_lifecycle.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../services/EmailService.php';
 require_once __DIR__ . '/../services/StripeService.php';
 require_once __DIR__ . '/public_links.php';
 require_once __DIR__ . '/invoice_content_links.php';
+require_once __DIR__ . '/invoice_numbers.php';
 
 function invoice_is_collectible_status(string $status): bool
 {
@@ -274,7 +275,11 @@ function invoice_record_locked_payment(
             throw new RuntimeException('Invoice not found.');
         }
 
-        if (!$allowUnfinalized && (empty($invoice['finalized_at']) || strtolower((string)$invoice['status']) === 'draft')) {
+        $invoiceStatus = strtolower((string)$invoice['status']);
+        if (in_array($invoiceStatus, ['void', 'cancelled'], true)) {
+            throw new RuntimeException('Payments cannot be recorded against a void or cancelled invoice.');
+        }
+        if (!$allowUnfinalized && (empty($invoice['finalized_at']) || $invoiceStatus === 'draft')) {
             throw new RuntimeException('Finalize the invoice before recording payment.');
         }
         if (($invoice['collection_mode'] ?? 'direct') !== 'direct') {
@@ -386,7 +391,7 @@ function invoice_finalize(PDO $pdo, int $invoiceId, array $appConfig, string $so
 function invoice_send_finalized(PDO $pdo, int $invoiceId, array $appConfig, string $notificationType = 'on_finalize'): bool
 {
     $stmt = $pdo->prepare(
-        'SELECT i.id,i.doc_number,i.total,i.due_date,i.status,i.finalized_at,i.collection_mode,c.email,c.name
+        'SELECT i.id,i.doc_number,i.invoice_type,i.total,i.due_date,i.status,i.finalized_at,i.collection_mode,c.email,c.name
          FROM invoices i JOIN clients c ON c.id=i.client_id WHERE i.id=?'
     );
     $stmt->execute([$invoiceId]);
@@ -446,12 +451,12 @@ function invoice_send_finalized(PDO $pdo, int $invoiceId, array $appConfig, stri
 
     $base = invoice_public_base_url($appConfig);
     $url = $base . '/?page=public-doc&token=' . rawurlencode($token);
-    $docNumber = $invoice['doc_number'] ?: $invoiceId;
+    $invoiceLabel = pa_invoice_label_from_row($invoice);
     $name = trim((string)($invoice['name'] ?? ''));
     $firstName = $name !== '' ? preg_split('/\s+/', $name)[0] : 'there';
-    $subject = 'Invoice I-' . $docNumber . ' is ready';
+    $subject = 'Invoice ' . $invoiceLabel . ' is ready';
     $body = '<p>Hello ' . htmlspecialchars($firstName) . ',</p>'
-        . '<p>Invoice <strong>I-' . htmlspecialchars((string)$docNumber) . '</strong> is ready for <strong>$'
+        . '<p>Invoice <strong>' . htmlspecialchars($invoiceLabel) . '</strong> is ready for <strong>$'
         . number_format((float)$invoice['total'], 2) . '</strong>.</p>'
         . (!empty($invoice['due_date']) ? '<p>Due date: ' . htmlspecialchars((string)$invoice['due_date']) . '</p>' : '')
         . '<p><a href="' . htmlspecialchars($url) . '">View and pay this invoice</a></p>';
@@ -521,6 +526,143 @@ function invoice_reopen_draft(PDO $pdo, int $invoiceId): void
         $pdo->commit();
     } catch (Throwable $e) {
         if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
+}
+
+/**
+ * Void an unpaid invoice without deleting its accounting history.
+ *
+ * @return array{previous_status:string,reason:string}
+ */
+function invoice_void(PDO $pdo, int $invoiceId, array $appConfig, string $reason, ?int $userId = null): array
+{
+    $reason = trim(preg_replace('/\s+/', ' ', $reason) ?? '');
+    if ($reason === '') {
+        throw new RuntimeException('A reason is required to void an invoice.');
+    }
+    if (mb_strlen($reason) > 500) {
+        throw new RuntimeException('The void reason must be 500 characters or fewer.');
+    }
+
+    invoice_ensure_payments_schema($pdo);
+    $ownsTransaction = !$pdo->inTransaction();
+    if ($ownsTransaction) {
+        $pdo->beginTransaction();
+    }
+    try {
+        $stmt = $pdo->prepare('SELECT id,status,collection_mode,stripe_session_id,stripe_checkout_expires_at FROM invoices WHERE id=? FOR UPDATE');
+        $stmt->execute([$invoiceId]);
+        $invoice = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        if (!$invoice) {
+            throw new RuntimeException('Invoice not found.');
+        }
+
+        $previousStatus = strtolower((string)$invoice['status']);
+        if (!in_array($previousStatus, ['draft', 'sent', 'unpaid', 'overdue'], true)) {
+            if (in_array($previousStatus, ['paid', 'partial'], true)) {
+                throw new RuntimeException('Paid or partially paid invoices cannot be voided. Refund or credit the payment instead.');
+            }
+            throw new RuntimeException('This invoice status cannot be voided.');
+        }
+
+        $projectParent = $pdo->prepare('SELECT pi.id,pi.doc_number,pi.status FROM project_invoice_items pii JOIN project_invoices pi ON pi.id=pii.project_invoice_id WHERE pii.invoice_id=? LIMIT 1');
+        $projectParent->execute([$invoiceId]);
+        $parent = $projectParent->fetch(PDO::FETCH_ASSOC) ?: [];
+        if ($parent) {
+            $parentNumber = (int)($parent['doc_number'] ?? $parent['id']);
+            throw new RuntimeException('This invoice is already included in project invoice PI-' . $parentNumber . ' and cannot be voided individually.');
+        }
+
+        $payment = $pdo->prepare('SELECT COUNT(*) FROM payments WHERE invoice_id=? AND status IN ("succeeded","pending")');
+        $payment->execute([$invoiceId]);
+        if ((int)$payment->fetchColumn() > 0) {
+            throw new RuntimeException('This invoice has payment activity and cannot be voided. Refund or resolve the payment first.');
+        }
+
+        $intent = $pdo->prepare('SELECT COUNT(*) FROM payment_intents WHERE invoice_id=? AND status IN ("pending","processing","requires_action")');
+        $intent->execute([$invoiceId]);
+        if ((int)$intent->fetchColumn() > 0) {
+            throw new RuntimeException('This invoice has an active payment attempt and cannot be voided yet.');
+        }
+
+        invoice_expire_active_checkout($pdo, 'invoices', $invoiceId, $appConfig);
+
+        $pdo->prepare(
+            'UPDATE invoices
+             SET status="void", balance_due=0, voided_at=NOW(), voided_by=?, void_reason=?, void_previous_status=?
+             WHERE id=?'
+        )->execute([$userId, $reason, $previousStatus, $invoiceId]);
+
+        $pdo->prepare('UPDATE time_entries SET billed=0,invoice_item_id=NULL,invoice_id=NULL WHERE invoice_id=?')
+            ->execute([$invoiceId]);
+        // A corrected invoice may already have links terminalized as paid.
+        // Refresh those terminal redirects so the retained history is
+        // consistently identified as void without re-enabling any link.
+        pa_public_link_terminalize($pdo, 'invoice', $invoiceId, 'void', true);
+
+        if ($ownsTransaction) {
+            $pdo->commit();
+        }
+        return ['previous_status' => $previousStatus, 'reason' => $reason];
+    } catch (Throwable $e) {
+        if ($ownsTransaction && $pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
+}
+
+/**
+ * Restore a void invoice while leaving every old public/payment link revoked.
+ *
+ * @return array{restored_status:string,reason:string}
+ */
+function invoice_reenable_void(PDO $pdo, int $invoiceId): array
+{
+    invoice_ensure_payments_schema($pdo);
+    $ownsTransaction = !$pdo->inTransaction();
+    if ($ownsTransaction) {
+        $pdo->beginTransaction();
+    }
+    try {
+        $stmt = $pdo->prepare('SELECT status,total,void_reason,void_previous_status FROM invoices WHERE id=? FOR UPDATE');
+        $stmt->execute([$invoiceId]);
+        $invoice = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        if (!$invoice) {
+            throw new RuntimeException('Invoice not found.');
+        }
+        if (strtolower((string)$invoice['status']) !== 'void') {
+            throw new RuntimeException('Only void invoices can be re-enabled.');
+        }
+
+        $payment = $pdo->prepare('SELECT COUNT(*) FROM payments WHERE invoice_id=? AND status IN ("succeeded","pending")');
+        $payment->execute([$invoiceId]);
+        if ((int)$payment->fetchColumn() > 0) {
+            throw new RuntimeException('This void invoice has payment activity and cannot be re-enabled automatically.');
+        }
+
+        $previousStatus = strtolower((string)($invoice['void_previous_status'] ?? ''));
+        $restoredStatus = $previousStatus === 'draft' ? 'draft' : 'unpaid';
+        $balanceDue = $restoredStatus === 'draft' ? 0.0 : max(0.0, (float)$invoice['total']);
+        $reason = trim((string)($invoice['void_reason'] ?? ''));
+
+        $pdo->prepare(
+            'UPDATE invoices
+             SET status=?, amount_paid=0, balance_due=?, paid_at=NULL,
+                 voided_at=NULL, voided_by=NULL, void_reason=NULL, void_previous_status=NULL,
+                 stripe_session_id=NULL, stripe_checkout_expires_at=NULL
+             WHERE id=?'
+        )->execute([$restoredStatus, $balanceDue, $invoiceId]);
+
+        if ($ownsTransaction) {
+            $pdo->commit();
+        }
+        return ['restored_status' => $restoredStatus, 'reason' => $reason];
+    } catch (Throwable $e) {
+        if ($ownsTransaction && $pdo->inTransaction()) {
             $pdo->rollBack();
         }
         throw $e;

--- a/src/utils/invoice_numbers.php
+++ b/src/utils/invoice_numbers.php
@@ -1,6 +1,37 @@
 <?php
 declare(strict_types=1);
 
+function pa_invoice_prefix(?string $invoiceType): string
+{
+    return match (strtolower(trim((string)$invoiceType))) {
+        'long_term' => 'LTI',
+        'on_demand' => 'ODI',
+        default => 'I',
+    };
+}
+
+function pa_invoice_label(mixed $docNumber, ?string $invoiceType = 'regular', mixed $fallback = null): string
+{
+    $number = $docNumber;
+    if ($number === null || $number === '') {
+        $number = $fallback;
+    }
+    if ($number === null || $number === '') {
+        $number = '?';
+    }
+
+    return pa_invoice_prefix($invoiceType) . '-' . (string)$number;
+}
+
+function pa_invoice_label_from_row(array $invoice): string
+{
+    return pa_invoice_label(
+        $invoice['doc_number'] ?? null,
+        isset($invoice['invoice_type']) ? (string)$invoice['invoice_type'] : 'regular',
+        $invoice['invoice_id'] ?? ($invoice['id'] ?? null)
+    );
+}
+
 function pa_next_invoice_doc_number(PDO $pdo, string $invoiceType = 'regular'): int
 {
     if ($invoiceType === 'regular') {

--- a/src/utils/notifications.php
+++ b/src/utils/notifications.php
@@ -290,15 +290,15 @@ function notify_admin_invoice_paid(PDO $pdo, array $appConfig, int $invoiceId, f
         
         $brand = (string)($appConfig['brand_name'] ?? 'Project Alpha');
         $clientName = (string)($invoice['client_name'] ?? 'Client');
-        $docnum = (string)($invoice['doc_number'] ?? $invoiceId);
+        $invoiceLabel = pa_invoice_label_from_row($invoice + ['id' => $invoiceId]);
         $project = (string)($invoice['project_code'] ?? '');
         $total = (float)($invoice['total'] ?? 0);
         
         $statusText = $status === 'paid' ? 'paid in full' : 'partially paid';
         if (admin_invoice_paid_notification_enabled($appConfig, $invoice)) {
-            $subject = sprintf('[%s] Invoice I-%s %s ($%.2f)', $brand, $docnum, $statusText, $amount);
-            $html = sprintf('<p>Invoice <strong>I-%s</strong> for client <strong>%s</strong>%s has been %s.</p><p>Payment amount: <strong>$%.2f</strong></p><p>Invoice total: <strong>$%.2f</strong></p><p>See details in the app.</p>',
-                htmlspecialchars($docnum), htmlspecialchars($clientName),
+            $subject = sprintf('[%s] Invoice %s %s ($%.2f)', $brand, $invoiceLabel, $statusText, $amount);
+            $html = sprintf('<p>Invoice <strong>%s</strong> for client <strong>%s</strong>%s has been %s.</p><p>Payment amount: <strong>$%.2f</strong></p><p>Invoice total: <strong>$%.2f</strong></p><p>See details in the app.</p>',
+                htmlspecialchars($invoiceLabel), htmlspecialchars($clientName),
                 $project !== '' ? (' on project <strong>'.htmlspecialchars($project).'</strong>') : '',
                 $statusText, $amount, $total
             );
@@ -308,7 +308,7 @@ function notify_admin_invoice_paid(PDO $pdo, array $appConfig, int $invoiceId, f
 
         // Log the activity
         log_activity($pdo, 'invoice_paid', 'invoice', $invoiceId, (int)($invoice['client_id'] ?? 0), 
-            "Invoice I-$docnum $statusText via public link (\$$amount)",
+            "Invoice $invoiceLabel $statusText via public link (\$$amount)",
             ['project_code' => $project, 'amount' => $amount, 'status' => $status, 'total' => $total]
         );
     } catch (Throwable $e) {

--- a/src/utils/payment_corrections.php
+++ b/src/utils/payment_corrections.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/invoice_lifecycle.php';
+
+/**
+ * Move a real payment to the invoice it should have paid and optionally
+ * reverse a duplicate manual entry on the target invoice.
+ *
+ * This is an accounting correction only. It never calls a payment processor,
+ * creates a refund, or changes refunded_amount.
+ *
+ * @return array{
+ *   correction_id:int,
+ *   source_invoice_id:int,
+ *   target_invoice_id:int,
+ *   moved_payment_id:int,
+ *   reversed_payment_id:int|null,
+ *   source_voided:bool,
+ *   source_status:string,
+ *   target_status:string
+ * }
+ */
+function payment_reallocate_to_invoice(
+    PDO $pdo,
+    int $paymentId,
+    int $targetInvoiceId,
+    ?int $replacementPaymentId,
+    bool $voidSource,
+    array $appConfig,
+    string $reason,
+    ?int $userId = null
+): array {
+    if ($paymentId <= 0 || $targetInvoiceId <= 0) {
+        throw new RuntimeException('Select a payment and target invoice.');
+    }
+
+    $reason = trim(preg_replace('/\s+/', ' ', $reason) ?? '');
+    if ($reason === '') {
+        throw new RuntimeException('A correction reason is required.');
+    }
+    if (mb_strlen($reason) > 500) {
+        throw new RuntimeException('The correction reason must be 500 characters or fewer.');
+    }
+
+    invoice_ensure_payments_schema($pdo);
+    $ownsTransaction = !$pdo->inTransaction();
+    if ($ownsTransaction) {
+        $pdo->beginTransaction();
+    }
+
+    try {
+        $paymentStmt = $pdo->prepare('
+            SELECT p.*, i.status AS source_invoice_status, i.collection_mode AS source_collection_mode
+            FROM payments p
+            JOIN invoices i ON i.id = p.invoice_id
+            WHERE p.id = ?
+            FOR UPDATE
+        ');
+        $paymentStmt->execute([$paymentId]);
+        $payment = $paymentStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        if (!$payment) {
+            throw new RuntimeException('Payment not found or is not linked to an invoice.');
+        }
+
+        $sourceInvoiceId = (int)$payment['invoice_id'];
+        if ($sourceInvoiceId === $targetInvoiceId) {
+            throw new RuntimeException('The payment is already assigned to that invoice.');
+        }
+        if (strtolower((string)$payment['status']) !== 'succeeded') {
+            throw new RuntimeException('Only a successful payment can be reallocated.');
+        }
+        if (!empty($payment['project_invoice_payment_id']) || (string)$payment['source_collection_mode'] !== 'direct') {
+            throw new RuntimeException('Project invoice payments must be corrected from the project invoice workflow.');
+        }
+        if ((float)$payment['refunded_amount'] > 0.005 || (float)$payment['disputed_amount'] > 0.005) {
+            throw new RuntimeException('A refunded or disputed payment cannot be reallocated.');
+        }
+
+        $financialEvent = $pdo->prepare('
+            SELECT COUNT(*)
+            FROM stripe_refunds
+            WHERE payment_id = ? AND LOWER(status) NOT IN ("failed", "canceled", "cancelled")
+        ');
+        $financialEvent->execute([$paymentId]);
+        if ((int)$financialEvent->fetchColumn() > 0) {
+            throw new RuntimeException('This payment has a Stripe refund in progress or completed and cannot be reallocated.');
+        }
+
+        $targetStmt = $pdo->prepare('
+            SELECT id, client_id, contract_id, organization_id, status, total, collection_mode
+            FROM invoices
+            WHERE id = ?
+            FOR UPDATE
+        ');
+        $targetStmt->execute([$targetInvoiceId]);
+        $target = $targetStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        if (!$target) {
+            throw new RuntimeException('Target invoice not found.');
+        }
+        if (in_array(strtolower((string)$target['status']), ['draft', 'void', 'cancelled'], true)) {
+            throw new RuntimeException('The target invoice must be finalized and active.');
+        }
+        if ((string)$target['collection_mode'] !== 'direct') {
+            throw new RuntimeException('Select a directly collected invoice, not a project invoice item.');
+        }
+        if ((int)$target['client_id'] !== (int)$payment['client_id']) {
+            throw new RuntimeException('Payments can only be moved between invoices for the same client.');
+        }
+        if ((int)($target['organization_id'] ?? 0) !== (int)($payment['organization_id'] ?? 0)) {
+            throw new RuntimeException('Payments can only be moved within the same organization.');
+        }
+
+        $replacement = null;
+        $replacementApplied = 0.0;
+        if ($replacementPaymentId !== null && $replacementPaymentId > 0) {
+            if ($replacementPaymentId === $paymentId) {
+                throw new RuntimeException('The moved payment cannot also be the reversed payment.');
+            }
+            $replacementStmt = $pdo->prepare('SELECT * FROM payments WHERE id = ? FOR UPDATE');
+            $replacementStmt->execute([$replacementPaymentId]);
+            $replacement = $replacementStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+            if (!$replacement || (int)($replacement['invoice_id'] ?? 0) !== $targetInvoiceId) {
+                throw new RuntimeException('The duplicate manual payment must belong to the target invoice.');
+            }
+            if (strtolower((string)$replacement['status']) !== 'succeeded') {
+                throw new RuntimeException('The duplicate manual payment is no longer active.');
+            }
+            $hasProcessorIdentity = strtolower((string)$replacement['payment_method']) === 'stripe'
+                || trim((string)($replacement['stripe_payment_intent_id'] ?? '')) !== ''
+                || trim((string)($replacement['stripe_session_id'] ?? '')) !== ''
+                || trim((string)($replacement['processor_provider'] ?? '')) !== ''
+                || trim((string)($replacement['processor_payment_id'] ?? '')) !== '';
+            if ($hasProcessorIdentity || !empty($replacement['project_invoice_payment_id'])) {
+                throw new RuntimeException('Only a manual cash, check, card, bank transfer, or other entry can be reversed here.');
+            }
+            if ((float)$replacement['refunded_amount'] > 0.005 || (float)$replacement['disputed_amount'] > 0.005) {
+                throw new RuntimeException('A refunded or disputed manual entry cannot be reversed as a duplicate.');
+            }
+            $replacementApplied = max(
+                0.0,
+                (float)$replacement['amount']
+                    - (float)$replacement['refunded_amount']
+                    - (float)$replacement['disputed_amount']
+            );
+        }
+
+        $targetPaid = invoice_effective_paid_total($pdo, $targetInvoiceId);
+        $targetPaidAfterReversal = max(0.0, $targetPaid - $replacementApplied);
+        $movedAmount = (float)$payment['amount'];
+        $targetAvailable = max(0.0, (float)$target['total'] - $targetPaidAfterReversal);
+        if ($movedAmount > $targetAvailable + 0.005) {
+            throw new RuntimeException(
+                'Moving this payment would overpay the target invoice. Select the duplicate manual entry to reverse, or choose another invoice.'
+            );
+        }
+
+        if ($replacement) {
+            $pdo->prepare('
+                UPDATE payments
+                SET status = "reversed", reversed_at = NOW(), reversed_by = ?, reversal_reason = ?
+                WHERE id = ?
+            ')->execute([$userId, $reason, $replacementPaymentId]);
+        }
+
+        $pdo->prepare('
+            UPDATE payments
+            SET invoice_id = ?, contract_id = ?, client_id = ?, organization_id = ?
+            WHERE id = ?
+        ')->execute([
+            $targetInvoiceId,
+            !empty($target['contract_id']) ? (int)$target['contract_id'] : null,
+            (int)$target['client_id'],
+            !empty($target['organization_id']) ? (int)$target['organization_id'] : null,
+            $paymentId,
+        ]);
+        $pdo->prepare('UPDATE payment_receipts SET invoice_id = ? WHERE payment_id = ?')
+            ->execute([$targetInvoiceId, $paymentId]);
+
+        $sourceTotals = invoice_refresh_payment_totals($pdo, $sourceInvoiceId);
+        $targetTotals = invoice_refresh_payment_totals($pdo, $targetInvoiceId);
+
+        $sourceWasVoided = false;
+        if ($voidSource) {
+            invoice_void($pdo, $sourceInvoiceId, $appConfig, $reason, $userId);
+            $sourceWasVoided = true;
+            $sourceTotals['status'] = 'void';
+        }
+
+        $insert = $pdo->prepare('
+            INSERT INTO payment_corrections
+                (moved_payment_id, reversed_payment_id, source_invoice_id, target_invoice_id, corrected_by, source_voided, reason)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        ');
+        $insert->execute([
+            $paymentId,
+            $replacement ? $replacementPaymentId : null,
+            $sourceInvoiceId,
+            $targetInvoiceId,
+            $userId,
+            $sourceWasVoided ? 1 : 0,
+            $reason,
+        ]);
+        $correctionId = (int)$pdo->lastInsertId();
+
+        if ($ownsTransaction) {
+            $pdo->commit();
+        }
+
+        return [
+            'correction_id' => $correctionId,
+            'source_invoice_id' => $sourceInvoiceId,
+            'target_invoice_id' => $targetInvoiceId,
+            'moved_payment_id' => $paymentId,
+            'reversed_payment_id' => $replacement ? $replacementPaymentId : null,
+            'source_voided' => $sourceWasVoided,
+            'source_status' => (string)$sourceTotals['status'],
+            'target_status' => (string)$targetTotals['status'],
+        ];
+    } catch (Throwable $e) {
+        if ($ownsTransaction && $pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
+}

--- a/src/utils/payment_receipts.php
+++ b/src/utils/payment_receipts.php
@@ -14,7 +14,7 @@ function payment_receipt_issue(PDO $pdo, int $paymentId, array $appConfig, bool 
 
     $stmt = $pdo->prepare(
         'SELECT p.id,p.invoice_id,p.processor_transaction_id,p.amount,p.payment_date,p.payment_method,p.reference_number,
-                i.doc_number,COALESCE(c.name,ppt.payer_name) AS client_name,COALESCE(c.email,ppt.payer_email) AS email
+                i.doc_number,i.invoice_type,COALESCE(c.name,ppt.payer_name) AS client_name,COALESCE(c.email,ppt.payer_email) AS email
          FROM payments p
          LEFT JOIN invoices i ON i.id=p.invoice_id
          LEFT JOIN clients c ON c.id=p.client_id
@@ -58,7 +58,7 @@ function payment_receipt_issue(PDO $pdo, int $paymentId, array $appConfig, bool 
 
     $base = invoice_public_base_url($appConfig);
     $url = $base . '/?page=payment-receipt&token=' . rawurlencode((string)$receipt['public_token']);
-    $invoiceLabel = !empty($payment['doc_number']) ? ' for invoice I-' . $payment['doc_number'] : '';
+    $invoiceLabel = !empty($payment['invoice_id']) ? ' for invoice ' . pa_invoice_label_from_row($payment) : '';
     $subject = 'Payment receipt ' . $receipt['receipt_number'];
     $body = '<p>Hello ' . htmlspecialchars((string)($payment['client_name'] ?: 'there')) . ',</p>'
         . '<p>We received your payment of <strong>$' . number_format((float)$payment['amount'], 2) . '</strong>'

--- a/src/utils/public_links.php
+++ b/src/utils/public_links.php
@@ -91,7 +91,13 @@ function pa_public_link_terminal_reason(PDO $pdo, string $type, int $id): ?strin
     return null;
 }
 
-function pa_public_link_terminalize(PDO $pdo, string $type, int $id, ?string $reason = null): ?string
+function pa_public_link_terminalize(
+    PDO $pdo,
+    string $type,
+    int $id,
+    ?string $reason = null,
+    bool $refreshPreviouslyTerminalLinks = false
+): ?string
 {
     if (!in_array($type, ['quote', 'contract', 'invoice', 'project_invoice'], true) || $id <= 0) {
         return null;
@@ -107,6 +113,7 @@ function pa_public_link_terminalize(PDO $pdo, string $type, int $id, ?string $re
     }
     $redirect = pa_public_link_redirect_path($type, $reason);
     try {
+        $revokedClause = $refreshPreviouslyTerminalLinks ? '' : ' AND revoked = 0';
         $stmt = $pdo->prepare(
             'UPDATE public_links
              SET revoked = 1,
@@ -114,8 +121,7 @@ function pa_public_link_terminalize(PDO $pdo, string $type, int $id, ?string $re
                  expires_at = DATE_ADD(NOW(), INTERVAL ' . PA_PUBLIC_LINK_TERMINAL_STATUS_DAYS . ' DAY),
                  expire_when_paid = 0
              WHERE document_type = ?
-               AND document_id = ?
-               AND revoked = 0'
+               AND document_id = ?' . $revokedClause
         );
         $stmt->execute([$redirect, $type, $id]);
     } catch (Throwable $e) {

--- a/src/utils/recurring_billing.php
+++ b/src/utils/recurring_billing.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/invoice_numbers.php';
 // src/utils/recurring_billing.php
 // Idempotent helper for generating a single long-term recurring invoice.
 require_once __DIR__ . '/recurring_services.php';
@@ -160,8 +161,8 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
         }
 
         // Assign doc number
-        $maxDoc = (int)$pdo->query('SELECT COALESCE(MAX(doc_number),0) FROM invoices WHERE invoice_type = "long_term"')->fetchColumn();
-        $pdo->prepare('UPDATE invoices SET doc_number=? WHERE id=?')->execute([$maxDoc + 1, $invoiceId]);
+        $docNumber = pa_next_invoice_doc_number($pdo, 'long_term');
+        $pdo->prepare('UPDATE invoices SET doc_number=? WHERE id=?')->execute([$docNumber, $invoiceId]);
 
         // Add invoice items
         if ($contract['pricing_type'] === 'per_invoice') {
@@ -238,7 +239,7 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
                 ->execute([$today, $newTotalInvoiced, $newInvoicesGenerated, $contractId]);
 
             $pdo->commit();
-            @error_log("$logPrefix Generated recurring-service invoice {$invoiceId} for contract LTC-{$contract['doc_number']} (\${$total})");
+            @error_log("$logPrefix Generated recurring-service invoice " . pa_invoice_label($docNumber, 'long_term') . " for contract LTC-{$contract['doc_number']} (\${$total})");
             return $invoiceId;
         }
 
@@ -268,7 +269,7 @@ function generate_recurring_invoice(PDO $pdo, array $contract, array $appConfig)
 
         $pdo->commit();
 
-        @error_log("$logPrefix Generated invoice INV-$maxDoc for contract LTC-{$contract['doc_number']} (\${$total})");
+        @error_log("$logPrefix Generated invoice " . pa_invoice_label($docNumber, 'long_term') . " for contract LTC-{$contract['doc_number']} (\${$total})");
 
         return $invoiceId;
     } catch (Throwable $e) {
@@ -343,8 +344,8 @@ function generate_recurring_proration_invoice(
             $dueDate,
         ]);
         $invoiceId = (int)$pdo->lastInsertId();
-        $maxDoc = (int)$pdo->query('SELECT COALESCE(MAX(doc_number),0) FROM invoices WHERE invoice_type="long_term"')->fetchColumn();
-        $pdo->prepare('UPDATE invoices SET doc_number=? WHERE id=?')->execute([$maxDoc + 1, $invoiceId]);
+        $docNumber = pa_next_invoice_doc_number($pdo, 'long_term');
+        $pdo->prepare('UPDATE invoices SET doc_number=? WHERE id=?')->execute([$docNumber, $invoiceId]);
 
         $lineDescription = trim($description) !== '' ? trim($description) : 'Prorated recurring service charge';
         $pdo->prepare('INSERT INTO invoice_items (invoice_id,item,description,quantity,unit_price,line_total) VALUES (?,?,?,?,?,?)')

--- a/src/utils/stripe_financial_events.php
+++ b/src/utils/stripe_financial_events.php
@@ -1,25 +1,19 @@
 <?php
 
+require_once __DIR__ . '/invoice_lifecycle.php';
+
 function stripe_refresh_invoice_from_payments(PDO $pdo, int $invoiceId): void
 {
     if ($invoiceId <= 0) {
         return;
     }
-    $paidStmt = $pdo->prepare(
-        'SELECT COALESCE(SUM(GREATEST(amount-refunded_amount,0)),0)
-         FROM payments WHERE invoice_id=? AND status="succeeded"'
-    );
-    $paidStmt->execute([$invoiceId]);
-    $paid = (float)$paidStmt->fetchColumn();
-    $invoice = $pdo->prepare('SELECT total,status FROM invoices WHERE id=?');
+    $invoice = $pdo->prepare('SELECT status FROM invoices WHERE id=?');
     $invoice->execute([$invoiceId]);
     $row = $invoice->fetch(PDO::FETCH_ASSOC) ?: [];
     if (!$row || in_array((string)($row['status'] ?? ''), ['void','cancelled','draft'], true)) {
         return;
     }
-    $status = $paid <= 0 ? 'unpaid' : ($paid + 0.005 >= (float)$row['total'] ? 'paid' : 'partial');
-    $pdo->prepare('UPDATE invoices SET amount_paid=?,balance_due=GREATEST(total-?,0),status=? WHERE id=?')
-        ->execute([$paid, $paid, $status, $invoiceId]);
+    invoice_refresh_payment_totals($pdo, $invoiceId);
 }
 
 function stripe_refresh_payment_totals(PDO $pdo, ?int $paymentId): void

--- a/src/views/pages/calendar.php
+++ b/src/views/pages/calendar.php
@@ -1,15 +1,16 @@
 <?php
 // src/views/pages/calendar.php
 require_once __DIR__ . '/../../config/db.php';
+require_once __DIR__ . '/../../utils/invoice_numbers.php';
 
 $start = $_GET['start'] ?? date('Y-m-01');
 $end = $_GET['end'] ?? date('Y-m-t');
 
 // Pull scheduled items from contracts and invoices within range
 $st = $pdo->prepare(
-  "SELECT 'contract' AS kind, id, client_id, project_code, doc_number, scheduled_date, status, created_at FROM contracts WHERE scheduled_date IS NOT NULL AND scheduled_date BETWEEN ? AND ?
+  "SELECT 'contract' AS kind, id, client_id, project_code, doc_number, NULL AS invoice_type, scheduled_date, status, created_at FROM contracts WHERE scheduled_date IS NOT NULL AND scheduled_date BETWEEN ? AND ?
    UNION ALL
-   SELECT 'invoice' AS kind, id, client_id, project_code, doc_number, due_date AS scheduled_date, status, created_at FROM invoices WHERE due_date IS NOT NULL AND due_date BETWEEN ? AND ?
+   SELECT 'invoice' AS kind, id, client_id, project_code, doc_number, invoice_type, due_date AS scheduled_date, status, created_at FROM invoices WHERE due_date IS NOT NULL AND due_date BETWEEN ? AND ?
    ORDER BY scheduled_date ASC, kind ASC, created_at DESC"
 );
 $st->execute([$start, $end, $start, $end]);
@@ -53,7 +54,7 @@ $clients = $pdo->query('SELECT id,name FROM clients')->fetchAll(PDO::FETCH_KEY_P
               <td style="padding:10px"><?php echo htmlspecialchars($r['scheduled_date']); ?></td>
               <td style="padding:10px;text-transform:capitalize"><?php echo htmlspecialchars($r['kind']); ?></td>
               <td style="padding:10px">
-                <?php if ($r['kind'] === 'contract'): ?>C-<?php echo (int)($r['doc_number'] ?? $r['id']); ?><?php else: ?>I-<?php echo (int)($r['doc_number'] ?? $r['id']); ?><?php endif; ?>
+                <?php if ($r['kind'] === 'contract'): ?>C-<?php echo (int)($r['doc_number'] ?? $r['id']); ?><?php else: ?><?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?><?php endif; ?>
               </td>
               <td style="padding:10px"><?php echo htmlspecialchars($r['project_code'] ?? ''); ?></td>
               <td style="padding:10px"><?php echo htmlspecialchars($clients[(int)$r['client_id']] ?? ''); ?></td>

--- a/src/views/pages/client/clients-list.php
+++ b/src/views/pages/client/clients-list.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/clients-list.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/format.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 require_once __DIR__ . '/../../../utils/escaper.php';
@@ -149,7 +150,7 @@ function client_list_email_html(?string $email): string
                   $q->execute([$selected, $pc]); $quotes = $q->fetchAll();
                   $co = $pdo->prepare('SELECT id, doc_number, status, created_at FROM contracts WHERE client_id=? AND project_code=? ORDER BY created_at DESC');
                   $co->execute([$selected, $pc]); $contracts = $co->fetchAll();
-                  $i = $pdo->prepare('SELECT id, doc_number, total, status, created_at FROM invoices WHERE client_id=? AND project_code=? ORDER BY created_at DESC');
+                  $i = $pdo->prepare('SELECT id, doc_number, invoice_type, total, status, created_at FROM invoices WHERE client_id=? AND project_code=? ORDER BY created_at DESC');
                   $i->execute([$selected, $pc]); $invoices = $i->fetchAll();
                 ?>
                 <div>
@@ -181,7 +182,7 @@ function client_list_email_html(?string $email): string
                   <?php if ($invoices): ?>
                     <ul style="list-style:none;margin:0;padding:0;display:grid;gap:6px">
                       <?php foreach ($invoices as $row): ?>
-                        <li><a href="/?page=invoice-print&id=<?php echo (int)$row['id']; ?>">I-<?php echo (int)($row['doc_number'] ?? $row['id']); ?></a> · $<?php echo number_format((float)$row['total'],2); ?> · <?php echo htmlspecialchars($row['status']); ?></li>
+                        <li><a href="/?page=invoice-print&id=<?php echo (int)$row['id']; ?>"><?php echo htmlspecialchars(pa_invoice_label_from_row($row)); ?></a> · $<?php echo number_format((float)$row['total'],2); ?> · <?php echo htmlspecialchars($row['status']); ?></li>
                       <?php endforeach; ?>
                     </ul>
                   <?php else: ?>

--- a/src/views/pages/contract/on-demand-invoices-list.php
+++ b/src/views/pages/contract/on-demand-invoices-list.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/contract/on-demand-invoices-list.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 
 $contract_id = isset($_GET['contract_id']) ? (int)$_GET['contract_id'] : 0;
@@ -117,7 +118,7 @@ $st=$pdo->prepare($sql);$st->execute($p);$rows=$st->fetchAll();
   $rowStyle = ($r['status']==='paid') ? 'background:#ecfdf5;' : (($r['status']==='unpaid' || $r['status']==='partial') ? 'background:#fffbeb;' : 'background:#fef2f2;');
 ?>
           <tr style="border-top:1px solid #f3f4f6;<?php echo $rowStyle; ?>">
-            <td style="padding:10px"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$r['id']; ?>" style="text-decoration:none;color:inherit">I-<?php echo (int)($r['doc_number'] ?? $r['id']); ?></a></td>
+            <td style="padding:10px"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$r['id']; ?>" style="text-decoration:none;color:inherit"><?php echo htmlspecialchars(pa_invoice_label($r['doc_number'] ?? null, 'on_demand', $r['id'])); ?></a></td>
             <td style="padding:10px">ODC-<?php echo (int)$r['contract_doc_number']; ?></td>
             <td style="padding:10px"><?php echo htmlspecialchars($r['project_code'] ?? ''); ?></td>
             <td style="padding:10px"><a href="/?page=client/clients-list&selected_client_id=<?php echo (int)$r['client_id']; ?>"><?php echo htmlspecialchars($r['client']); ?></a></td>

--- a/src/views/pages/invoice/invoice-details.php
+++ b/src/views/pages/invoice/invoice-details.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/invoice-print.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../config/app.php';
 require_once __DIR__ . '/../../../utils/format.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
@@ -63,6 +64,9 @@ if ($invoiceCollectionMode === '') {
 if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? '')); }
 ?>
 <section>
+  <?php if (strtolower((string)($inv['status'] ?? '')) === 'void'): ?>
+    <div style="margin:0 0 12px;padding:10px 14px;border:3px solid #6b7280;color:#4b5563;text-align:center;font-size:28px;font-weight:800;letter-spacing:8px">VOID</div>
+  <?php endif; ?>
   <div class="doc-type" style="text-align:center;font-weight:700;font-size:22px;margin-bottom:6px">Invoice</div>
   <?php if (!defined('PDF_MODE') && !defined('PUBLIC_VIEW')): ?>
   <?php 
@@ -72,6 +76,9 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
       'unpaid' => ['bg' => '#fffbeb', 'text' => '#92400e', 'border' => '#fbbf24'],
       'partial' => ['bg' => '#fef3c7', 'text' => '#92400e', 'border' => '#f59e0b'],
       'paid' => ['bg' => '#ecfdf5', 'text' => '#065f46', 'border' => '#10b981'],
+      'draft' => ['bg' => '#eff6ff', 'text' => '#1e40af', 'border' => '#60a5fa'],
+      'sent' => ['bg' => '#f5f3ff', 'text' => '#5b21b6', 'border' => '#8b5cf6'],
+      'overdue' => ['bg' => '#fff1f2', 'text' => '#9f1239', 'border' => '#fb7185'],
       'void' => ['bg' => '#f3f4f6', 'text' => '#6b7280', 'border' => '#9ca3af']
     ];
     $icolors = $istatusColors[$istatus] ?? ['bg' => '#f3f4f6', 'text' => '#374151', 'border' => '#9ca3af'];
@@ -82,7 +89,7 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
   <div class="no-print document-actions">
     <a href="javascript:history.back()" class="btn btn-sm">Back</a>
     <a href="/?page=invoice/invoice-pdf&id=<?php echo (int)$id; ?>" target="_blank" rel="noopener" class="btn btn-sm">View PDF</a>
-    <a href="/?page=invoice/invoice-pdf&id=<?php echo (int)$id; ?>" download="invoice-<?php echo htmlspecialchars($inv['doc_number'] ?? $inv['id']); ?>.pdf" class="btn btn-sm">Download</a>
+    <a href="/?page=invoice/invoice-pdf&id=<?php echo (int)$id; ?>" download="invoice-<?php echo htmlspecialchars(pa_invoice_label_from_row($inv)); ?>.pdf" class="btn btn-sm">Download</a>
     <?php
       $actionStatus = strtolower((string)$inv['status']);
       $canEditInvoice = $actionStatus === 'draft'
@@ -120,25 +127,59 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
       </form>
     <?php endif; ?>
     <?php if (!empty($inv['status']) && strtolower($inv['status']) === 'void'): ?>
-    <form method="post" action="/?page=document-reenable" style="display:inline" onsubmit="return confirm('Re-enable this invoice? It will be set back to unpaid status.');">
+    <form method="post" action="/?page=invoice/invoice-reenable" style="display:inline" onsubmit="return confirm('Re-enable this invoice? Previous public and payment links will remain revoked.');">
       <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
-      <input type="hidden" name="type" value="invoice">
       <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
       <button type="submit" class="btn btn-sm btn-warning">Re-enable</button>
     </form>
     <?php endif; ?>
+    <?php if (in_array($actionStatus, ['draft','sent','unpaid','overdue'], true)): ?>
+      <details style="display:inline-block;position:relative;vertical-align:top">
+        <summary class="btn btn-sm" style="list-style:none;background:#fff1f2;color:#9f1239;border-color:#fda4af;cursor:pointer">Void Invoice</summary>
+        <form method="post" action="/?page=invoice/invoice-void" style="position:absolute;z-index:20;right:0;top:calc(100% + 6px);width:min(360px,80vw);padding:12px;background:#fff;border:1px solid #fecdd3;border-radius:8px;box-shadow:0 10px 25px rgba(15,23,42,.16)" onsubmit="return confirm('Void this invoice? This keeps the record for audit history and revokes all payment links.');">
+          <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+          <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
+          <label style="display:grid;gap:6px;font-size:13px;font-weight:600;color:#374151">
+            Reason for voiding
+            <textarea name="reason" maxlength="500" required rows="3" placeholder="Example: Created for the wrong client" style="width:100%;padding:8px;border:1px solid #d1d5db;border-radius:6px;resize:vertical"></textarea>
+          </label>
+          <div style="margin-top:7px;font-size:12px;color:#6b7280">Paid, partially paid, and project-aggregated invoices cannot be voided here.</div>
+          <button type="submit" class="btn btn-sm" style="margin-top:10px;background:#be123c;color:#fff;border-color:#be123c">Confirm Void</button>
+        </form>
+      </details>
+    <?php endif; ?>
+    <?php if ($actionStatus !== 'void'): ?>
     <form method="post" action="/?page=document-date-update" style="display:inline" onsubmit="return confirm('Update document date to today? This will refresh the date shown on the PDF.');">
       <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
       <input type="hidden" name="type" value="invoice">
       <input type="hidden" name="id" value="<?php echo (int)$id; ?>">
       <button type="submit" class="btn btn-sm btn-info">Update Document Date</button>
     </form>
+    <?php endif; ?>
     <?php if (!empty($inv['finalized_at']) && $invoiceCollectionMode === 'direct' && in_array(strtolower((string)$inv['status']), ['sent','unpaid','partial','overdue'], true)): ?>
       <button type="button" onclick="generatePublicLink()" class="btn btn-sm btn-info">Share Link</button>
     <?php endif; ?>
   </div>
+  <?php if (!empty($_GET['error'])): ?>
+    <div class="no-print" style="padding:8px 12px;background:#fff1f2;color:#9f1239;border:1px solid #fecdd3;border-radius:6px;margin-bottom:8px;font-size:14px"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['voided'])): ?>
+    <div class="no-print" style="padding:8px 12px;background:#f3f4f6;color:#374151;border:1px solid #d1d5db;border-radius:6px;margin-bottom:8px;font-size:14px">Invoice voided. It remains in invoice history and its public/payment links have been revoked.</div>
+  <?php endif; ?>
   <?php if (!empty($_GET['reenabled'])): ?>
-    <div class="no-print" style="padding:8px 12px;background:#d1fae5;color:#065f46;border-radius:6px;margin-bottom:8px;font-size:14px">✓ Invoice re-enabled successfully</div>
+    <div class="no-print" style="padding:8px 12px;background:#d1fae5;color:#065f46;border-radius:6px;margin-bottom:8px;font-size:14px">Invoice re-enabled successfully. Create a new public link before sending it again.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['payment_corrected'])): ?>
+    <div class="no-print" style="padding:10px 12px;background:#d1fae5;color:#065f46;border:1px solid #a7f3d0;border-radius:6px;margin-bottom:8px;font-size:14px">
+      Payment allocation corrected. The original processor transaction now applies to this invoice; no Stripe refund or new charge was created.<?php if (!empty($_GET['source_invoice_id'])): ?> The duplicate source invoice #<?php echo (int)$_GET['source_invoice_id']; ?> was retained in history as void.<?php endif; ?>
+    </div>
+  <?php endif; ?>
+  <?php if ($actionStatus === 'void'): ?>
+    <div class="no-print" style="padding:12px 14px;background:#f9fafb;border:1px solid #d1d5db;border-radius:8px;margin-bottom:12px">
+      <div style="font-weight:700;color:#374151">Void reason</div>
+      <div style="margin-top:4px;color:#4b5563"><?php echo htmlspecialchars(trim((string)($inv['void_reason'] ?? '')) ?: 'No reason was recorded for this legacy void.'); ?></div>
+      <?php if (!empty($inv['voided_at'])): ?><div style="margin-top:5px;font-size:12px;color:#6b7280">Voided <?php echo htmlspecialchars(date('M j, Y g:i A', strtotime((string)$inv['voided_at']))); ?></div><?php endif; ?>
+    </div>
   <?php endif; ?>
   <?php if (!empty($_GET['payment']) && $_GET['payment'] === 'success'): ?>
     <div class="no-print" style="padding:8px 12px;background:#d1fae5;color:#065f46;border-radius:6px;margin-bottom:8px;font-size:14px">✓ Payment processed successfully! The invoice status will update shortly.</div>
@@ -261,7 +302,7 @@ if ($termsText === '') { $termsText = trim((string)($appConfig['terms'] ?? ''));
     <tr>
       <td style="vertical-align:middle;width:70%">
         <div style="font-weight:700;font-size:20px"><?php echo htmlspecialchars($brand); ?></div>
-        <div style="color:#374151;font-size:13px;margin-top:2px">Invoice I-<?php echo htmlspecialchars($inv['doc_number'] ?? $inv['id']); ?></div>
+        <div style="color:#374151;font-size:13px;margin-top:2px">Invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($inv)); ?></div>
         <?php if (!empty($inv['project_code'])): ?><div style="color:#374151;font-size:13px;margin-top:2px">Job <?php echo htmlspecialchars($inv['project_code']); ?></div><?php endif; ?>
         <?php if (!empty($inv['project_id'])): ?><div style="color:#374151;font-size:13px;margin-top:2px">Project <?php echo htmlspecialchars($inv['project_id']); ?></div><?php endif; ?>
       </td>

--- a/src/views/pages/invoice/invoices-edit.php
+++ b/src/views/pages/invoice/invoices-edit.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/invoices-edit.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../config/app.php';
 require_once __DIR__ . '/../../../utils/document_fields.php';
 require_once __DIR__ . '/../../../utils/acl.php';
@@ -27,7 +28,7 @@ foreach ($clients as $c) {
 }
 ?>
 <section>
-  <h2>Edit Invoice I-<?php echo htmlspecialchars($inv['doc_number'] ?? $inv['id']); ?><?php if (!empty($inv['project_code'])) echo ' (Job ' . htmlspecialchars($inv['project_code']) . ')'; ?></h2>
+  <h2>Edit Invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($inv)); ?><?php if (!empty($inv['project_code'])) echo ' (Job ' . htmlspecialchars($inv['project_code']) . ')'; ?></h2>
   <form id="invEditForm" method="post" action="/?page=invoices-update" style="display:grid;gap:16px;max-width:900px">
     <input type="hidden" name="csrf" value="<?php echo csrf_token(); ?>">
     <input type="hidden" name="id" value="<?php echo (int)$inv['id']; ?>">

--- a/src/views/pages/invoice/invoices-list.php
+++ b/src/views/pages/invoice/invoices-list.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/invoices-list.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 require_once __DIR__ . '/../../../config/app.php';
@@ -53,6 +54,8 @@ if ($statusFilter === 'paid') {
     (i.due_date IS NULL AND i.created_at < ?)
   )";
   $params[] = date('Y-m-d', strtotime('-'.$netDays.' days'));
+} elseif ($statusFilter === 'void') {
+  $where[] = "i.status='void'";
 }
 if ($project_code !== '') {
   $where[] = 'i.project_code LIKE ?';
@@ -78,7 +81,7 @@ $stc = $pdo->prepare($sqlCount);
 $stc->execute($params);
 $total = (int)$stc->fetchColumn();
 
-$sql = 'SELECT i.id,i.doc_number,i.project_code,i.total,i.status,i.collection_mode,i.created_at,i.due_date,c.name client,c.id AS client_id FROM invoices i JOIN clients c ON c.id=i.client_id';
+$sql = 'SELECT i.id,i.doc_number,i.invoice_type,i.project_code,i.total,i.status,i.collection_mode,i.created_at,i.due_date,c.name client,c.id AS client_id FROM invoices i JOIN clients c ON c.id=i.client_id';
 if ($where) {
   $sql .= ' WHERE ' . implode(' AND ', $where);
 }
@@ -116,7 +119,8 @@ $clients = $pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archi
                   ['value' => 'all', 'label' => 'All'],
                   ['value' => 'paid', 'label' => 'Paid'],
                   ['value' => 'unpaid', 'label' => 'Unpaid/Partial'],
-                  ['value' => 'overdue', 'label' => 'Overdue']
+                  ['value' => 'overdue', 'label' => 'Overdue'],
+                  ['value' => 'void', 'label' => 'Void']
               ]
           ],
           'start' => [
@@ -198,7 +202,7 @@ $clients = $pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archi
           }
           ?>
           <tr style="border-top:1px solid #f3f4f6;<?php echo $rowStyle; ?>">
-            <td style="padding:10px">I-<?php echo (int)($r['doc_number'] ?? $r['id']); ?></td>
+            <td style="padding:10px"><?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?></td>
             <td style="padding:10px"><?php echo htmlspecialchars($r['project_code'] ?? ''); ?></td>
             <td style="padding:10px"><a href="/?page=client/clients-list&selected_client_id=<?php echo (int)$r['client_id']; ?>"><?php echo htmlspecialchars($r['client']); ?></a></td>
             <td style="padding:10px">$<?php echo number_format((float)$r['total'], 2); ?></td>

--- a/src/views/pages/invoice/notifications-list.php
+++ b/src/views/pages/invoice/notifications-list.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/invoice/notifications-list.php
 // Admin UI for viewing sent invoice reminders
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 ?>
 
 <div class="container content-wrapper">
@@ -88,7 +89,7 @@
                         <tr>
                             <td>
                                 <a href="?page=invoice/view&id=<?php echo $n['invoice_id']; ?>">
-                                    <?php echo htmlspecialchars($n['doc_number']); ?>
+                                    <?php echo htmlspecialchars(pa_invoice_label_from_row($n)); ?>
                                 </a>
                             </td>
                             <td><?php echo htmlspecialchars($n['client_name']); ?></td>

--- a/src/views/pages/invoice/on-demand-invoices-list.php
+++ b/src/views/pages/invoice/on-demand-invoices-list.php
@@ -2,6 +2,7 @@
 // src/views/pages/invoice/on-demand-invoices-list.php
 // Dedicated view for ALL on-demand invoices (ODI prefix)
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 
@@ -123,7 +124,7 @@ $st=$pdo->prepare($sql);$st->execute($p);$rows=$st->fetchAll();
   $rowStyle = ($r['status']==='paid') ? 'background:#ecfdf5;' : (($r['status']==='unpaid' || $r['status']==='partial') ? 'background:#fffbeb;' : 'background:#fef2f2;');
 ?>
           <tr style="border-top:1px solid #f3f4f6;<?php echo $rowStyle; ?>">
-            <td style="padding:10px"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$r['id']; ?>" style="text-decoration:none;color:inherit">ODI-<?php echo (int)($r['doc_number'] ?? $r['id']); ?></a></td>
+            <td style="padding:10px"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$r['id']; ?>" style="text-decoration:none;color:inherit"><?php echo htmlspecialchars(pa_invoice_label($r['doc_number'] ?? null, 'on_demand', $r['id'])); ?></a></td>
             <td style="padding:10px"><a href="/?page=contract/on-demand-contracts-list" style="text-decoration:none;color:inherit">ODC-<?php echo (int)$r['contract_doc_number']; ?></a></td>
             <td style="padding:10px"><?php echo htmlspecialchars($r['project_code'] ?? ''); ?></td>
             <td style="padding:10px"><a href="/?page=client/clients-list&selected_client_id=<?php echo (int)$r['client_id']; ?>"><?php echo htmlspecialchars($r['client']); ?></a></td>

--- a/src/views/pages/invoice/recurring-invoices-list.php
+++ b/src/views/pages/invoice/recurring-invoices-list.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/invoice/recurring-invoices-list.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 
@@ -243,8 +244,8 @@ $invoiceHistory = $historyStmt->fetchAll(PDO::FETCH_ASSOC);
               </td>
               <td style="padding:10px"><?php echo htmlspecialchars($progressText); ?></td>
               <td style="padding:10px;white-space:nowrap">
-                <a href="/?page=invoice/recurring-invoices-list&status=all&contract_id=<?php echo (int)$ltc['id']; ?>#invoice-history" style="font-size:13px;color:#2563eb;text-decoration:none">
-                  View invoices (<?php echo (int)$ltc['invoice_history_count']; ?>)
+                <a href="/?page=invoice/recurring-invoices-list&status=all&contract_id=<?php echo (int)$ltc['id']; ?>&history_page=1#invoice-history" style="display:inline-block;padding:6px 9px;border:1px solid #bfdbfe;border-radius:7px;background:#eff6ff;font-size:13px;color:#1d4ed8;text-decoration:none;font-weight:600">
+                  View history (<?php echo (int)$ltc['invoice_history_count']; ?>)
                 </a>
               </td>
             </tr>
@@ -262,6 +263,11 @@ $invoiceHistory = $historyStmt->fetchAll(PDO::FETCH_ASSOC);
           <?php echo number_format($historyTotal); ?> invoice<?php echo $historyTotal === 1 ? '' : 's'; ?>, including paid and completed billing periods.
           <?php if ($history_contract_id > 0): ?> Filtered to LTC-<?php echo (int)($contracts[0]['doc_number'] ?? $history_contract_id); ?>.<?php endif; ?>
         </div>
+        <?php if ($history_contract_id > 0 && !empty($contracts[0])): ?>
+          <div style="margin-top:8px;padding:8px 10px;border:1px solid #bfdbfe;border-radius:7px;background:#eff6ff;color:#1e3a8a;font-size:13px">
+            Showing invoices for <strong>LTC-<?php echo (int)($contracts[0]['doc_number'] ?? $contracts[0]['id']); ?></strong> — <?php echo htmlspecialchars((string)$contracts[0]['client_name']); ?>.
+          </div>
+        <?php endif; ?>
       </div>
       <form method="get" action="/" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
         <input type="hidden" name="page" value="invoice/recurring-invoices-list">
@@ -297,11 +303,12 @@ $invoiceHistory = $historyStmt->fetchAll(PDO::FETCH_ASSOC);
             <th style="padding:10px;text-align:right">Total</th>
             <th style="padding:10px;text-align:right">Paid</th>
             <th style="padding:10px;text-align:right">Balance</th>
+            <th style="padding:10px">Actions</th>
           </tr>
         </thead>
         <tbody>
           <?php if (!$invoiceHistory): ?>
-            <tr><td colspan="9" style="padding:20px;text-align:center;color:#6b7280">No recurring invoices match these filters.</td></tr>
+            <tr><td colspan="10" style="padding:20px;text-align:center;color:#6b7280">No recurring invoices match these filters.</td></tr>
           <?php else: ?>
             <?php foreach ($invoiceHistory as $historyInvoice): ?>
               <?php
@@ -313,7 +320,7 @@ $invoiceHistory = $historyStmt->fetchAll(PDO::FETCH_ASSOC);
                 $historyRowStyle = $historyStatus === 'paid' ? 'background:#f0fdf4;' : (in_array($historyStatus, ['unpaid', 'partial', 'overdue', 'sent'], true) ? 'background:#fffbeb;' : '');
               ?>
               <tr style="border-top:1px solid #f3f4f6;<?php echo $historyRowStyle; ?>">
-                <td style="padding:10px;font-weight:600"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$historyInvoice['id']; ?>" style="color:#2563eb;text-decoration:none">I-<?php echo (int)($historyInvoice['doc_number'] ?? $historyInvoice['id']); ?></a></td>
+                <td style="padding:10px;font-weight:600"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$historyInvoice['id']; ?>" style="color:#2563eb;text-decoration:none"><?php echo htmlspecialchars(pa_invoice_label($historyInvoice['doc_number'] ?? null, 'long_term', $historyInvoice['id'])); ?></a></td>
                 <td style="padding:10px"><a href="/?page=contract/long-term-contract-details&id=<?php echo (int)$historyInvoice['contract_id']; ?>" style="color:inherit;text-decoration:none">LTC-<?php echo (int)($historyInvoice['contract_doc_number'] ?? $historyInvoice['contract_id']); ?></a></td>
                 <td style="padding:10px"><a href="/?page=client/clients-list&selected_client_id=<?php echo (int)$historyInvoice['client_id']; ?>"><?php echo htmlspecialchars((string)$historyInvoice['client_name']); ?></a></td>
                 <td style="padding:10px;white-space:nowrap"><?php echo !empty($historyInvoice['created_at']) ? date('M j, Y', strtotime((string)$historyInvoice['created_at'])) : '—'; ?></td>
@@ -322,6 +329,7 @@ $invoiceHistory = $historyStmt->fetchAll(PDO::FETCH_ASSOC);
                 <td style="padding:10px;text-align:right">$<?php echo number_format((float)$historyInvoice['total'], 2); ?></td>
                 <td style="padding:10px;text-align:right">$<?php echo number_format($historyPaid, 2); ?></td>
                 <td style="padding:10px;text-align:right;font-weight:600">$<?php echo number_format($historyBalance, 2); ?></td>
+                <td style="padding:10px"><a href="/?page=invoice/invoice-details&id=<?php echo (int)$historyInvoice['id']; ?>" style="display:inline-block;padding:6px 9px;border:1px solid #d1d5db;border-radius:7px;background:#fff;color:#374151;text-decoration:none;font-size:13px">View / Actions</a></td>
               </tr>
             <?php endforeach; ?>
           <?php endif; ?>

--- a/src/views/pages/jobs/job-details.php
+++ b/src/views/pages/jobs/job-details.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 ?>
 
 <section>
@@ -191,7 +192,7 @@ require_once __DIR__ . '/../../../config/db.php';
         <div style="border:1px solid #eee;border-radius:8px;padding:12px;background:#fff">
             <h4>Invoices</h4>
             <?php
-            $istmt = $pdo->prepare('SELECT id, doc_number, client_id, total, status, created_at FROM invoices WHERE project_code = ? ORDER BY created_at DESC');
+            $istmt = $pdo->prepare('SELECT id, doc_number, invoice_type, client_id, total, status, created_at FROM invoices WHERE project_code = ? ORDER BY created_at DESC');
             $istmt->execute([$project_code]);
             $invoices = $istmt->fetchAll();
             if (!$invoices):
@@ -203,7 +204,7 @@ require_once __DIR__ . '/../../../config/db.php';
                         <?php $ivId = (int)$inv['id']; ?>
                         <li style="display:block;border-bottom:1px solid #f3f4f6;padding:10px">
                             <div style="display:flex;gap:8px;align-items:center">
-                                <div class="doc-toggle" data-type="invoice" data-id="<?php echo $ivId; ?>" style="flex:1;cursor:pointer">I-<?php echo (int)($inv['doc_number'] ?? $inv['id']); ?> · $<?php echo number_format((float)($inv['total'] ?? 0), 2); ?> · <?php echo htmlspecialchars($inv['status']); ?> · <?php echo htmlspecialchars($inv['created_at']); ?></div>
+                                <div class="doc-toggle" data-type="invoice" data-id="<?php echo $ivId; ?>" style="flex:1;cursor:pointer"><?php echo htmlspecialchars(pa_invoice_label_from_row($inv)); ?> · $<?php echo number_format((float)($inv['total'] ?? 0), 2); ?> · <?php echo htmlspecialchars($inv['status']); ?> · <?php echo htmlspecialchars($inv['created_at']); ?></div>
                                 <div style="display:flex;gap:6px;align-items:center">
                                     <button type="button" class="doc-toggle" data-type="invoice" data-id="<?php echo $ivId; ?>" style="padding:6px 10px;border-radius:6px;border:1px solid #ddd;background:#fff">Details</button>
                                     <a href="/?page=invoice/invoices-edit&id=<?php echo $ivId; ?>" style="padding:6px 10px;border-radius:6px;border:1px solid #ddd;background:#fff">View Document</a>

--- a/src/views/pages/jobs/jobs-list.php
+++ b/src/views/pages/jobs/jobs-list.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/jobs-list.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 // TODo: Change the Details Button in the project list view to "Preview" and then add button called "Details" That will open up a new page with all the details of the project.
@@ -141,7 +142,7 @@ if ($selected !== '') {
               }
               $co->execute([$cid, $pc]);
               $contracts = $co->fetchAll();
-              $i = $pdo->prepare('SELECT id, doc_number, total, status, created_at FROM invoices WHERE client_id=? AND project_code=? ORDER BY created_at DESC LIMIT 5');
+              $i = $pdo->prepare('SELECT id, doc_number, invoice_type, total, status, created_at FROM invoices WHERE client_id=? AND project_code=? ORDER BY created_at DESC LIMIT 5');
               $i->execute([$cid, $pc]);
               $invoices = $i->fetchAll();
               ?>
@@ -184,7 +185,7 @@ if ($selected !== '') {
                 <?php if ($invoices): ?>
                   <ul style="list-style:none;margin:0;padding:0;display:grid;gap:6px">
                     <?php foreach ($invoices as $row): ?>
-                      <li><a href="/?page=invoice/invoice-print&amp;id=<?php echo (int)$row['id']; ?>">I-<?php echo (int)($row['doc_number'] ?? $row['id']); ?></a> · $<?php echo number_format((float)$row['total'], 2); ?> · <?php echo htmlspecialchars($row['status']); ?></li>
+                      <li><a href="/?page=invoice/invoice-print&amp;id=<?php echo (int)$row['id']; ?>"><?php echo htmlspecialchars(pa_invoice_label_from_row($row)); ?></a> · $<?php echo number_format((float)$row['total'], 2); ?> · <?php echo htmlspecialchars($row['status']); ?></li>
                     <?php endforeach; ?>
                   </ul>
                 <?php else: ?>

--- a/src/views/pages/payments/payment-correction.php
+++ b/src/views/pages/payments/payment-correction.php
@@ -1,0 +1,184 @@
+<?php
+
+require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/acl.php';
+require_once __DIR__ . '/../../../utils/csrf.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
+
+$paymentId = (int)($_GET['payment_id'] ?? 0);
+$userId = (int)($_SESSION['user']['id'] ?? 0);
+$payment = null;
+$targets = [];
+$manualCandidates = [];
+$pageError = trim((string)($_GET['error'] ?? ''));
+
+if ($paymentId <= 0 || !can_access_record($pdo, 'payments', $paymentId, $userId)) {
+    $pageError = $pageError ?: 'Payment not found or permission denied.';
+} else {
+    $stmt = $pdo->prepare('
+        SELECT p.*, i.doc_number, i.invoice_type, i.status AS invoice_status,
+               i.collection_mode, c.name AS client_name
+        FROM payments p
+        JOIN invoices i ON i.id = p.invoice_id
+        JOIN clients c ON c.id = p.client_id
+        WHERE p.id = ?
+    ');
+    $stmt->execute([$paymentId]);
+    $payment = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+
+    if (!$payment) {
+        $pageError = $pageError ?: 'This payment is not linked to an invoice.';
+    } elseif (strtolower((string)$payment['status']) !== 'succeeded') {
+        $pageError = $pageError ?: 'Only a successful payment can be corrected.';
+    } elseif (!empty($payment['project_invoice_payment_id']) || (string)$payment['collection_mode'] !== 'direct') {
+        $pageError = $pageError ?: 'Project invoice payments must be corrected from the project invoice workflow.';
+    } elseif ((float)$payment['refunded_amount'] > 0.005 || (float)$payment['disputed_amount'] > 0.005) {
+        $pageError = $pageError ?: 'Refunded or disputed payments cannot be reallocated.';
+    } else {
+        $targetStmt = $pdo->prepare('
+            SELECT i.id, i.doc_number, i.invoice_type, i.status, i.total, i.amount_paid, i.balance_due,
+                   i.contract_id, i.issue_date
+            FROM invoices i
+            WHERE i.client_id = ?
+              AND i.id <> ?
+              AND i.organization_id <=> ?
+              AND i.collection_mode = "direct"
+              AND i.status NOT IN ("draft", "void", "cancelled")
+              AND i.finalized_at IS NOT NULL
+            ORDER BY i.id DESC
+            LIMIT 250
+        ');
+        $targetStmt->execute([
+            (int)$payment['client_id'],
+            (int)$payment['invoice_id'],
+            $payment['organization_id'] !== null ? (int)$payment['organization_id'] : null,
+        ]);
+        $targets = $targetStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $manualStmt = $pdo->prepare('
+            SELECT p.id, p.invoice_id, p.amount, p.payment_method, p.payment_date,
+                   i.doc_number, i.invoice_type
+            FROM payments p
+            JOIN invoices i ON i.id = p.invoice_id
+            WHERE p.client_id = ?
+              AND p.organization_id <=> ?
+              AND p.status = "succeeded"
+              AND p.payment_method <> "stripe"
+              AND p.stripe_payment_intent_id IS NULL
+              AND p.stripe_session_id IS NULL
+              AND p.processor_provider IS NULL
+              AND p.processor_payment_id IS NULL
+              AND p.project_invoice_payment_id IS NULL
+              AND p.refunded_amount <= 0.005
+              AND p.disputed_amount <= 0.005
+              AND p.invoice_id <> ?
+              AND i.collection_mode = "direct"
+              AND i.status NOT IN ("draft", "void", "cancelled")
+            ORDER BY p.payment_date DESC, p.id DESC
+            LIMIT 250
+        ');
+        $manualStmt->execute([
+            (int)$payment['client_id'],
+            $payment['organization_id'] !== null ? (int)$payment['organization_id'] : null,
+            (int)$payment['invoice_id'],
+        ]);
+        foreach ($manualStmt->fetchAll(PDO::FETCH_ASSOC) as $candidate) {
+            $candidate['invoice_label'] = pa_invoice_label_from_row($candidate);
+            $manualCandidates[] = $candidate;
+        }
+    }
+}
+?>
+<section style="max-width:900px">
+  <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap">
+    <div>
+      <h2 style="margin:0">Correct payment allocation</h2>
+      <p style="color:var(--muted);margin:6px 0 0">Move a real payment to the invoice it should have paid without sending or recording a refund.</p>
+    </div>
+    <a href="/?page=payments-list" style="padding:8px 12px;border:1px solid #ddd;border-radius:8px;background:#fff">Back to payments</a>
+  </div>
+
+  <?php if ($pageError !== ''): ?>
+    <div style="margin:16px 0;padding:12px;border-radius:8px;background:#fff1f2;color:#881337;border:1px solid #fca5a5"><?php echo htmlspecialchars($pageError); ?></div>
+  <?php endif; ?>
+
+  <?php if ($payment && $pageError === ''): ?>
+    <div style="margin:18px 0;padding:16px;border:1px solid #bfdbfe;border-radius:10px;background:#eff6ff;color:#1e3a8a">
+      <strong>No money moves in this workflow.</strong> Project Alpha keeps the existing Stripe transaction and processor IDs. It only corrects which invoice receives the payment.
+    </div>
+
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin-bottom:18px">
+      <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Payment</div><div style="font-size:20px;font-weight:700">#<?php echo (int)$payment['id']; ?> · $<?php echo number_format((float)$payment['amount'], 2); ?></div></div>
+      <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Currently applied to</div><div style="font-size:20px;font-weight:700"><?php echo htmlspecialchars(pa_invoice_label_from_row($payment)); ?></div></div>
+      <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Client</div><div style="font-size:20px;font-weight:700"><?php echo htmlspecialchars((string)$payment['client_name']); ?></div></div>
+      <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Method</div><div style="font-size:20px;font-weight:700"><?php echo htmlspecialchars(ucwords(str_replace('_', ' ', (string)$payment['payment_method']))); ?></div></div>
+    </div>
+
+    <?php if (!$targets): ?>
+      <div style="padding:12px;border-radius:8px;background:#fffbeb;color:#92400e;border:1px solid #fde68a">No other finalized direct invoices are available for this client.</div>
+    <?php else: ?>
+      <form method="post" action="/?page=payments/payment-correct" style="display:grid;gap:16px;padding:18px;border:1px solid #e5e7eb;border-radius:10px;background:#fff" onsubmit="return confirm('Correct this payment allocation? No Stripe refund will be created.');">
+        <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+        <input type="hidden" name="payment_id" value="<?php echo (int)$payment['id']; ?>">
+
+        <label>
+          <div style="font-weight:600;margin-bottom:6px">Target invoice</div>
+          <select name="target_invoice_id" id="correctionTargetInvoice" required style="width:100%;padding:10px;border:1px solid #d1d5db;border-radius:8px;background:#fff">
+            <option value="">Select the correct invoice</option>
+            <?php foreach ($targets as $target): ?>
+              <option value="<?php echo (int)$target['id']; ?>">
+                <?php echo htmlspecialchars(pa_invoice_label_from_row($target)); ?> · <?php echo htmlspecialchars(ucfirst((string)$target['status'])); ?> · $<?php echo number_format((float)$target['total'], 2); ?> total · $<?php echo number_format((float)$target['balance_due'], 2); ?> due
+              </option>
+            <?php endforeach; ?>
+          </select>
+        </label>
+
+        <label>
+          <div style="font-weight:600;margin-bottom:6px">Duplicate manual payment to reverse</div>
+          <select name="replacement_payment_id" id="correctionReplacementPayment" style="width:100%;padding:10px;border:1px solid #d1d5db;border-radius:8px;background:#fff" disabled>
+            <option value="">None</option>
+          </select>
+          <div style="font-size:13px;color:var(--muted);margin-top:5px">For your case, select the cash payment you manually recorded on the LTI. It will be marked “reversed,” not refunded or deleted.</div>
+        </label>
+
+        <label>
+          <div style="font-weight:600;margin-bottom:6px">Correction reason</div>
+          <textarea name="reason" maxlength="500" required rows="3" style="width:100%;padding:10px;border:1px solid #d1d5db;border-radius:8px;box-sizing:border-box">Duplicate invoice created after the original recurring invoice email was delayed; reallocate the real payment to the correct invoice.</textarea>
+        </label>
+
+        <label style="display:flex;gap:10px;align-items:flex-start;padding:12px;border:1px solid #e5e7eb;border-radius:8px">
+          <input type="checkbox" name="void_source" value="1" checked style="margin-top:3px">
+          <span><strong>Void the original invoice after moving its payment</strong><br><span style="font-size:13px;color:var(--muted)">This is appropriate for an accidental duplicate invoice. The invoice remains in history as void.</span></span>
+        </label>
+
+        <div style="display:flex;gap:10px;justify-content:flex-end;flex-wrap:wrap">
+          <a href="/?page=payments-list" style="padding:10px 14px;border:1px solid #d1d5db;border-radius:8px;background:#fff">Cancel</a>
+          <button type="submit" style="padding:10px 14px;border:1px solid #1d4ed8;border-radius:8px;background:#2563eb;color:#fff;font-weight:600">Correct allocation</button>
+        </div>
+      </form>
+    <?php endif; ?>
+  <?php endif; ?>
+</section>
+
+<?php if ($payment && $pageError === '' && $targets): ?>
+<script>
+(function () {
+  var target = document.getElementById('correctionTargetInvoice');
+  var replacement = document.getElementById('correctionReplacementPayment');
+  var candidates = <?php echo json_encode($manualCandidates, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?>;
+  function refreshCandidates() {
+    var invoiceId = String(target.value || '');
+    replacement.innerHTML = '<option value="">None</option>';
+    candidates.filter(function (item) { return String(item.invoice_id) === invoiceId; }).forEach(function (item) {
+      var option = document.createElement('option');
+      option.value = item.id;
+      option.textContent = 'Payment #' + item.id + ' · $' + Number(item.amount).toFixed(2) + ' · ' + String(item.payment_method).replaceAll('_', ' ') + ' · ' + item.payment_date;
+      replacement.appendChild(option);
+    });
+    replacement.disabled = invoiceId === '' || replacement.options.length === 1;
+  }
+  target.addEventListener('change', refreshCandidates);
+  refreshCandidates();
+})();
+</script>
+<?php endif; ?>

--- a/src/views/pages/payments/payments-list.php
+++ b/src/views/pages/payments/payments-list.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/payments-list.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/acl.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/payment_accounting.php';
@@ -32,7 +33,9 @@ if($where){$sqlCount.=' WHERE '.implode(' AND ',$where);} $stc=$pdo->prepare($sq
 $sql = 'SELECT p.id, p.amount, p.refunded_amount, p.disputed_amount, p.status, p.payment_date, p.created_at,
                p.payment_method, p.reference_number, p.surcharge_paid, p.surcharge_refunded, p.surcharge_refund_amount,
                p.processor_provider, p.processor_gross_amount, p.processor_fee_amount, p.processor_net_amount,
-               p.processor_fee_policy, p.processor_fee_source, i.id AS invoice_id, i.doc_number,
+               p.processor_payment_id, p.stripe_payment_intent_id, p.stripe_session_id, p.project_invoice_payment_id,
+               p.reversed_at, p.reversal_reason,
+               p.processor_fee_policy, p.processor_fee_source, i.id AS invoice_id, i.doc_number, i.invoice_type, i.collection_mode,
                c.name AS client, ppt.payer_name, ppt.payer_email
         ' . $fromSql;
 if($where){$sql.=' WHERE '.implode(' AND ',$where);} $sql.=" ORDER BY p.payment_date DESC, p.created_at DESC LIMIT $per OFFSET $offset";
@@ -107,15 +110,27 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
           $disputed = (float)$r['disputed_amount'];
           $appliedNet = max(0, $amount - $refunded - $disputed);
           $processorFee = $r['processor_fee_amount'] !== null ? (float)$r['processor_fee_amount'] : 0.0;
-          $net = payment_accounting_net_income($r);
+          $isSucceeded = strtolower((string)$r['status']) === 'succeeded';
+          $net = $isSucceeded ? payment_accounting_net_income($r) : 0.0;
           $feeSource = (string)($r['processor_fee_source'] ?? 'unknown');
-          $canRefund = strtolower((string)$r['status']) === 'succeeded' && $appliedNet > 0.005;
+          $isProcessorBacked = strtolower((string)$r['payment_method']) === 'stripe'
+            || trim((string)($r['processor_provider'] ?? '')) !== ''
+            || trim((string)($r['processor_payment_id'] ?? '')) !== ''
+            || trim((string)($r['stripe_payment_intent_id'] ?? '')) !== ''
+            || trim((string)($r['stripe_session_id'] ?? '')) !== '';
+          $canRecordRefund = $isSucceeded && !$isProcessorBacked && $appliedNet > 0.005;
+          $canCorrect = $isSucceeded
+            && !empty($r['invoice_id'])
+            && (string)($r['collection_mode'] ?? 'direct') === 'direct'
+            && empty($r['project_invoice_payment_id'])
+            && $refunded <= 0.005
+            && $disputed <= 0.005;
         ?>
           <tr style="border-top:1px solid #f3f4f6">
             <td style="padding:10px">#<?php echo (int)$r['id']; ?></td>
             <td style="padding:10px">
               <?php if (!empty($r['invoice_id'])): ?>
-                Invoice #<?php echo htmlspecialchars((string)($r['doc_number'] ?: $r['invoice_id'])); ?>
+                Invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?>
               <?php elseif (!empty($r['processor_provider'])): ?>
                 Processor income
               <?php else: ?>
@@ -132,16 +147,23 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
             <td style="padding:10px;text-transform:capitalize"><?php echo htmlspecialchars($r['status']); ?></td>
             <td style="padding:10px"><?php echo $r['payment_date'] ? date('m/d/Y', strtotime($r['payment_date'])) : ''; ?></td>
             <td style="padding:10px">
-              <?php if ($canRefund): ?>
-                <form method="post" action="/?page=payments/payment-refund" style="display:flex;gap:6px;align-items:center" onsubmit="return confirm('Record this refund? This changes income and invoice balance.');">
+              <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;min-width:190px">
+              <?php if ($canCorrect): ?>
+                <a href="/?page=payments/payment-correction&payment_id=<?php echo (int)$r['id']; ?>" style="padding:6px 9px;border-radius:6px;border:1px solid #bfdbfe;background:#eff6ff;color:#1d4ed8;white-space:nowrap">Correct allocation</a>
+              <?php endif; ?>
+              <?php if ($canRecordRefund): ?>
+                <form method="post" action="/?page=payments/payment-refund" style="display:flex;gap:6px;align-items:center" onsubmit="return confirm('Record this refund only after money has been returned to the client outside Project Alpha. Continue?');">
                   <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
                   <input type="hidden" name="payment_id" value="<?php echo (int)$r['id']; ?>">
                   <input type="number" name="amount" step="0.01" min="0.01" max="<?php echo htmlspecialchars(number_format($appliedNet, 2, '.', '')); ?>" placeholder="0.00" style="width:92px;padding:6px;border-radius:6px;border:1px solid #ddd">
-                  <button type="submit" style="padding:6px 9px;border-radius:6px;border:1px solid #fecaca;background:#fff1f2;color:#991b1b">Refund</button>
+                  <button type="submit" style="padding:6px 9px;border-radius:6px;border:1px solid #fecaca;background:#fff1f2;color:#991b1b;white-space:nowrap">Record refund</button>
                 </form>
-              <?php else: ?>
+              <?php elseif ($isProcessorBacked && $isSucceeded): ?>
+                <span title="Refund the payment in Stripe. Project Alpha will sync the Stripe refund webhook." style="color:var(--muted);font-size:12px">Refund via Stripe</span>
+              <?php elseif (!$canCorrect): ?>
                 <span style="color:var(--muted);font-size:13px">-</span>
               <?php endif; ?>
+              </div>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/src/views/pages/project/project-invoice-details.php
+++ b/src/views/pages/project/project-invoice-details.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/project/project-invoice-details.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../config/app.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/acl.php';
@@ -38,7 +39,7 @@ if (!defined('PUBLIC_VIEW')) {
 }
 
 $itemsStmt = $pdo->prepare('
-    SELECT pii.*, i.project_code, i.status AS current_status, i.total AS current_total, i.amount_paid AS current_paid,
+    SELECT pii.*, i.project_code, i.invoice_type, i.status AS current_status, i.total AS current_total, i.amount_paid AS current_paid,
            c.name AS client_name
     FROM project_invoice_items pii
     JOIN invoices i ON i.id = pii.invoice_id
@@ -214,7 +215,7 @@ $showEmailPanel = !empty($_GET['email_panel']) || !empty($_GET['content_link_war
     <tbody>
       <?php foreach ($items as $item): ?>
         <tr>
-          <td style="padding:9px;border:1px solid #e5e7eb">I-<?php echo htmlspecialchars((string)($item['invoice_doc_number'] ?: $item['invoice_id'])); ?></td>
+          <td style="padding:9px;border:1px solid #e5e7eb"><?php echo htmlspecialchars(pa_invoice_label($item['invoice_doc_number'] ?? null, $item['invoice_type'] ?? 'regular', $item['invoice_id'])); ?></td>
           <td style="padding:9px;border:1px solid #e5e7eb"><?php echo htmlspecialchars($item['client_name']); ?></td>
           <td style="padding:9px;border:1px solid #e5e7eb"><?php echo $item['invoice_date'] ? htmlspecialchars(date('M j, Y', strtotime($item['invoice_date']))) : ''; ?></td>
           <td style="padding:9px;border:1px solid #e5e7eb;text-align:right">$<?php echo number_format((float)$item['amount_due_at_generation'], 2); ?></td>
@@ -250,7 +251,7 @@ $showEmailPanel = !empty($_GET['email_panel']) || !empty($_GET['content_link_war
     <div style="break-inside:avoid;margin-bottom:18px;border:1px solid #e5e7eb;border-radius:8px;padding:14px;background:#fff">
       <div style="display:flex;justify-content:space-between;gap:12px;margin-bottom:10px">
         <div>
-          <div style="font-weight:800">Invoice I-<?php echo htmlspecialchars((string)($item['invoice_doc_number'] ?: $item['invoice_id'])); ?></div>
+          <div style="font-weight:800">Invoice <?php echo htmlspecialchars(pa_invoice_label($item['invoice_doc_number'] ?? null, $item['invoice_type'] ?? 'regular', $item['invoice_id'])); ?></div>
           <div style="font-size:13px;color:#6b7280"><?php echo htmlspecialchars($item['client_name']); ?></div>
         </div>
         <div style="font-weight:800">$<?php echo number_format((float)$item['amount_due_at_generation'], 2); ?></div>

--- a/src/views/pages/project/projects-details.php
+++ b/src/views/pages/project/projects-details.php
@@ -1,6 +1,7 @@
 <?php
 // src/views/pages/project/projects-details.php
 require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../utils/escaper.php';
 require_once __DIR__ . '/../../../utils/acl.php';
@@ -45,7 +46,7 @@ $stmt->execute([$projectId]);
 $contracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 // Fetch associated invoices
-$stmt = $pdo->prepare('SELECT id, doc_number, status, total, amount_paid, balance_due, created_at FROM invoices WHERE project_id = ? ORDER BY created_at DESC');
+$stmt = $pdo->prepare('SELECT id, doc_number, invoice_type, status, total, amount_paid, balance_due, created_at FROM invoices WHERE project_id = ? ORDER BY created_at DESC');
 $stmt->execute([$projectId]);
 $invoices = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -279,7 +280,7 @@ $stmt = $pdo->prepare("SELECT id, doc_number, status, total, created_at FROM con
 $stmt->execute($docScopeParams);
 $availableContracts = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$stmt = $pdo->prepare("SELECT id, doc_number, status, total, created_at FROM invoices WHERE {$docScopeSql} AND project_id IS NULL ORDER BY created_at DESC LIMIT 50");
+$stmt = $pdo->prepare("SELECT id, doc_number, invoice_type, status, total, created_at FROM invoices WHERE {$docScopeSql} AND project_id IS NULL ORDER BY created_at DESC LIMIT 50");
 $stmt->execute($docScopeParams);
 $availableInvoices = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -318,7 +319,7 @@ $renderDocumentAttachForm = static function (string $type, string $label, array 
                     <option value="">Select <?php echo htmlspecialchars(strtolower($label)); ?></option>
                     <?php foreach ($documents as $document): ?>
                         <option value="<?php echo (int)$document['id']; ?>">
-                            #<?php echo htmlspecialchars((string)($document['doc_number'] ?? $document['id'])); ?>
+                            <?php echo htmlspecialchars($type === 'invoice' ? pa_invoice_label_from_row($document) : '#' . (string)($document['doc_number'] ?? $document['id'])); ?>
                             - <?php echo htmlspecialchars(ucfirst((string)$document['status'])); ?>
                             - $<?php echo number_format((float)$document['total'], 2); ?>
                         </option>
@@ -710,7 +711,7 @@ $renderProjectFileRow = static function (array $file, int $projectId): void {
                         <?php foreach ($invoices as $invoice): ?>
                         <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;padding:12px;border:1px solid #e5e7eb;border-radius:8px;background:#f9fafb">
                             <div>
-                                <div class="font-600">Invoice #<?php echo e($invoice['doc_number'] ?? $invoice['id']); ?></div>
+                                <div class="font-600">Invoice <?php echo e(pa_invoice_label_from_row($invoice)); ?></div>
                                 <div style="font-size:13px;color:var(--muted)">
                                     <?php echo e(ucfirst($invoice['status'])); ?> · 
                                     <?php echo date('M j, Y', strtotime($invoice['created_at'])); ?>

--- a/tests/Payments/PaymentIntegrityTest.php
+++ b/tests/Payments/PaymentIntegrityTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 require_once dirname(__DIR__, 2) . '/src/migrations/migration_lib.php';
 require_once dirname(__DIR__, 2) . '/src/utils/invoice_lifecycle.php';
+require_once dirname(__DIR__, 2) . '/src/utils/payment_corrections.php';
+require_once dirname(__DIR__, 2) . '/src/utils/stripe_financial_events.php';
 
 use PHPUnit\Framework\TestCase;
 
@@ -27,6 +29,12 @@ final class PaymentIntegrityTest extends TestCase
             return;
         }
 
+        foreach (array_reverse($this->ids['payment_corrections'] ?? []) as $id) {
+            $this->pdo->prepare('DELETE FROM payment_corrections WHERE id = ?')->execute([$id]);
+        }
+        foreach (array_reverse($this->ids['stripe_refunds'] ?? []) as $id) {
+            $this->pdo->prepare('DELETE FROM stripe_refunds WHERE id = ?')->execute([$id]);
+        }
         foreach (array_reverse($this->ids['public_links'] ?? []) as $id) {
             $this->pdo->prepare('DELETE FROM public_links WHERE id = ?')->execute([$id]);
         }
@@ -126,6 +134,230 @@ final class PaymentIntegrityTest extends TestCase
         self::assertSame('active', (string)$status->fetchColumn(), 'A recurring installment must not complete its long-term contract.');
     }
 
+    public function testStripePaymentCanReplaceMistakenCashEntryAndVoidDuplicateInvoiceWithoutRefunding(): void
+    {
+        $orgId = $this->insertOrganization();
+        $clientId = $this->insertClient($orgId);
+        $contractId = $this->insertContract($orgId, $clientId, 'long_term', 'active');
+        $sourceInvoiceId = $this->insertInvoice($orgId, $clientId, 100.00);
+        $targetInvoiceId = $this->insertInvoice($orgId, $clientId, 100.00, $contractId, 'long_term');
+        $sourcePublicLinkId = $this->insertInvoicePublicLink($sourceInvoiceId);
+
+        $stripe = invoice_record_locked_payment($this->pdo, $sourceInvoiceId, 100.00, 'stripe', null, null, [
+            'organization_id' => $orgId,
+            'source' => 'test_stripe',
+        ]);
+        $stripePaymentId = $this->remember('payments', (int)$stripe['payment_id']);
+        $stripeIntentId = 'pi_correction_' . bin2hex(random_bytes(6));
+        $this->pdo->prepare('UPDATE payments SET stripe_payment_intent_id=?,processor_provider="stripe",processor_payment_id=? WHERE id=?')
+            ->execute([$stripeIntentId, $stripeIntentId, $stripePaymentId]);
+
+        $cash = invoice_record_locked_payment($this->pdo, $targetInvoiceId, 100.00, 'cash', null, 'Mistaken duplicate entry', [
+            'organization_id' => $orgId,
+            'complete_contract_when_paid' => true,
+            'source' => 'test_manual',
+        ]);
+        $cashPaymentId = $this->remember('payments', (int)$cash['payment_id']);
+
+        $receiptToken = bin2hex(random_bytes(32));
+        $this->pdo->prepare('INSERT INTO payment_receipts (payment_id,invoice_id,receipt_number,public_token,amount) VALUES (?,?,?,?,100)')
+            ->execute([$stripePaymentId, $sourceInvoiceId, 'R-CORR-' . bin2hex(random_bytes(5)), $receiptToken]);
+
+        $result = payment_reallocate_to_invoice(
+            $this->pdo,
+            $stripePaymentId,
+            $targetInvoiceId,
+            $cashPaymentId,
+            true,
+            [],
+            'Duplicate first-month invoice; move the real Stripe payment to the recurring invoice.',
+            null
+        );
+        $this->remember('payment_corrections', (int)$result['correction_id']);
+
+        self::assertTrue($result['source_voided']);
+        self::assertSame('void', $result['source_status']);
+        self::assertSame('paid', $result['target_status']);
+
+        $moved = $this->pdo->prepare('SELECT invoice_id,contract_id,status,refunded_amount,stripe_payment_intent_id FROM payments WHERE id=?');
+        $moved->execute([$stripePaymentId]);
+        $moved = $moved->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame($targetInvoiceId, (int)$moved['invoice_id']);
+        self::assertSame($contractId, (int)$moved['contract_id']);
+        self::assertSame('succeeded', $moved['status']);
+        self::assertEqualsWithDelta(0.0, (float)$moved['refunded_amount'], 0.005);
+        self::assertSame($stripeIntentId, $moved['stripe_payment_intent_id']);
+
+        $reversed = $this->pdo->prepare('SELECT status,reversed_at,reversal_reason,refunded_amount FROM payments WHERE id=?');
+        $reversed->execute([$cashPaymentId]);
+        $reversed = $reversed->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('reversed', $reversed['status']);
+        self::assertNotEmpty($reversed['reversed_at']);
+        self::assertStringContainsString('Duplicate first-month invoice', (string)$reversed['reversal_reason']);
+        self::assertEqualsWithDelta(0.0, (float)$reversed['refunded_amount'], 0.005, 'A reversal must not be recorded as a refund.');
+
+        $source = $this->pdo->prepare('SELECT status,amount_paid,balance_due,void_reason FROM invoices WHERE id=?');
+        $source->execute([$sourceInvoiceId]);
+        $source = $source->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('void', $source['status']);
+        self::assertEqualsWithDelta(0.0, (float)$source['amount_paid'], 0.005);
+        self::assertEqualsWithDelta(0.0, (float)$source['balance_due'], 0.005);
+        self::assertStringContainsString('Duplicate first-month invoice', (string)$source['void_reason']);
+
+        $target = $this->pdo->prepare('SELECT status,amount_paid,balance_due FROM invoices WHERE id=?');
+        $target->execute([$targetInvoiceId]);
+        $target = $target->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('paid', $target['status']);
+        self::assertEqualsWithDelta(100.0, (float)$target['amount_paid'], 0.005);
+        self::assertEqualsWithDelta(0.0, (float)$target['balance_due'], 0.005);
+
+        $contract = $this->pdo->prepare('SELECT status FROM contracts WHERE id=?');
+        $contract->execute([$contractId]);
+        self::assertSame('active', (string)$contract->fetchColumn());
+        self::assertStringContainsString('reason=void', (string)$this->publicLinkState($sourcePublicLinkId)['redirect']);
+
+        $receipt = $this->pdo->prepare('SELECT invoice_id FROM payment_receipts WHERE payment_id=?');
+        $receipt->execute([$stripePaymentId]);
+        self::assertSame($targetInvoiceId, (int)$receipt->fetchColumn(), 'The real payment receipt must follow the corrected invoice.');
+
+        $refunds = $this->pdo->prepare('SELECT COUNT(*) FROM stripe_refunds WHERE payment_id=?');
+        $refunds->execute([$stripePaymentId]);
+        self::assertSame(0, (int)$refunds->fetchColumn(), 'A correction must not create a Stripe refund record.');
+    }
+
+    public function testStripeRefundWebhookClearsPaidAtAndIsIdempotent(): void
+    {
+        $orgId = $this->insertOrganization();
+        $clientId = $this->insertClient($orgId);
+        $contractId = $this->insertContract($orgId, $clientId, 'long_term', 'active');
+        $invoiceId = $this->insertInvoice($orgId, $clientId, 100.00, $contractId, 'long_term');
+        $payment = invoice_record_locked_payment($this->pdo, $invoiceId, 100.00, 'stripe', null, null, [
+            'organization_id' => $orgId,
+            'complete_contract_when_paid' => true,
+        ]);
+        $paymentId = $this->remember('payments', (int)$payment['payment_id']);
+        $intentId = 'pi_refund_' . bin2hex(random_bytes(6));
+        $refundId = 're_refund_' . bin2hex(random_bytes(6));
+        $this->pdo->prepare('UPDATE payments SET stripe_payment_intent_id=? WHERE id=?')->execute([$intentId, $paymentId]);
+
+        stripe_record_refund($this->pdo, [
+            'id' => $refundId,
+            'payment_intent' => $intentId,
+            'amount' => 3000,
+            'status' => 'succeeded',
+        ]);
+        $refundRow = $this->pdo->prepare('SELECT id FROM stripe_refunds WHERE stripe_refund_id=?');
+        $refundRow->execute([$refundId]);
+        $this->remember('stripe_refunds', (int)$refundRow->fetchColumn());
+
+        $partial = $this->pdo->prepare('SELECT status,amount_paid,balance_due,paid_at FROM invoices WHERE id=?');
+        $partial->execute([$invoiceId]);
+        $partial = $partial->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('partial', $partial['status']);
+        self::assertEqualsWithDelta(70.0, (float)$partial['amount_paid'], 0.005);
+        self::assertEqualsWithDelta(30.0, (float)$partial['balance_due'], 0.005);
+        self::assertNull($partial['paid_at']);
+
+        stripe_record_refund($this->pdo, [
+            'id' => $refundId,
+            'payment_intent' => $intentId,
+            'amount' => 10000,
+            'status' => 'succeeded',
+        ]);
+        $full = $this->pdo->prepare('SELECT status,amount_paid,balance_due,paid_at FROM invoices WHERE id=?');
+        $full->execute([$invoiceId]);
+        $full = $full->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('unpaid', $full['status']);
+        self::assertEqualsWithDelta(0.0, (float)$full['amount_paid'], 0.005);
+        self::assertEqualsWithDelta(100.0, (float)$full['balance_due'], 0.005);
+        self::assertNull($full['paid_at']);
+
+        $count = $this->pdo->prepare('SELECT COUNT(*) FROM stripe_refunds WHERE stripe_refund_id=?');
+        $count->execute([$refundId]);
+        self::assertSame(1, (int)$count->fetchColumn());
+        $contract = $this->pdo->prepare('SELECT status FROM contracts WHERE id=?');
+        $contract->execute([$contractId]);
+        self::assertSame('active', (string)$contract->fetchColumn());
+    }
+
+    public function testProcessorRefundActionCannotRecordALocalOnlyRefund(): void
+    {
+        $controller = (string)file_get_contents(dirname(__DIR__, 2) . '/src/controllers/payments_refund.php');
+        self::assertStringContainsString('$isProcessorBacked', $controller);
+        self::assertStringContainsString('must be refunded in Stripe', $controller);
+        self::assertStringContainsString('use Correct allocation instead', $controller);
+    }
+
+    public function testUnpaidInvoiceCanBeVoidedAndSafelyReenabled(): void
+    {
+        $orgId = $this->insertOrganization();
+        $clientId = $this->insertClient($orgId);
+        $invoiceId = $this->insertInvoice($orgId, $clientId, 175.00);
+        $publicLinkId = $this->insertInvoicePublicLink($invoiceId);
+
+        $result = invoice_void($this->pdo, $invoiceId, [], '  Created   for the wrong client  ', 987);
+        self::assertSame('unpaid', $result['previous_status']);
+        self::assertSame('Created for the wrong client', $result['reason']);
+
+        $state = $this->invoiceVoidState($invoiceId);
+        self::assertSame('void', $state['status']);
+        self::assertEqualsWithDelta(0.0, (float)$state['balance_due'], 0.005);
+        self::assertSame('unpaid', $state['void_previous_status']);
+        self::assertSame('Created for the wrong client', $state['void_reason']);
+        self::assertSame(987, (int)$state['voided_by']);
+        self::assertNotEmpty($state['voided_at']);
+
+        $publicLink = $this->publicLinkState($publicLinkId);
+        self::assertSame(1, (int)$publicLink['revoked']);
+        self::assertStringContainsString('reason=void', (string)$publicLink['redirect']);
+
+        try {
+            invoice_record_locked_payment($this->pdo, $invoiceId, 25.00, 'cash', null, null);
+            self::fail('A payment was recorded against a void invoice.');
+        } catch (RuntimeException $error) {
+            self::assertStringContainsString('void or cancelled invoice', $error->getMessage());
+        }
+
+        $reenabled = invoice_reenable_void($this->pdo, $invoiceId);
+        self::assertSame('unpaid', $reenabled['restored_status']);
+        self::assertSame('Created for the wrong client', $reenabled['reason']);
+
+        $restored = $this->invoiceVoidState($invoiceId);
+        self::assertSame('unpaid', $restored['status']);
+        self::assertEqualsWithDelta(175.0, (float)$restored['balance_due'], 0.005);
+        self::assertNull($restored['voided_at']);
+        self::assertNull($restored['void_reason']);
+        self::assertSame(1, $this->publicLinkRevoked($publicLinkId), 'Re-enabling must not resurrect an old client link.');
+    }
+
+    public function testDraftInvoiceReturnsToDraftAfterVoidAndPaidInvoiceIsRejected(): void
+    {
+        $orgId = $this->insertOrganization();
+        $clientId = $this->insertClient($orgId);
+        $draftId = $this->insertInvoice($orgId, $clientId, 80.00);
+        $this->pdo->prepare('UPDATE invoices SET status="draft",finalized_at=NULL,balance_due=0 WHERE id=?')->execute([$draftId]);
+
+        invoice_void($this->pdo, $draftId, [], 'Duplicate draft');
+        $reenabled = invoice_reenable_void($this->pdo, $draftId);
+        self::assertSame('draft', $reenabled['restored_status']);
+        $draft = $this->invoiceVoidState($draftId);
+        self::assertSame('draft', $draft['status']);
+        self::assertEqualsWithDelta(0.0, (float)$draft['balance_due'], 0.005);
+
+        $paidId = $this->insertInvoice($orgId, $clientId, 60.00);
+        $payment = invoice_record_locked_payment($this->pdo, $paidId, 10.00, 'cash', null, null);
+        $this->ids['payments'][] = (int)$payment['payment_id'];
+
+        try {
+            invoice_void($this->pdo, $paidId, [], 'Should not work');
+            self::fail('Partially paid invoice was voided.');
+        } catch (RuntimeException $error) {
+            self::assertStringContainsString('cannot be voided', $error->getMessage());
+        }
+        $paidState = $this->invoiceVoidState($paidId);
+        self::assertSame('partial', $paidState['status']);
+    }
+
     public function testDepositControllersUseCentralizedPaymentGuardrails(): void
     {
         $deposit = (string)file_get_contents(dirname(__DIR__, 2) . '/src/controllers/contract/contract_deposit_received.php');
@@ -197,6 +429,13 @@ final class PaymentIntegrityTest extends TestCase
     {
         $stmt = $this->pdo->prepare('SELECT revoked, redirect, expires_at FROM public_links WHERE id = ?');
         $stmt->execute([$publicLinkId]);
+        return $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    }
+
+    private function invoiceVoidState(int $invoiceId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT status,balance_due,voided_at,voided_by,void_reason,void_previous_status FROM invoices WHERE id=?');
+        $stmt->execute([$invoiceId]);
         return $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
     }
 

--- a/tests/Workflows/InvoiceVoidWorkflowTest.php
+++ b/tests/Workflows/InvoiceVoidWorkflowTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class InvoiceVoidWorkflowTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = dirname(__DIR__, 2);
+    }
+
+    public function testInvoiceVoidLifecycleIsRoutedAndPermissioned(): void
+    {
+        $router = (string)file_get_contents($this->root . '/public/index.php');
+        $acl = (string)file_get_contents($this->root . '/src/utils/acl_middleware.php');
+        $audit = (string)file_get_contents($this->root . '/src/utils/audit_middleware.php');
+        $controller = (string)file_get_contents($this->root . '/src/controllers/invoice/invoice_void.php');
+        $reenable = (string)file_get_contents($this->root . '/src/controllers/invoice/invoice_reenable.php');
+
+        self::assertStringContainsString("'invoice/invoice-void'", $router);
+        self::assertStringContainsString("'invoice/invoice-reenable'", $router);
+        self::assertStringContainsString("'invoice/invoice-void'      => 'invoices.void'", $acl);
+        self::assertStringContainsString("'invoice/invoice-reenable'  => 'invoices.void'", $acl);
+        self::assertStringContainsString("'invoice/invoice-void'", $audit);
+        self::assertStringContainsString("require_record_ownership(\$pdo, 'invoices', \$id)", $controller);
+        self::assertStringContainsString('invoice_void($pdo, $id, $appConfig, $reason, $userId)', $controller);
+        self::assertStringContainsString('invoice_reenable_void($pdo, $id)', $reenable);
+    }
+
+    public function testVoidMetadataAndActionsAreVisibleButAccountingHistoryIsPreserved(): void
+    {
+        $baseline = (string)file_get_contents($this->root . '/database/baseline.sql');
+        $migration = (string)file_get_contents($this->root . '/database/migrations/0030_invoice_void_workflow.sql');
+        $lifecycle = (string)file_get_contents($this->root . '/src/utils/invoice_lifecycle.php');
+        $details = (string)file_get_contents($this->root . '/src/views/pages/invoice/invoice-details.php');
+
+        foreach (['voided_at', 'voided_by', 'void_reason', 'void_previous_status'] as $column) {
+            self::assertStringContainsString($column, $baseline);
+            self::assertStringContainsString($column, $migration);
+        }
+        self::assertStringContainsString('function invoice_void(', $lifecycle);
+        self::assertStringContainsString('Paid or partially paid invoices cannot be voided', $lifecycle);
+        self::assertStringContainsString('project invoice PI-', $lifecycle);
+        self::assertStringContainsString('pa_public_link_terminalize($pdo, \'invoice\', $invoiceId, \'void\', true)', $lifecycle);
+        self::assertStringContainsString('UPDATE time_entries SET billed=0', $lifecycle);
+        self::assertStringContainsString('function invoice_reenable_void(', $lifecycle);
+        self::assertStringContainsString('/?page=invoice/invoice-void', $details);
+        self::assertStringContainsString('Reason for voiding', $details);
+        self::assertStringContainsString('View PDF', $details);
+        self::assertStringContainsString('Void reason', $details);
+    }
+
+    public function testRecurringHistoryActionPreservesEveryFilterAndScrollsToResults(): void
+    {
+        $history = (string)file_get_contents($this->root . '/src/views/pages/invoice/recurring-invoices-list.php');
+        $navigation = (string)file_get_contents($this->root . '/public/assets/navigation.js');
+
+        self::assertStringContainsString('&contract_id=<?php echo (int)$ltc[\'id\']; ?>&history_page=1#invoice-history', $history);
+        self::assertStringContainsString('View history (', $history);
+        self::assertStringContainsString('Showing invoices for', $history);
+        self::assertStringContainsString('View / Actions', $history);
+        self::assertStringContainsString("const rest = separatorIndex >= 0 ? page.slice(separatorIndex + 1) : '';", $navigation);
+        self::assertStringContainsString('navigateToPage(fullPage, true, linkUrl.hash)', $navigation);
+        self::assertStringContainsString('scrollToPageHash(targetHash)', $navigation);
+    }
+}

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -365,6 +365,33 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('pa_next_invoice_doc_number($pdo, \'on_demand\')', (string)$odcInvoice);
     }
 
+    public function testInvoiceLabelsAreConsistentAcrossInvoiceTypes(): void
+    {
+        require_once $this->root . '/src/utils/invoice_numbers.php';
+
+        self::assertSame('I-12', pa_invoice_label(12, 'regular'));
+        self::assertSame('I-12', pa_invoice_label(12, null));
+        self::assertSame('LTI-12', pa_invoice_label(12, 'long_term'));
+        self::assertSame('ODI-12', pa_invoice_label(12, 'on_demand'));
+        self::assertSame('LTI-44', pa_invoice_label_from_row([
+            'invoice_id' => 44,
+            'doc_number' => null,
+            'invoice_type' => 'long_term',
+        ]));
+
+        $details = (string)file_get_contents($this->root . '/src/views/pages/invoice/invoice-details.php');
+        $history = (string)file_get_contents($this->root . '/src/views/pages/invoice/recurring-invoices-list.php');
+        $onDemand = (string)file_get_contents($this->root . '/src/views/pages/invoice/on-demand-invoices-list.php');
+        $onDemandGenerator = (string)file_get_contents($this->root . '/src/controllers/contract/on_demand_invoice_generate.php');
+        $delivery = (string)file_get_contents($this->root . '/src/utils/invoice_lifecycle.php');
+        self::assertStringContainsString('pa_invoice_label_from_row($inv)', $details);
+        self::assertStringContainsString("'long_term'", $history);
+        self::assertStringContainsString("'on_demand'", $onDemand);
+        self::assertStringContainsString("pa_invoice_label(\$docNumber, 'on_demand')", $onDemandGenerator);
+        self::assertStringContainsString('pa_invoice_label_from_row($invoice)', $delivery);
+        self::assertStringNotContainsString('Invoice I-', $delivery);
+    }
+
     public function testCreatePageScriptsInitializeAfterAjaxNavigation(): void
     {
         $navigation = file_get_contents($this->root . '/public/assets/navigation.js');

--- a/tests/Workflows/RecurringServicesTest.php
+++ b/tests/Workflows/RecurringServicesTest.php
@@ -114,7 +114,7 @@ final class RecurringServicesTest extends TestCase
         self::assertCount(1, $deliveries);
         self::assertSame('recurring@example.invalid', $deliveries[0]['to']);
         self::assertSame((int)$invoiceId, (int)$deliveries[0]['context']['invoice_id']);
-        self::assertStringContainsString('Invoice I-', $deliveries[0]['subject']);
+        self::assertStringContainsString('Invoice LTI-', $deliveries[0]['subject']);
 
         $notificationStmt = $this->pdo->prepare('SELECT id,sent_at FROM invoice_notifications WHERE invoice_id=? AND notification_type="on_generate"');
         $notificationStmt->execute([$invoiceId]);


### PR DESCRIPTION
## What changed

- keeps open-ended long-term contracts active when recurring invoices are paid
- improves recurring invoice history, filtering, actions, and long-term detail navigation
- supports future recurring-service pricing changes and amendments
- adds durable invoice void and re-enable workflows
- uses distinct `I-`, `LTI-`, `ODI-`, and `PI-` invoice labels throughout PA
- adds an audited payment-allocation correction workflow for moving a real Stripe payment to the correct invoice without refunding it
- separates real processor refunds from local manual refund records
- fixes Stripe refund reconciliation, invoice balances, paid dates, receipts, and recurring-contract behavior

## Why

Testing uncovered lifecycle coupling between recurring contracts and individual invoice payments, inaccessible paid recurring history, ambiguous invoice identifiers, and no safe way to correct a payment applied to an accidental invoice.

## Validation

- migration 0031 applied successfully with schema validation
- exact Stripe-payment-to-LTI correction scenario verified against MySQL
- full PHPUnit suite: 131 tests, 1,492 assertions, 1 intentional skip
- `git diff --check` passed
