### PR TITLE
Fix legacy payment recovery and invoice void UI

### DIFF
--- a/src/controllers/invoice/invoice_void.php
+++ b/src/controllers/invoice/invoice_void.php
@@ -15,6 +15,18 @@ require_record_ownership($pdo, 'invoices', $id);
 
 $reason = trim((string)($_POST['reason'] ?? ''));
 $userId = (int)($_SESSION['user']['id'] ?? 0) ?: null;
+$redirectTo = trim((string)($_POST['redirect_to'] ?? ''));
+$redirectBase = '/?page=invoice/invoice-details&id=' . $id;
+if ($redirectTo !== ''
+    && str_starts_with($redirectTo, '/')
+    && !str_starts_with($redirectTo, '//')
+    && !str_contains($redirectTo, "\r")
+    && !str_contains($redirectTo, "\n")) {
+    $redirectBase = $redirectTo;
+}
+$appendResult = static function (string $url, string $key, string $value): string {
+    return $url . (str_contains($url, '?') ? '&' : '?') . rawurlencode($key) . '=' . rawurlencode($value);
+};
 
 try {
     $result = invoice_void($pdo, $id, $appConfig, $reason, $userId);
@@ -23,8 +35,8 @@ try {
         'previous_status' => $result['previous_status'],
         'user_id' => $userId,
     ]);
-    header('Location: /?page=invoice/invoice-details&id=' . $id . '&voided=1');
+    header('Location: ' . $appendResult($redirectBase, 'voided', '1'));
 } catch (Throwable $e) {
-    header('Location: /?page=invoice/invoice-details&id=' . $id . '&error=' . urlencode($e->getMessage()));
+    header('Location: ' . $appendResult($redirectBase, 'error', $e->getMessage()));
 }
 exit;

--- a/src/utils/payment_corrections.php
+++ b/src/utils/payment_corrections.php
@@ -117,9 +117,12 @@ function payment_reallocate_to_invoice(
 
     try {
         $paymentStmt = $pdo->prepare('
-            SELECT p.*, i.status AS source_invoice_status, i.collection_mode AS source_collection_mode
+            SELECT p.*, i.status AS source_invoice_status, i.collection_mode AS source_collection_mode,
+                   i.client_id AS source_invoice_client_id,
+                   c.organization_id AS source_client_organization_id
             FROM payments p
             JOIN invoices i ON i.id = p.invoice_id
+            JOIN clients c ON c.id = i.client_id
             WHERE p.id = ?
             FOR UPDATE
         ');
@@ -130,13 +133,18 @@ function payment_reallocate_to_invoice(
         }
 
         $sourceInvoiceId = (int)$payment['invoice_id'];
+        $sourceClientId = (int)$payment['source_invoice_client_id'];
+        $sourceOrganizationId = $payment['source_client_organization_id'] !== null
+            ? (int)$payment['source_client_organization_id']
+            : null;
         if ($sourceInvoiceId === $targetInvoiceId) {
             throw new RuntimeException('The payment is already assigned to that invoice.');
         }
         if (strtolower((string)$payment['status']) !== 'succeeded') {
             throw new RuntimeException('Only a successful payment can be reallocated.');
         }
-        if (!empty($payment['project_invoice_payment_id']) || (string)$payment['source_collection_mode'] !== 'direct') {
+        $sourceCollectionMode = trim((string)($payment['source_collection_mode'] ?? '')) ?: 'direct';
+        if (!empty($payment['project_invoice_payment_id']) || $sourceCollectionMode !== 'direct') {
             throw new RuntimeException('Project invoice payments must be corrected from the project invoice workflow.');
         }
         if ((float)$payment['disputed_amount'] > 0.005) {
@@ -180,9 +188,12 @@ function payment_reallocate_to_invoice(
         }
 
         $targetStmt = $pdo->prepare('
-            SELECT id, client_id, contract_id, organization_id, status, total, collection_mode
-            FROM invoices
-            WHERE id = ?
+            SELECT i.id, i.client_id, i.contract_id, i.organization_id, i.status, i.total, i.collection_mode,
+                   COALESCE(i.organization_id, c.organization_id) AS effective_organization_id,
+                   c.organization_id AS target_client_organization_id
+            FROM invoices i
+            JOIN clients c ON c.id = i.client_id
+            WHERE i.id = ?
             FOR UPDATE
         ');
         $targetStmt->execute([$targetInvoiceId]);
@@ -193,19 +204,28 @@ function payment_reallocate_to_invoice(
         if (in_array(strtolower((string)$target['status']), ['draft', 'void', 'cancelled'], true)) {
             throw new RuntimeException('The target invoice must be finalized and active.');
         }
-        if ((string)$target['collection_mode'] !== 'direct') {
+        $targetCollectionMode = trim((string)($target['collection_mode'] ?? '')) ?: 'direct';
+        if ($targetCollectionMode !== 'direct') {
             throw new RuntimeException('Select a directly collected invoice, not a project invoice item.');
         }
-        if ((int)$target['client_id'] !== (int)$payment['client_id']) {
+        if ((int)$target['client_id'] !== $sourceClientId) {
             throw new RuntimeException('Payments can only be moved between invoices for the same client.');
         }
-        if ((int)($target['organization_id'] ?? 0) !== (int)($payment['organization_id'] ?? 0)) {
+        if (($target['target_client_organization_id'] !== null ? (int)$target['target_client_organization_id'] : null) !== $sourceOrganizationId) {
             throw new RuntimeException('Payments can only be moved within the same organization.');
         }
 
         $replacements = [];
         $targetReplacementApplied = 0.0;
-        $replacementStmt = $pdo->prepare('SELECT * FROM payments WHERE id = ? FOR UPDATE');
+        $replacementStmt = $pdo->prepare('
+            SELECT p.*, i.client_id AS replacement_invoice_client_id,
+                   c.organization_id AS replacement_client_organization_id
+            FROM payments p
+            JOIN invoices i ON i.id = p.invoice_id
+            JOIN clients c ON c.id = i.client_id
+            WHERE p.id = ?
+            FOR UPDATE
+        ');
         foreach ($replacementPaymentIds as $replacementPaymentId) {
             if ($replacementPaymentId === $paymentId) {
                 throw new RuntimeException('The moved payment cannot also be a reversed payment.');
@@ -216,8 +236,11 @@ function payment_reallocate_to_invoice(
             if (!$replacement || !in_array($replacementInvoiceId, [$sourceInvoiceId, $targetInvoiceId], true)) {
                 throw new RuntimeException('Each duplicate manual payment must belong to the source or target invoice.');
             }
-            if ((int)$replacement['client_id'] !== (int)$payment['client_id']
-                || (int)($replacement['organization_id'] ?? 0) !== (int)($payment['organization_id'] ?? 0)) {
+            $replacementOrganizationId = $replacement['replacement_client_organization_id'] !== null
+                ? (int)$replacement['replacement_client_organization_id']
+                : null;
+            if ((int)$replacement['replacement_invoice_client_id'] !== $sourceClientId
+                || $replacementOrganizationId !== $sourceOrganizationId) {
                 throw new RuntimeException('Each duplicate manual payment must belong to the same client and organization.');
             }
             if (strtolower((string)$replacement['status']) !== 'succeeded') {
@@ -226,11 +249,19 @@ function payment_reallocate_to_invoice(
             if (payment_is_processor_backed($replacement) || !empty($replacement['project_invoice_payment_id'])) {
                 throw new RuntimeException('Only manual cash, check, card, bank transfer, or other entries can be reversed as duplicates.');
             }
-            if ((float)$replacement['refunded_amount'] > 0.005 || (float)$replacement['disputed_amount'] > 0.005) {
-                throw new RuntimeException('A refunded or disputed manual entry cannot be reversed as a duplicate.');
+            if ((float)$replacement['disputed_amount'] > 0.005) {
+                throw new RuntimeException('A disputed manual entry cannot be reversed as a duplicate.');
             }
 
-            $applied = max(0.0, (float)$replacement['amount']);
+            // A mistaken manual refund may have already reduced this entry's
+            // applied amount to zero. It can still be reversed for audit
+            // cleanup, but only its current net application frees target room.
+            $applied = max(
+                0.0,
+                (float)$replacement['amount']
+                    - (float)$replacement['refunded_amount']
+                    - (float)$replacement['disputed_amount']
+            );
             if ($replacementInvoiceId === $targetInvoiceId) {
                 $targetReplacementApplied += $applied;
             }
@@ -263,7 +294,7 @@ function payment_reallocate_to_invoice(
             $targetInvoiceId,
             !empty($target['contract_id']) ? (int)$target['contract_id'] : null,
             (int)$target['client_id'],
-            !empty($target['organization_id']) ? (int)$target['organization_id'] : null,
+            $target['effective_organization_id'] !== null ? (int)$target['effective_organization_id'] : null,
             $clearedLocalRefund > 0.005 ? 0 : (float)$payment['refunded_amount'],
             $paymentId,
         ]);

--- a/src/views/pages/invoice/invoices-list.php
+++ b/src/views/pages/invoice/invoices-list.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/invoice_numbers.php';
 require_once __DIR__ . '/../../../utils/twig.php';
 require_once __DIR__ . '/../../../utils/acl.php';
+require_once __DIR__ . '/../../../utils/csrf.php';
 require_once __DIR__ . '/../../../config/app.php';
 $netDays = (int)($appConfig['net_terms_days'] ?? 30);
 if ($netDays < 0) $netDays = 0;
@@ -99,6 +100,12 @@ $clients = $pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archi
     <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0">Email sent.</div>
   <?php elseif (!empty($_GET['email_err'])): ?>
     <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#fff1f2;color:#881337;border:1px solid #fca5a5">Email failed: <?php echo htmlspecialchars($_GET['email_err']); ?></div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['voided'])): ?>
+    <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#f3f4f6;color:#374151;border:1px solid #d1d5db">Invoice voided. It remains available under the Void filter for audit history.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['error'])): ?>
+    <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#fff1f2;color:#881337;border:1px solid #fca5a5"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
   <?php endif; ?>
 
   <?php
@@ -225,6 +232,19 @@ $clients = $pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archi
                   <input type="hidden" name="id" value="<?php echo (int)$r['id']; ?>">
                   <button type="submit" style="padding:6px 10px;border:0;border-radius:8px;background:#d1fae5;color:#065f46; font-size: small;">Paid</button>
                 </form>
+              <?php endif; ?>
+              <?php if (in_array(strtolower((string)$r['status']), ['draft','sent','unpaid','overdue'], true)): ?>
+                <details style="display:inline-block;position:relative;vertical-align:top;margin-left:6px">
+                  <summary style="padding:6px 10px;border:1px solid #fda4af;border-radius:8px;background:#fff1f2;color:#9f1239;font-size:small;cursor:pointer;list-style:none">Void</summary>
+                  <form method="post" action="/?page=invoice/invoice-void" style="position:absolute;z-index:30;right:0;top:calc(100% + 6px);width:300px;display:grid;gap:8px;padding:12px;background:#fff;border:1px solid #fecdd3;border-radius:8px;box-shadow:0 10px 25px rgba(15,23,42,.16)" onsubmit="return confirm('Void invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?>? It will remain in audit history and cannot be paid.');">
+                    <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+                    <input type="hidden" name="id" value="<?php echo (int)$r['id']; ?>">
+                    <input type="hidden" name="redirect_to" value="<?php echo htmlspecialchars((string)($_SERVER['REQUEST_URI'] ?? '/?page=invoice/invoices-list')); ?>">
+                    <label style="font-size:12px;font-weight:600;color:#374151">Reason<textarea name="reason" maxlength="500" required rows="3" placeholder="Example: Accidental duplicate invoice" style="display:block;width:100%;box-sizing:border-box;margin-top:4px;padding:7px;border:1px solid #d1d5db;border-radius:6px;resize:vertical"></textarea></label>
+                    <div style="font-size:12px;color:#6b7280">If PA reports payment activity, correct or reverse those payment entries first.</div>
+                    <button type="submit" style="padding:7px 10px;border:1px solid #be123c;border-radius:6px;background:#be123c;color:#fff">Confirm Void Invoice</button>
+                  </form>
+                </details>
               <?php endif; ?>
             </td>
             <td style="padding:10px">

--- a/src/views/pages/payments/payment-correction.php
+++ b/src/views/pages/payments/payment-correction.php
@@ -20,10 +20,13 @@ try {
     } else {
         $stmt = $pdo->prepare('
             SELECT p.*, i.doc_number, i.invoice_type, i.status AS invoice_status,
-                   i.collection_mode, c.name AS client_name
+                   i.collection_mode,
+                   i.client_id AS source_invoice_client_id,
+                   c.organization_id AS source_client_organization_id,
+                   c.name AS client_name
             FROM payments p
             JOIN invoices i ON i.id = p.invoice_id
-            JOIN clients c ON c.id = p.client_id
+            JOIN clients c ON c.id = i.client_id
             WHERE p.id = ?
         ');
         $stmt->execute([$paymentId]);
@@ -42,31 +45,27 @@ try {
         } else {
             $targetStmt = $pdo->prepare('
                 SELECT i.id, i.doc_number, i.invoice_type, i.status, i.total, i.amount_paid, i.balance_due,
-                       i.contract_id, i.document_date
+                       i.contract_id, i.document_date, i.finalized_at
                 FROM invoices i
                 WHERE i.client_id = ?
                   AND i.id <> ?
-                  AND i.organization_id <=> ?
-                  AND i.collection_mode = "direct"
+                  AND COALESCE(i.collection_mode, "direct") = "direct"
                   AND i.status NOT IN ("draft", "void", "cancelled")
-                  AND i.finalized_at IS NOT NULL
                 ORDER BY i.id DESC
                 LIMIT 250
             ');
             $targetStmt->execute([
-                (int)$payment['client_id'],
+                (int)$payment['source_invoice_client_id'],
                 (int)$payment['invoice_id'],
-                $payment['organization_id'] !== null ? (int)$payment['organization_id'] : null,
             ]);
             $targets = $targetStmt->fetchAll(PDO::FETCH_ASSOC);
 
             $manualStmt = $pdo->prepare('
-                SELECT p.id, p.invoice_id, p.amount, p.payment_method, p.payment_date,
+                SELECT p.id, p.invoice_id, p.amount, p.refunded_amount, p.payment_method, p.payment_date,
                        i.doc_number, i.invoice_type
                 FROM payments p
                 JOIN invoices i ON i.id = p.invoice_id
-                WHERE p.client_id = ?
-                  AND p.organization_id <=> ?
+                WHERE i.client_id = ?
                   AND p.status = "succeeded"
                   AND p.payment_method <> "stripe"
                   AND p.stripe_payment_intent_id IS NULL
@@ -74,16 +73,14 @@ try {
                   AND COALESCE(p.processor_provider, "") = ""
                   AND COALESCE(p.processor_payment_id, "") = ""
                   AND p.project_invoice_payment_id IS NULL
-                  AND p.refunded_amount <= 0.005
                   AND p.disputed_amount <= 0.005
-                  AND i.collection_mode = "direct"
+                  AND COALESCE(i.collection_mode, "direct") = "direct"
                   AND i.status NOT IN ("draft", "void", "cancelled")
                 ORDER BY p.payment_date DESC, p.id DESC
                 LIMIT 250
             ');
             $manualStmt->execute([
-                (int)$payment['client_id'],
-                $payment['organization_id'] !== null ? (int)$payment['organization_id'] : null,
+                (int)$payment['source_invoice_client_id'],
             ]);
             foreach ($manualStmt->fetchAll(PDO::FETCH_ASSOC) as $candidate) {
                 $candidate['invoice_label'] = pa_invoice_label_from_row($candidate);
@@ -121,15 +118,16 @@ $hasLocalRefund = $payment && (float)$payment['refunded_amount'] > 0.005;
       <strong>No money moves in this workflow.</strong> PA keeps the existing Stripe transaction and processor IDs. The invoice receives the gross client payment; Stripe fees remain separately reported as processing expense and net received.
     </div>
 
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px;margin-bottom:18px">
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(145px,1fr));gap:12px;margin-bottom:18px">
       <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Payment</div><div style="font-size:20px;font-weight:700">#<?php echo (int)$payment['id']; ?> &middot; $<?php echo number_format((float)$payment['amount'], 2); ?></div></div>
       <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Currently applied to</div><div style="font-size:20px;font-weight:700"><?php echo htmlspecialchars(pa_invoice_label_from_row($payment)); ?></div></div>
+      <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Client</div><div style="font-size:18px;font-weight:700"><?php echo htmlspecialchars((string)$payment['client_name']); ?></div></div>
       <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Processor fee</div><div style="font-size:20px;font-weight:700">$<?php echo number_format($processorFee, 2); ?></div></div>
       <div style="padding:14px;border:1px solid #e5e7eb;border-radius:10px;background:#fff"><div style="font-size:12px;color:var(--muted);text-transform:uppercase">Current net received</div><div style="font-size:20px;font-weight:700">$<?php echo number_format($netReceived, 2); ?></div></div>
     </div>
 
     <?php if (!$targets): ?>
-      <div style="padding:12px;border-radius:8px;background:#fffbeb;color:#92400e;border:1px solid #fde68a">No other finalized direct invoices are available for this client.</div>
+      <div style="padding:12px;border-radius:8px;background:#fffbeb;color:#92400e;border:1px solid #fde68a">No other eligible invoice is available for <?php echo htmlspecialchars((string)$payment['client_name']); ?>. Corrections cannot cross clients or organizations.</div>
     <?php else: ?>
       <form method="post" action="/?page=payments/payment-correct" style="display:grid;gap:16px;padding:18px;border:1px solid #e5e7eb;border-radius:10px;background:#fff" onsubmit="return confirm('Correct this payment allocation? No Stripe refund or new charge will be created.');">
         <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
@@ -148,7 +146,7 @@ $hasLocalRefund = $payment && (float)$payment['refunded_amount'] > 0.005;
             <option value="">Select the correct invoice</option>
             <?php foreach ($targets as $target): ?>
               <option value="<?php echo (int)$target['id']; ?>">
-                <?php echo htmlspecialchars(pa_invoice_label_from_row($target)); ?> &middot; <?php echo htmlspecialchars(ucfirst((string)$target['status'])); ?> &middot; $<?php echo number_format((float)$target['total'], 2); ?> total &middot; $<?php echo number_format((float)$target['balance_due'], 2); ?> due
+                <?php echo htmlspecialchars(pa_invoice_label_from_row($target)); ?> &middot; <?php echo htmlspecialchars(ucfirst((string)$target['status'])); ?> &middot; $<?php echo number_format((float)$target['total'], 2); ?> total &middot; $<?php echo number_format((float)$target['balance_due'], 2); ?> due<?php echo empty($target['finalized_at']) ? ' &middot; Legacy record' : ''; ?>
               </option>
             <?php endforeach; ?>
           </select>
@@ -157,7 +155,7 @@ $hasLocalRefund = $payment && (float)$payment['refunded_amount'] > 0.005;
         <div>
           <div style="font-weight:600;margin-bottom:6px">Duplicate manual payments to reverse</div>
           <div id="correctionDuplicatePayments" style="display:grid;gap:8px;padding:10px;border:1px solid #e5e7eb;border-radius:8px;background:#f9fafb"></div>
-          <div style="font-size:13px;color:var(--muted);margin-top:5px">Select every duplicate cash/manual entry on both the accidental source invoice and the correct target invoice. They remain in the audit trail as reversed and are hidden from the normal payment list.</div>
+          <div style="font-size:13px;color:var(--muted);margin-top:5px">Select every duplicate cash/manual entry on both invoices, including entries that were mistakenly recorded as refunded. They remain in the audit trail as reversed and are hidden from the normal payment list.</div>
         </div>
 
         <label>
@@ -209,7 +207,10 @@ $hasLocalRefund = $payment && (float)$payment['refunded_amount'] > 0.005;
       checkbox.style.marginTop = '3px';
       var text = document.createElement('span');
       var location = Number(item.invoice_id) === sourceInvoiceId ? 'Source' : 'Target';
-      text.textContent = location + ' ' + item.invoice_label + ' - Payment #' + item.id + ' - $' + Number(item.amount).toFixed(2) + ' - ' + String(item.payment_method).replaceAll('_', ' ') + ' - ' + item.payment_date;
+      var refundNote = Number(item.refunded_amount || 0) > 0
+        ? ' - $' + Number(item.refunded_amount).toFixed(2) + ' locally recorded as refunded'
+        : '';
+      text.textContent = location + ' ' + item.invoice_label + ' - Payment #' + item.id + ' - $' + Number(item.amount).toFixed(2) + refundNote + ' - ' + String(item.payment_method).replaceAll('_', ' ') + ' - ' + item.payment_date;
       label.appendChild(checkbox);
       label.appendChild(text);
       container.appendChild(label);

--- a/src/views/pages/payments/payments-list.php
+++ b/src/views/pages/payments/payments-list.php
@@ -38,7 +38,15 @@ $sql = 'SELECT p.id, p.amount, p.refunded_amount, p.disputed_amount, p.status, p
                p.processor_payment_id, p.stripe_payment_intent_id, p.stripe_session_id, p.project_invoice_payment_id,
                p.reversed_at, p.reversal_reason,
                p.processor_fee_policy, p.processor_fee_source, i.id AS invoice_id, i.doc_number, i.invoice_type, i.collection_mode,
-               c.name AS client, ppt.payer_name, ppt.payer_email
+               c.name AS client, ppt.payer_name, ppt.payer_email,
+               EXISTS (
+                   SELECT 1
+                   FROM invoices correction_target
+                   WHERE correction_target.client_id = i.client_id
+                     AND correction_target.id <> i.id
+                     AND COALESCE(correction_target.collection_mode, "direct") = "direct"
+                     AND correction_target.status NOT IN ("draft", "void", "cancelled")
+               ) AS has_correction_target
         ' . $fromSql;
 if($where){$sql.=' WHERE '.implode(' AND ',$where);} $sql.=" ORDER BY p.payment_date DESC, p.created_at DESC LIMIT $per OFFSET $offset";
 $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FETCH_ASSOC);
@@ -137,6 +145,7 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
           $canCorrect = $isSucceeded
             && !empty($r['invoice_id'])
             && (string)($r['collection_mode'] ?? 'direct') === 'direct'
+            && !empty($r['has_correction_target'])
             && empty($r['project_invoice_payment_id'])
             && ($refunded <= 0.005 || $isProcessorBacked)
             && $disputed <= 0.005;
@@ -165,6 +174,8 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
               <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;min-width:190px">
               <?php if ($canCorrect): ?>
                 <a href="/?page=payments/payment-correction&payment_id=<?php echo (int)$r['id']; ?>" style="padding:6px 9px;border-radius:6px;border:1px solid #bfdbfe;background:#eff6ff;color:#1d4ed8;white-space:nowrap">Correct allocation</a>
+              <?php elseif ($isSucceeded && !empty($r['invoice_id']) && (string)($r['collection_mode'] ?? 'direct') === 'direct' && empty($r['project_invoice_payment_id']) && empty($r['has_correction_target'])): ?>
+                <span title="Allocation corrections can only move a payment to another invoice for the same client." style="color:var(--muted);font-size:12px">No other invoice for this client</span>
               <?php endif; ?>
               <?php if ($canRecordRefund): ?>
                 <form method="post" action="/?page=payments/payment-refund" style="display:flex;gap:6px;align-items:center" onsubmit="return confirm('Record this refund only after money has been returned to the client outside Project Alpha. Continue?');">

--- a/tests/Payments/PaymentIntegrityTest.php
+++ b/tests/Payments/PaymentIntegrityTest.php
@@ -265,6 +265,18 @@ final class PaymentIntegrityTest extends TestCase
         ]);
         $targetCashId = $this->remember('payments', (int)$targetCash['payment_id']);
 
+        // Match the reported legacy state: the imported Stripe row and source
+        // invoice lost denormalized organization values, both cash duplicates
+        // were mistakenly recorded as fully refunded, and the recurring
+        // invoice predates the finalized_at metadata convention.
+        $this->pdo->prepare('UPDATE payments SET organization_id=NULL WHERE id=?')->execute([$stripePaymentId]);
+        $this->pdo->prepare('UPDATE invoices SET organization_id=NULL WHERE id=?')->execute([$sourceInvoiceId]);
+        $this->pdo->prepare('UPDATE payments SET refunded_amount=amount WHERE id IN (?,?)')
+            ->execute([$sourceCashId, $targetCashId]);
+        invoice_refresh_payment_totals($this->pdo, $sourceInvoiceId);
+        invoice_refresh_payment_totals($this->pdo, $targetInvoiceId);
+        $this->pdo->prepare('UPDATE invoices SET finalized_at=NULL WHERE id=?')->execute([$targetInvoiceId]);
+
         $result = payment_reallocate_to_invoice(
             $this->pdo,
             $stripePaymentId,
@@ -288,17 +300,23 @@ final class PaymentIntegrityTest extends TestCase
         $moved = $moved->fetch(PDO::FETCH_ASSOC) ?: [];
         self::assertSame($targetInvoiceId, (int)$moved['invoice_id']);
         self::assertSame($contractId, (int)$moved['contract_id']);
+        self::assertSame($orgId, (int)$moved['organization_id']);
         self::assertSame('stripe', $moved['payment_method']);
         self::assertEqualsWithDelta(300.0, (float)$moved['amount'], 0.005, 'The invoice receives the gross client payment.');
         self::assertEqualsWithDelta(0.0, (float)$moved['refunded_amount'], 0.005);
         self::assertEqualsWithDelta(9.0, (float)$moved['processor_fee_amount'], 0.005);
         self::assertEqualsWithDelta(291.0, payment_accounting_net_income($moved), 0.005, 'Stripe net income remains gross less the processor fee.');
 
-        $manualRows = $this->pdo->prepare('SELECT id,status,refunded_amount FROM payments WHERE id IN (?,?) ORDER BY id');
+        $manualRows = $this->pdo->prepare('SELECT id,status,amount,refunded_amount FROM payments WHERE id IN (?,?) ORDER BY id');
         $manualRows->execute([$sourceCashId, $targetCashId]);
         foreach ($manualRows->fetchAll(PDO::FETCH_ASSOC) as $manual) {
             self::assertSame('reversed', $manual['status']);
-            self::assertEqualsWithDelta(0.0, (float)$manual['refunded_amount'], 0.005, 'Duplicate entries are reversed, not refunded.');
+            self::assertEqualsWithDelta(
+                (float)$manual['amount'],
+                (float)$manual['refunded_amount'],
+                0.005,
+                'The mistaken local refund remains visible only in the reversed audit row.'
+            );
         }
 
         $source = $this->pdo->prepare('SELECT status,amount_paid,balance_due FROM invoices WHERE id=?');
@@ -379,6 +397,15 @@ final class PaymentIntegrityTest extends TestCase
         self::assertStringContainsString('No accounting data was changed', $view);
         self::assertStringContainsString('replacement_payment_ids[]', $view);
         self::assertStringContainsString('clear_local_refund', $view);
+        self::assertStringContainsString('c.organization_id AS source_client_organization_id', $view);
+        self::assertStringNotContainsString('i.organization_id <=> ?', $view);
+        self::assertStringNotContainsString('AND i.finalized_at IS NOT NULL', $view);
+        self::assertStringNotContainsString('AND p.refunded_amount <= 0.005', $view);
+        self::assertStringContainsString('locally recorded as refunded', $view);
+
+        $paymentsList = (string)file_get_contents(dirname(__DIR__, 2) . '/src/views/pages/payments/payments-list.php');
+        self::assertStringContainsString('AS has_correction_target', $paymentsList);
+        self::assertStringContainsString('No other invoice for this client', $paymentsList);
     }
 
     public function testLongTermSequenceDoesNotAdvanceRegularInvoiceSequence(): void

--- a/tests/Workflows/InvoiceVoidWorkflowTest.php
+++ b/tests/Workflows/InvoiceVoidWorkflowTest.php
@@ -37,6 +37,8 @@ final class InvoiceVoidWorkflowTest extends TestCase
         $migration = (string)file_get_contents($this->root . '/database/migrations/0030_invoice_void_workflow.sql');
         $lifecycle = (string)file_get_contents($this->root . '/src/utils/invoice_lifecycle.php');
         $details = (string)file_get_contents($this->root . '/src/views/pages/invoice/invoice-details.php');
+        $list = (string)file_get_contents($this->root . '/src/views/pages/invoice/invoices-list.php');
+        $controller = (string)file_get_contents($this->root . '/src/controllers/invoice/invoice_void.php');
 
         foreach (['voided_at', 'voided_by', 'void_reason', 'void_previous_status'] as $column) {
             self::assertStringContainsString($column, $baseline);
@@ -52,6 +54,10 @@ final class InvoiceVoidWorkflowTest extends TestCase
         self::assertStringContainsString('Reason for voiding', $details);
         self::assertStringContainsString('View PDF', $details);
         self::assertStringContainsString('Void reason', $details);
+        self::assertStringContainsString('Confirm Void Invoice', $list);
+        self::assertStringContainsString('name="redirect_to"', $list);
+        self::assertStringContainsString("!str_starts_with(\$redirectTo, '//')", $controller);
+        self::assertStringContainsString("\$appendResult(\$redirectBase, 'voided', '1')", $controller);
     }
 
     public function testRecurringHistoryActionPreservesEveryFilterAndScrollsToResults(): void


### PR DESCRIPTION
## What changed

- Make payment-allocation recovery use the authoritative invoice/client relationship instead of stale legacy payment and invoice organization copies.
- Allow legitimate non-draft legacy recurring invoices without newer `finalized_at` metadata to appear as correction targets.
- Show fully locally-refunded manual cash entries as duplicate entries that can be reversed during one atomic correction.
- Hide the correction action when a payment truly has no other same-client invoice and show a clear explanation.
- Add a direct, reason-required Void action to the regular invoice list with safe return navigation and visible success/error messages.

## Root cause

The correction selector required both modern finalization metadata and exact matches across denormalized organization columns. Older I-2/LTI-1 records can have missing or inconsistent copies even though both invoices belong to the same client. The duplicate selector also rejected any manual entry with a local refund value, so the mistakenly refunded cash entries could not be cleaned up.

## Impact

Renee's real Stripe payment can select LTI-1, recover the incorrect local-only refund after live Stripe verification, reverse both refunded cash duplicates, and void I-2 in one audited workflow. Regular invoices also expose a direct Void control in the list UI.

## Validation

- Focused payment/void suites: 18 tests, 176 assertions
- Full suite: 136 tests, 1551 assertions, 1 intentional skip
- PHP lint passed for all changed PHP files
- `git diff --check` passed
- Local Docker application image rebuilt successfully
