### PR TITLE
Allow voiding zero-balance invoices

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1119,6 +1119,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         require_once __DIR__ . '/../src/controllers/payments_refund.php';
         exit;
     }
+    if ($page === 'payments/payment-reverse') {
+        require_once __DIR__ . '/../src/controllers/payments_reverse.php';
+        exit;
+    }
     if ($page === 'payments/payment-correct') {
         require_once __DIR__ . '/../src/controllers/payments_correct.php';
         exit;

--- a/src/controllers/payments_reverse.php
+++ b/src/controllers/payments_reverse.php
@@ -1,0 +1,29 @@
+<?php
+
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../utils/acl.php';
+require_once __DIR__ . '/../utils/audit.php';
+require_once __DIR__ . '/../utils/csrf.php';
+require_once __DIR__ . '/../utils/payment_corrections.php';
+
+csrf_verify_post_or_redirect('payments-list');
+
+$paymentId = (int)($_POST['payment_id'] ?? 0);
+$reason = trim((string)($_POST['reason'] ?? ''));
+$userId = (int)($_SESSION['user']['id'] ?? 0) ?: null;
+
+try {
+    require_record_ownership($pdo, 'payments', $paymentId);
+    $result = payment_reverse_manual_entry($pdo, $paymentId, $reason, $userId);
+    audit_log($pdo, 'payment.manual_entry_reversed', 'payment', $paymentId, [
+        'invoice_id' => $result['invoice_id'],
+        'invoice_status' => $result['invoice_status'],
+        'preserved_local_refund_amount' => $result['refunded_amount'],
+        'reason' => $reason,
+        'processor_action' => 'none',
+    ], $userId);
+    header('Location: /?page=payments-list&manual_reversed=1');
+} catch (Throwable $e) {
+    header('Location: /?page=payments-list&error=' . urlencode($e->getMessage()));
+}
+exit;

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -156,6 +156,7 @@ function page_permission_map(): array
         'payments-list'             => 'payments.view',
         'payments/payments-create'  => 'invoices.mark_paid',
         'payments/payment-refund'   => 'invoices.mark_paid',
+        'payments/payment-reverse'  => 'invoices.mark_paid',
         'payments/payment-correction' => 'invoices.mark_paid',
         'payments/payment-correct'  => 'invoices.mark_paid',
 

--- a/src/utils/audit_middleware.php
+++ b/src/utils/audit_middleware.php
@@ -62,6 +62,7 @@ function audit_sensitive_map(): array
             'stripe-webhook-legacy'          => ['payment.stripe_webhook', 'payment'],
             'payments-create'                => ['payment.create', 'payment'],
             'payments/payment-refund'        => ['payment.refund', 'payment'],
+            'payments/payment-reverse'       => ['payment.manual_entry_reversed', 'payment'],
             'payments/payment-correct'       => ['payment.allocation_corrected', 'payment'],
             'invoice/invoices-mark-paid'     => ['invoice.mark_paid', 'invoice'],
             'invoices-mark-paid'             => ['invoice.mark_paid', 'invoice'],

--- a/src/utils/invoice_lifecycle.php
+++ b/src/utils/invoice_lifecycle.php
@@ -171,10 +171,26 @@ function invoice_status_for_balance(float $total, float $paid): array
 
 function invoice_refresh_payment_totals(PDO $pdo, int $invoiceId, bool $revokePaidPublicLinks = true): array
 {
-    $totalStmt = $pdo->prepare('SELECT total FROM invoices WHERE id = ?');
+    $totalStmt = $pdo->prepare('SELECT total,status FROM invoices WHERE id = ?');
     $totalStmt->execute([$invoiceId]);
-    $total = (float)$totalStmt->fetchColumn();
+    $invoice = $totalStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    $total = (float)($invoice['total'] ?? 0);
     $paid = invoice_effective_paid_total($pdo, $invoiceId);
+
+    // Payment audit cleanup must never resurrect a void invoice. Void records
+    // intentionally have no collectible balance, even when their historical
+    // payment rows are later reversed or reconciled.
+    if (strtolower((string)($invoice['status'] ?? '')) === 'void') {
+        $pdo->prepare('UPDATE invoices SET amount_paid=?,balance_due=0,paid_at=NULL WHERE id=?')
+            ->execute([max(0.0, $paid), $invoiceId]);
+        return [
+            'status' => 'void',
+            'amount_paid' => max(0.0, $paid),
+            'balance_due' => 0.0,
+            'total' => $total,
+        ];
+    }
+
     [$status, $storedPaid, $balanceDue] = invoice_status_for_balance($total, $paid);
 
     $paidAtSql = $status === 'paid'
@@ -576,10 +592,24 @@ function invoice_void(PDO $pdo, int $invoiceId, array $appConfig, string $reason
             throw new RuntimeException('This invoice is already included in project invoice PI-' . $parentNumber . ' and cannot be voided individually.');
         }
 
-        $payment = $pdo->prepare('SELECT COUNT(*) FROM payments WHERE invoice_id=? AND status IN ("succeeded","pending")');
+        $payment = $pdo->prepare('
+            SELECT COUNT(*)
+            FROM payments
+            WHERE invoice_id=?
+              AND (
+                  status="pending"
+                  OR (
+                      status="succeeded"
+                      AND GREATEST(
+                          COALESCE(amount,0)-COALESCE(refunded_amount,0)-COALESCE(disputed_amount,0),
+                          0
+                      ) > 0.005
+                  )
+              )
+        ');
         $payment->execute([$invoiceId]);
         if ((int)$payment->fetchColumn() > 0) {
-            throw new RuntimeException('This invoice has payment activity and cannot be voided. Refund or resolve the payment first.');
+            throw new RuntimeException('This invoice still has a pending or active payment balance. Refund, reverse, or reallocate it before voiding.');
         }
 
         $intent = $pdo->prepare('SELECT COUNT(*) FROM payment_intents WHERE invoice_id=? AND status IN ("pending","processing","requires_action")');

--- a/src/utils/payment_corrections.php
+++ b/src/utils/payment_corrections.php
@@ -59,6 +59,83 @@ function payment_verify_stripe_refunded_amount(array $payment, array $appConfig)
 }
 
 /**
+ * Reverse a duplicate or mistaken manual payment entry without moving money.
+ * Processor-backed payments must use allocation correction or a real refund.
+ *
+ * @return array{payment_id:int,invoice_id:int,invoice_status:string,refunded_amount:float}
+ */
+function payment_reverse_manual_entry(
+    PDO $pdo,
+    int $paymentId,
+    string $reason,
+    ?int $userId = null
+): array {
+    if ($paymentId <= 0) {
+        throw new RuntimeException('Select a manual payment entry to reverse.');
+    }
+
+    $reason = trim(preg_replace('/\s+/', ' ', $reason) ?? '');
+    if ($reason === '') {
+        throw new RuntimeException('A reversal reason is required.');
+    }
+    if (mb_strlen($reason) > 500) {
+        throw new RuntimeException('The reversal reason must be 500 characters or fewer.');
+    }
+
+    invoice_ensure_payments_schema($pdo);
+    $ownsTransaction = !$pdo->inTransaction();
+    if ($ownsTransaction) {
+        $pdo->beginTransaction();
+    }
+
+    try {
+        $stmt = $pdo->prepare('SELECT * FROM payments WHERE id=? FOR UPDATE');
+        $stmt->execute([$paymentId]);
+        $payment = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        if (!$payment) {
+            throw new RuntimeException('Payment entry not found.');
+        }
+        if (strtolower((string)$payment['status']) !== 'succeeded') {
+            throw new RuntimeException('Only an active successful manual entry can be reversed.');
+        }
+        if (payment_is_processor_backed($payment) || !empty($payment['project_invoice_payment_id'])) {
+            throw new RuntimeException('Processor and project payments cannot be reversed as manual entries.');
+        }
+        if ((float)$payment['disputed_amount'] > 0.005) {
+            throw new RuntimeException('A disputed payment entry cannot be manually reversed.');
+        }
+
+        $invoiceId = (int)($payment['invoice_id'] ?? 0);
+        if ($invoiceId <= 0) {
+            throw new RuntimeException('This manual payment is not linked to an invoice.');
+        }
+
+        $pdo->prepare('
+            UPDATE payments
+            SET status="reversed", reversed_at=NOW(), reversed_by=?, reversal_reason=?
+            WHERE id=?
+        ')->execute([$userId, $reason, $paymentId]);
+        $invoiceTotals = invoice_refresh_payment_totals($pdo, $invoiceId);
+
+        if ($ownsTransaction) {
+            $pdo->commit();
+        }
+
+        return [
+            'payment_id' => $paymentId,
+            'invoice_id' => $invoiceId,
+            'invoice_status' => (string)$invoiceTotals['status'],
+            'refunded_amount' => (float)$payment['refunded_amount'],
+        ];
+    } catch (Throwable $e) {
+        if ($ownsTransaction && $pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        throw $e;
+    }
+}
+
+/**
  * Move a real payment to the invoice it should have paid, reverse selected
  * duplicate manual entries, and optionally void the accidental source invoice.
  *

--- a/src/views/pages/invoice/invoices-list.php
+++ b/src/views/pages/invoice/invoices-list.php
@@ -95,6 +95,7 @@ $hasArchived = (bool)$pdo->query("SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE
 $clients = $pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archived=0 ':'').'ORDER BY name')->fetchAll();
 ?>
 <section>
+  <style>.invoice-void-dialog::backdrop{background:rgba(15,23,42,.48)}</style>
   <h2>Invoices</h2>
   <?php if (!empty($_GET['emailed'])): ?>
     <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0">Email sent.</div>
@@ -234,17 +235,19 @@ $clients = $pdo->query('SELECT id,name FROM clients '.($hasArchived?'WHERE archi
                 </form>
               <?php endif; ?>
               <?php if (in_array(strtolower((string)$r['status']), ['draft','sent','unpaid','overdue'], true)): ?>
-                <details style="display:inline-block;position:relative;vertical-align:top;margin-left:6px">
-                  <summary style="padding:6px 10px;border:1px solid #fda4af;border-radius:8px;background:#fff1f2;color:#9f1239;font-size:small;cursor:pointer;list-style:none">Void</summary>
-                  <form method="post" action="/?page=invoice/invoice-void" style="position:absolute;z-index:30;right:0;top:calc(100% + 6px);width:300px;display:grid;gap:8px;padding:12px;background:#fff;border:1px solid #fecdd3;border-radius:8px;box-shadow:0 10px 25px rgba(15,23,42,.16)" onsubmit="return confirm('Void invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?>? It will remain in audit history and cannot be paid.');">
+                <?php $voidDialogId = 'voidInvoiceDialog' . (int)$r['id']; ?>
+                <button type="button" onclick="document.getElementById('<?php echo $voidDialogId; ?>').showModal()" style="padding:6px 10px;border:1px solid #fda4af;border-radius:8px;background:#fff1f2;color:#9f1239;font-size:small;cursor:pointer;margin-left:6px">Void</button>
+                <dialog id="<?php echo $voidDialogId; ?>" class="invoice-void-dialog" style="width:min(420px,calc(100vw - 32px));box-sizing:border-box;padding:0;border:1px solid #fecdd3;border-radius:12px;box-shadow:0 24px 60px rgba(15,23,42,.28)">
+                  <form method="post" action="/?page=invoice/invoice-void" style="display:grid;gap:12px;padding:18px;margin:0" onsubmit="return confirm('Void invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?>? It will remain in audit history and cannot be paid.');">
                     <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
                     <input type="hidden" name="id" value="<?php echo (int)$r['id']; ?>">
                     <input type="hidden" name="redirect_to" value="<?php echo htmlspecialchars((string)($_SERVER['REQUEST_URI'] ?? '/?page=invoice/invoices-list')); ?>">
-                    <label style="font-size:12px;font-weight:600;color:#374151">Reason<textarea name="reason" maxlength="500" required rows="3" placeholder="Example: Accidental duplicate invoice" style="display:block;width:100%;box-sizing:border-box;margin-top:4px;padding:7px;border:1px solid #d1d5db;border-radius:6px;resize:vertical"></textarea></label>
-                    <div style="font-size:12px;color:#6b7280">If PA reports payment activity, correct or reverse those payment entries first.</div>
-                    <button type="submit" style="padding:7px 10px;border:1px solid #be123c;border-radius:6px;background:#be123c;color:#fff">Confirm Void Invoice</button>
+                    <div><div style="font-size:18px;font-weight:700;color:#111827">Void invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?></div><div style="margin-top:4px;font-size:13px;color:#6b7280">The invoice stays in audit history and all payment links are revoked.</div></div>
+                    <label style="font-size:13px;font-weight:600;color:#374151">Reason<textarea name="reason" maxlength="500" required rows="4" placeholder="Example: Accidental duplicate invoice" style="display:block;width:100%;box-sizing:border-box;margin-top:5px;padding:9px;border:1px solid #d1d5db;border-radius:7px;resize:vertical"></textarea></label>
+                    <div style="font-size:12px;color:#6b7280">Pending or economically active payments must be resolved first. Fully refunded zero-balance history will not block voiding.</div>
+                    <div style="display:flex;justify-content:flex-end;gap:8px"><button type="button" onclick="document.getElementById('<?php echo $voidDialogId; ?>').close()" style="padding:8px 11px;border:1px solid #d1d5db;border-radius:7px;background:#fff">Cancel</button><button type="submit" style="padding:8px 11px;border:1px solid #be123c;border-radius:7px;background:#be123c;color:#fff">Confirm Void Invoice</button></div>
                   </form>
-                </details>
+                </dialog>
               <?php endif; ?>
             </td>
             <td style="padding:10px">

--- a/src/views/pages/payments/payments-list.php
+++ b/src/views/pages/payments/payments-list.php
@@ -52,6 +52,7 @@ if($where){$sql.=' WHERE '.implode(' AND ',$where);} $sql.=" ORDER BY p.payment_
 $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <section>
+  <style>.payment-reverse-dialog::backdrop{background:rgba(15,23,42,.48)}</style>
   <div style="display:flex;justify-content:space-between;gap:12px;align-items:center;flex-wrap:wrap">
     <h2 style="margin:0">Payments</h2>
     <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
@@ -67,6 +68,9 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
   <?php endif; ?>
   <?php if (!empty($_GET['stripe_refunded'])): ?>
     <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0">Stripe accepted the refund. PA has recorded the Stripe refund and will continue reconciling webhook updates.</div>
+  <?php endif; ?>
+  <?php if (!empty($_GET['manual_reversed'])): ?>
+    <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0">Manual payment entry reversed. It no longer affects invoice totals and is hidden from the normal payment list.</div>
   <?php endif; ?>
   <?php if ($showReversed): ?>
     <div style="margin:10px 0;padding:10px 12px;border-radius:8px;background:#f3f4f6;color:#374151;border:1px solid #d1d5db">Showing reversed accounting corrections. These entries remain for audit history but do not count as income or invoice payments.</div>
@@ -138,6 +142,11 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
             || trim((string)($r['stripe_payment_intent_id'] ?? '')) !== ''
             || trim((string)($r['stripe_session_id'] ?? '')) !== '';
           $canRecordRefund = $isSucceeded && !$isProcessorBacked && $appliedNet > 0.005;
+          $canReverseManual = $isSucceeded
+            && !$isProcessorBacked
+            && !empty($r['invoice_id'])
+            && empty($r['project_invoice_payment_id'])
+            && $disputed <= 0.005;
           $processorGross = $r['processor_gross_amount'] !== null
             ? (float)$r['processor_gross_amount']
             : $amount + max(0.0, (float)$r['surcharge_paid']);
@@ -185,6 +194,21 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
                   <button type="submit" style="padding:6px 9px;border-radius:6px;border:1px solid #fecaca;background:#fff1f2;color:#991b1b;white-space:nowrap">Record refund</button>
                 </form>
               <?php endif; ?>
+              <?php if ($canReverseManual): ?>
+                <?php $reverseDialogId = 'reversePaymentDialog' . (int)$r['id']; ?>
+                <button type="button" onclick="document.getElementById('<?php echo $reverseDialogId; ?>').showModal()" style="padding:6px 9px;border-radius:6px;border:1px solid #fbbf24;background:#fffbeb;color:#92400e;white-space:nowrap">Reverse entry</button>
+                <dialog id="<?php echo $reverseDialogId; ?>" class="payment-reverse-dialog" style="width:min(440px,calc(100vw - 32px));box-sizing:border-box;padding:0;border:1px solid #fcd34d;border-radius:12px;box-shadow:0 24px 60px rgba(15,23,42,.28)">
+                  <form method="post" action="/?page=payments/payment-reverse" style="display:grid;gap:12px;padding:18px;margin:0" onsubmit="return confirm('Reverse this manual accounting entry? No money will move.');">
+                    <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token()); ?>">
+                    <input type="hidden" name="payment_id" value="<?php echo (int)$r['id']; ?>">
+                    <div><div style="font-size:18px;font-weight:700;color:#111827">Reverse manual payment #<?php echo (int)$r['id']; ?></div><div style="margin-top:4px;font-size:13px;color:#6b7280">Invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($r)); ?> &middot; $<?php echo number_format($amount, 2); ?> &middot; <?php echo htmlspecialchars(ucwords(str_replace('_', ' ', (string)$r['payment_method']))); ?></div></div>
+                    <?php if ($refunded > 0.005): ?><div style="padding:9px;border:1px solid #fde68a;border-radius:7px;background:#fffbeb;color:#92400e;font-size:13px">This row has $<?php echo number_format($refunded, 2); ?> recorded as refunded. Reversing it preserves that history but removes the mistaken entry from active payment reporting.</div><?php endif; ?>
+                    <label style="font-size:13px;font-weight:600;color:#374151">Reason<textarea name="reason" maxlength="500" required rows="4" placeholder="Example: Duplicate manual entry created during payment correction" style="display:block;width:100%;box-sizing:border-box;margin-top:5px;padding:9px;border:1px solid #d1d5db;border-radius:7px;resize:vertical"></textarea></label>
+                    <div style="font-size:12px;color:#6b7280"><strong>No money moves.</strong> Use a refund instead if an actual client payment still needs to be returned.</div>
+                    <div style="display:flex;justify-content:flex-end;gap:8px"><button type="button" onclick="document.getElementById('<?php echo $reverseDialogId; ?>').close()" style="padding:8px 11px;border:1px solid #d1d5db;border-radius:7px;background:#fff">Cancel</button><button type="submit" style="padding:8px 11px;border:1px solid #b45309;border-radius:7px;background:#b45309;color:#fff">Confirm Reverse Entry</button></div>
+                  </form>
+                </dialog>
+              <?php endif; ?>
               <?php if ($isProcessorBacked && $isSucceeded && $processorRefundRemaining > 0.005): ?>
                 <details style="position:relative">
                   <summary style="padding:6px 9px;border-radius:6px;border:1px solid #fecaca;background:#fff1f2;color:#991b1b;cursor:pointer;white-space:nowrap;list-style:none">Refund via Stripe</summary>
@@ -199,7 +223,7 @@ $rows = $pdo->prepare($sql); $rows->execute($p); $rows = $rows->fetchAll(PDO::FE
                     <button type="submit" style="padding:7px 9px;border:1px solid #be123c;border-radius:6px;background:#be123c;color:#fff">Send Stripe refund</button>
                   </form>
                 </details>
-              <?php elseif (!$canCorrect && !$canRecordRefund): ?>
+              <?php elseif (!$canCorrect && !$canRecordRefund && !$canReverseManual): ?>
                 <span style="color:var(--muted);font-size:13px">-</span>
               <?php endif; ?>
               </div>

--- a/tests/Payments/PaymentIntegrityTest.php
+++ b/tests/Payments/PaymentIntegrityTest.php
@@ -530,6 +530,100 @@ final class PaymentIntegrityTest extends TestCase
         self::assertStringContainsString('sends real money back', $paymentsList);
     }
 
+    public function testFullyRefundedZeroBalancePaymentHistoryDoesNotBlockInvoiceVoid(): void
+    {
+        $orgId = $this->insertOrganization();
+        $clientId = $this->insertClient($orgId);
+        $invoiceId = $this->insertInvoice($orgId, $clientId, 291.00);
+        $payment = invoice_record_locked_payment($this->pdo, $invoiceId, 291.00, 'cash', null, null, [
+            'organization_id' => $orgId,
+        ]);
+        $paymentId = $this->remember('payments', (int)$payment['payment_id']);
+        $this->pdo->prepare('UPDATE payments SET refunded_amount=amount WHERE id=?')->execute([$paymentId]);
+        invoice_refresh_payment_totals($this->pdo, $invoiceId);
+
+        $result = invoice_void($this->pdo, $invoiceId, [], 'Duplicate one-off invoice with fully refunded history.');
+        self::assertSame('unpaid', $result['previous_status']);
+
+        $invoice = $this->pdo->prepare('SELECT status,amount_paid,balance_due FROM invoices WHERE id=?');
+        $invoice->execute([$invoiceId]);
+        $invoice = $invoice->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('void', (string)$invoice['status']);
+        self::assertEqualsWithDelta(0.0, (float)$invoice['amount_paid'], 0.005);
+        self::assertEqualsWithDelta(0.0, (float)$invoice['balance_due'], 0.005);
+
+        $history = $this->pdo->prepare('SELECT status,amount,refunded_amount FROM payments WHERE id=?');
+        $history->execute([$paymentId]);
+        $history = $history->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('succeeded', (string)$history['status']);
+        self::assertEqualsWithDelta(291.0, (float)$history['amount'], 0.005);
+        self::assertEqualsWithDelta(291.0, (float)$history['refunded_amount'], 0.005);
+
+        $reversed = payment_reverse_manual_entry(
+            $this->pdo,
+            $paymentId,
+            'Hide the duplicate zero-balance entry after voiding.',
+            42
+        );
+        self::assertSame('void', $reversed['invoice_status']);
+        $status = $this->pdo->prepare('SELECT status,balance_due FROM invoices WHERE id=?');
+        $status->execute([$invoiceId]);
+        $status = $status->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('void', (string)$status['status']);
+        self::assertEqualsWithDelta(0.0, (float)$status['balance_due'], 0.005);
+    }
+
+    public function testMistakenRefundedManualEntryCanBeReversedWithoutMovingMoney(): void
+    {
+        $orgId = $this->insertOrganization();
+        $clientId = $this->insertClient($orgId);
+        $invoiceId = $this->insertInvoice($orgId, $clientId, 300.00);
+        $payment = invoice_record_locked_payment($this->pdo, $invoiceId, 300.00, 'cash', null, null, [
+            'organization_id' => $orgId,
+        ]);
+        $paymentId = $this->remember('payments', (int)$payment['payment_id']);
+        $this->pdo->prepare('UPDATE payments SET refunded_amount=amount WHERE id=?')->execute([$paymentId]);
+        invoice_refresh_payment_totals($this->pdo, $invoiceId);
+
+        $result = payment_reverse_manual_entry(
+            $this->pdo,
+            $paymentId,
+            ' Duplicate manual entry created while correcting allocation. ',
+            42
+        );
+        self::assertSame($invoiceId, $result['invoice_id']);
+        self::assertSame('unpaid', $result['invoice_status']);
+        self::assertEqualsWithDelta(300.0, $result['refunded_amount'], 0.005);
+
+        $reversed = $this->pdo->prepare('SELECT status,reversed_at,reversed_by,reversal_reason,refunded_amount FROM payments WHERE id=?');
+        $reversed->execute([$paymentId]);
+        $reversed = $reversed->fetch(PDO::FETCH_ASSOC) ?: [];
+        self::assertSame('reversed', (string)$reversed['status']);
+        self::assertNotEmpty($reversed['reversed_at']);
+        self::assertSame(42, (int)$reversed['reversed_by']);
+        self::assertSame('Duplicate manual entry created while correcting allocation.', (string)$reversed['reversal_reason']);
+        self::assertEqualsWithDelta(300.0, (float)$reversed['refunded_amount'], 0.005);
+    }
+
+    public function testManualEntryReversalIsRoutedPermissionedAndVisible(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $router = (string)file_get_contents($root . '/public/index.php');
+        $acl = (string)file_get_contents($root . '/src/utils/acl_middleware.php');
+        $audit = (string)file_get_contents($root . '/src/utils/audit_middleware.php');
+        $controller = (string)file_get_contents($root . '/src/controllers/payments_reverse.php');
+        $paymentsList = (string)file_get_contents($root . '/src/views/pages/payments/payments-list.php');
+
+        self::assertStringContainsString("'payments/payment-reverse'", $router);
+        self::assertStringContainsString("'payments/payment-reverse'  => 'invoices.mark_paid'", $acl);
+        self::assertStringContainsString("'payments/payment-reverse'", $audit);
+        self::assertStringContainsString('payment_reverse_manual_entry($pdo, $paymentId, $reason, $userId)', $controller);
+        self::assertStringContainsString('payment.manual_entry_reversed', $controller);
+        self::assertStringContainsString('Reverse entry', $paymentsList);
+        self::assertStringContainsString('class="payment-reverse-dialog"', $paymentsList);
+        self::assertStringContainsString('.showModal()', $paymentsList);
+    }
+
     public function testUnpaidInvoiceCanBeVoidedAndSafelyReenabled(): void
     {
         $orgId = $this->insertOrganization();

--- a/tests/Workflows/InvoiceVoidWorkflowTest.php
+++ b/tests/Workflows/InvoiceVoidWorkflowTest.php
@@ -56,6 +56,9 @@ final class InvoiceVoidWorkflowTest extends TestCase
         self::assertStringContainsString('Void reason', $details);
         self::assertStringContainsString('Confirm Void Invoice', $list);
         self::assertStringContainsString('name="redirect_to"', $list);
+        self::assertStringContainsString('class="invoice-void-dialog"', $list);
+        self::assertStringContainsString('.showModal()', $list);
+        self::assertStringContainsString('Fully refunded zero-balance history will not block voiding.', $list);
         self::assertStringContainsString("!str_starts_with(\$redirectTo, '//')", $controller);
         self::assertStringContainsString("\$appendResult(\$redirectBase, 'voided', '1')", $controller);
     }


### PR DESCRIPTION
## What changed

- Allow invoices to be voided when every succeeded payment has zero economic balance because it is fully refunded or disputed.
- Continue blocking pending payments and succeeded payments with an active applied balance.
- Replace the invoice-list Void popover with a native modal that is not clipped by the table scroll container.
- Add a reason-required, audited Reverse entry action for duplicate or mistaken manual payment rows without moving money.
- Preserve a void invoice's status when audit-only payment rows are later reversed or reconciled.

## Root cause

The void guard counted every historical succeeded payment as active, even when `amount - refunded - disputed` was zero. The Void form was absolutely positioned inside an overflow container, so the table clipped it. Manual rows that were fully refunded also had no remaining cleanup action in the Payments UI.

## Impact

The old I-2 invoice can now be voided with its fully refunded $291 history intact. Duplicate manual rows such as #3, #4, and #5 can optionally be reversed and hidden from the normal payment list while remaining available in audit history. Reversing those rows after voiding cannot resurrect I-2.

## Validation

- Focused payment/void suites: 21 tests, 205 assertions
- Full suite: 139 tests, 1580 assertions, 1 intentional skip
- PHP lint passed for all changed PHP files
- `git diff --check` passed
- Local Docker image rebuilt successfully
