### PR TITLE
Fix standalone client links and nightly resolver scan

### DIFF
--- a/cron/README.md
+++ b/cron/README.md
@@ -13,6 +13,7 @@ On container startup, the entrypoint runs a scheduled backup catch-up check and 
 | Hourly at :30 | `backup_database.php --scheduled` | Creates rotating backups when the configured local backup hour matches |
 | Daily 03:00 | `auto_terminate_contracts.php` | Complete contracts whose configured end date has passed |
 | Daily 04:00 | `link_expiration_checker.php` | Expire public document links |
+| Daily 04:15 | `daily_link_resolver.php` | Scan enabled providers for organization, department, and standalone-client folders when Daily folder scan is enabled |
 | Every 6 hours | `stripe_reconciliation.php` | Recover Stripe payments missed by webhooks or downtime |
 | Every minute | `sync_alphaledger.php` | Capture PA-owned changes and retry signed AlphaLedger webhooks |
 | Daily 05:00 | `sync_merchant_rate.php` | Calculate the observed Stripe processing rate |
@@ -49,6 +50,7 @@ docker compose exec cron tail -f /var/www/config/logs/cron/cron.log
 docker compose exec cron php /var/www/src/cron/generate_recurring_invoices.php
 docker compose exec cron php /var/www/src/cron/generate_recurring_expenses.php
 docker compose exec cron php /var/www/src/cron/sync_alphaledger.php
+docker compose exec cron php /var/www/src/cron/daily_link_resolver.php
 ```
 
 ## Application Settings
@@ -56,6 +58,7 @@ docker compose exec cron php /var/www/src/cron/sync_alphaledger.php
 The container schedule always starts with the service. Individual scripts also honor application settings where applicable, including:
 
 - `cron_enabled`
+- link resolver, daily folder scan, and provider enablement toggles
 - invoice due and overdue reminder toggles
 - invoice email-on-generation toggle
 - Stripe and SMTP configuration

--- a/cron/crontab
+++ b/cron/crontab
@@ -28,6 +28,9 @@ CRON_LOG=/var/www/config/logs/cron/cron.log
 # Check and expire links - daily at 4:00 AM
 0 4 * * * root . /etc/environment && php /var/www/src/cron/link_expiration_checker.php >> $CRON_LOG 2>&1
 
+# Scan enabled link providers for organization, department, and standalone client folders - daily at 4:15 AM
+15 4 * * * root . /etc/environment && php /var/www/src/cron/daily_link_resolver.php >> $CRON_LOG 2>&1
+
 # Process audit schedules - daily at 6:00 AM
 0 6 * * * root . /etc/environment && php /var/www/src/cron/process_audit_schedules.php >> $CRON_LOG 2>&1
 

--- a/public/assets/navigation.js
+++ b/public/assets/navigation.js
@@ -369,6 +369,7 @@ function updatePageTitle(page) {
     const pageTitles = {
         'home': 'Dashboard',
         'client/clients-list': 'List Clients',
+        'client/client-details': 'Client Details',
         'client/clients-create': 'Create Client',
         'client/clients-edit': 'Edit Client',
         'client/archived-clients': 'Archived Clients',

--- a/src/controllers/client/clients_update.php
+++ b/src/controllers/client/clients_update.php
@@ -39,5 +39,5 @@ $st->execute([
   $id
 ]);
 
-header('Location: /?page=client/clients-list&updated=1');
+header('Location: /?page=client/client-details&id=' . $id . '&updated=1');
 exit;

--- a/src/cron/CONTEXT.md
+++ b/src/cron/CONTEXT.md
@@ -11,6 +11,7 @@ These PHP scripts run unattended from `cron/crontab`. They use the same database
 - `backup_database.php`
 - `auto_terminate_contracts.php`
 - `link_expiration_checker.php`
+- `daily_link_resolver.php`
 - `process_audit_schedules.php`
 - `send_invoice_reminders.php`
 - `stripe_reconciliation.php`

--- a/src/cron/daily_link_resolver.php
+++ b/src/cron/daily_link_resolver.php
@@ -1,0 +1,79 @@
+<?php
+
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../config/app.php';
+require_once __DIR__ . '/../services/LinkResolverService.php';
+require_once __DIR__ . '/../utils/cron_state.php';
+
+$jobName = 'daily_link_resolver';
+$logPrefix = '[daily_link_resolver]';
+
+if (empty($appConfig['cron_enabled'])) {
+    @error_log($logPrefix . ' Cron is disabled.');
+    cron_state_mark_success($pdo, $jobName, 'Cron disabled');
+    exit(0);
+}
+
+if (empty($appConfig['link_resolver_enabled'])) {
+    @error_log($logPrefix . ' Link resolver is disabled.');
+    cron_state_mark_success($pdo, $jobName, 'Link resolver disabled');
+    exit(0);
+}
+
+if (empty($appConfig['link_resolver_daily_scan_enabled'])) {
+    @error_log($logPrefix . ' Daily folder scan is disabled.');
+    cron_state_mark_success($pdo, $jobName, 'Daily folder scan disabled');
+    exit(0);
+}
+
+try {
+    $enabledProviders = [];
+    foreach (pa_link_provider_best_rows($pdo) as $provider => $row) {
+        if (!empty($row['is_enabled']) && in_array($provider, ['dropbox', 'gdrive', 's3'], true)) {
+            $enabledProviders[] = $provider;
+        }
+    }
+
+    if (!$enabledProviders) {
+        cron_state_mark_success($pdo, $jobName, 'No enabled link providers; skipped');
+        @error_log($logPrefix . ' No enabled link providers.');
+        exit(0);
+    }
+
+    $service = new LinkResolverService($pdo);
+    $summaries = [];
+    $failures = [];
+
+    foreach ($enabledProviders as $provider) {
+        @error_log($logPrefix . ' Starting ' . $provider . ' folder scan.');
+        $result = $service->runProviderScan($provider);
+        $summaries[] = sprintf(
+            '%s: scanned %d, generated %d, reused %d, review %d, no match %d, errors %d',
+            $provider,
+            (int)($result['scanned'] ?? 0),
+            (int)($result['generated'] ?? 0),
+            (int)($result['skipped'] ?? 0),
+            (int)($result['review_required'] ?? 0),
+            (int)($result['no_match'] ?? 0),
+            (int)($result['errors'] ?? 0)
+        );
+
+        if (empty($result['success']) || (int)($result['errors'] ?? 0) > 0) {
+            $failures[] = $provider . ': ' . (string)($result['message'] ?? 'scan failed');
+        }
+    }
+
+    $summary = implode('; ', $summaries);
+    if ($failures) {
+        throw new RuntimeException(implode('; ', $failures) . '. ' . $summary);
+    }
+
+    cron_state_mark_success($pdo, $jobName, $summary);
+    @error_log($logPrefix . ' Completed. ' . $summary);
+} catch (Throwable $e) {
+    @error_log($logPrefix . ' Failed: ' . $e->getMessage());
+    cron_state_mark_failure($pdo, $jobName, $e);
+    exit(1);
+}
+
+exit(0);

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -163,6 +163,7 @@ function page_permission_map(): array
 
         // Clients module
         'client/clients-list'    => 'clients.view',
+        'client/client-details'  => 'clients.view',
         'client/clients-create'  => 'clients.create',
         'client/clients-edit'    => 'clients.edit',
         'client/clients-update'  => 'clients.edit',

--- a/src/utils/cron_state.php
+++ b/src/utils/cron_state.php
@@ -71,6 +71,7 @@ function cron_state_ensure_schema(PDO $pdo): void {
             'backup_database',
             'auto_terminate_contracts',
             'link_expiration_checker',
+            'daily_link_resolver',
             'process_audit_schedules',
             'send_invoice_reminders',
             'stripe_reconciliation',

--- a/src/views/pages/client/client-details.php
+++ b/src/views/pages/client/client-details.php
@@ -1,0 +1,155 @@
+<?php
+// src/views/pages/client/client-details.php
+require_once __DIR__ . '/../../../config/db.php';
+require_once __DIR__ . '/../../../config/app.php';
+require_once __DIR__ . '/../../../utils/acl.php';
+require_once __DIR__ . '/../../../utils/escaper.php';
+require_once __DIR__ . '/../../../utils/format.php';
+
+$id = (int)($_GET['id'] ?? 0);
+if ($id <= 0) {
+    echo '<p>Client not found.</p>';
+    return;
+}
+
+require_record_ownership($pdo, 'clients', $id);
+$stmt = $pdo->prepare('
+    SELECT c.*, o.name AS organization_name
+    FROM clients c
+    LEFT JOIN organizations o ON o.id = c.organization_id
+    WHERE c.id = ?
+    LIMIT 1
+');
+$stmt->execute([$id]);
+$client = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$client) {
+    echo '<p>Client not found.</p>';
+    return;
+}
+
+$projectStmt = $pdo->prepare('
+    SELECT p.id, p.name, p.status
+    FROM projects p
+    LEFT JOIN project_clients pc ON pc.project_id = p.id
+    WHERE p.client_id = ? OR pc.client_id = ?
+    GROUP BY p.id, p.name, p.status
+    ORDER BY p.updated_at DESC, p.id DESC
+');
+$projectStmt->execute([$id, $id]);
+$projects = $projectStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$documentCounts = [];
+foreach (['quotes' => 'Quotes', 'contracts' => 'Contracts', 'invoices' => 'Invoices'] as $table => $label) {
+    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM {$table} WHERE client_id = ?");
+    $countStmt->execute([$id]);
+    $documentCounts[$label] = (int)$countStmt->fetchColumn();
+}
+
+$addressLines = array_values(array_filter([
+    trim((string)($client['address_line1'] ?? '')),
+    trim((string)($client['address_line2'] ?? '')),
+    trim(implode(', ', array_filter([
+        trim((string)($client['city'] ?? '')),
+        trim((string)($client['state'] ?? '')),
+        trim((string)($client['postal_code'] ?? '')),
+    ]))),
+], static fn(string $value): bool => $value !== ''));
+?>
+<style>
+  .client-view { max-width: 1280px; margin: 0 auto; padding-bottom: 32px; }
+  .client-view__header { display:flex;justify-content:space-between;gap:18px;align-items:flex-start;margin-bottom:18px; }
+  .client-view__title { margin:0;font-size:30px;line-height:1.15; }
+  .client-view__meta { margin-top:6px;color:var(--muted);font-size:13px; }
+  .client-view__actions { display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end; }
+  .client-view__button { padding:8px 12px;border:1px solid #d1d5db;border-radius:8px;background:#fff;color:inherit;text-decoration:none;font-size:13px; }
+  .client-view__button--primary { background:var(--nav-accent);border-color:var(--nav-accent);color:#fff; }
+  .client-view__layout { display:grid;grid-template-columns:minmax(280px,360px) minmax(0,1fr);gap:18px;align-items:start; }
+  .client-view__sidebar,.client-view__main { display:grid;gap:18px;min-width:0; }
+  .client-card { background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:16px;box-shadow:0 6px 18px rgba(11,18,32,.05); }
+  .client-card h3 { margin:0 0 14px;font-size:17px; }
+  .client-detail-list { display:grid;gap:12px;margin:0; }
+  .client-detail-list dt { color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.04em; }
+  .client-detail-list dd { margin:4px 0 0;line-height:1.5;overflow-wrap:anywhere; }
+  .client-stats { display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px; }
+  .client-stat { padding:12px;border:1px solid #e5e7eb;border-radius:8px;background:#f8fafc; }
+  .client-stat span { display:block;color:var(--muted);font-size:12px; }
+  .client-stat strong { display:block;margin-top:5px;font-size:22px; }
+  .client-projects { display:grid;gap:10px; }
+  .client-project { display:flex;justify-content:space-between;gap:12px;padding:12px;border:1px solid #e5e7eb;border-radius:8px;text-decoration:none;color:inherit; }
+  .client-empty { padding:20px;text-align:center;color:var(--muted);border:1px dashed #d1d5db;border-radius:8px;background:#f9fafb; }
+  .client-links-card > div { margin-top:0 !important;padding-top:0 !important;border-top:0 !important; }
+  @media (max-width:900px) { .client-view__layout { grid-template-columns:1fr; } .client-view__header { display:grid; } .client-view__actions { justify-content:flex-start; } }
+</style>
+
+<section class="client-view">
+  <?php if (!empty($_GET['updated'])): ?>
+    <div style="margin:0 0 14px;padding:10px 12px;border-radius:8px;background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0">Client updated.</div>
+  <?php endif; ?>
+  <div class="client-view__header">
+    <div>
+      <h2 class="client-view__title"><?php echo e((string)$client['name']); ?></h2>
+      <div class="client-view__meta">
+        <?php echo !empty($client['organization_id']) ? 'Organization contact' : 'Standalone client'; ?>
+      </div>
+    </div>
+    <div class="client-view__actions">
+      <a class="client-view__button client-view__button--primary" href="/?page=client/clients-edit&id=<?php echo $id; ?>">Edit Client</a>
+      <?php if (!empty($client['organization_id'])): ?>
+        <a class="client-view__button" href="/?page=organization/organization-view&id=<?php echo (int)$client['organization_id']; ?>">View Organization</a>
+      <?php endif; ?>
+      <a class="client-view__button" href="/?page=client/clients-list">Back to List</a>
+    </div>
+  </div>
+
+  <div class="client-view__layout">
+    <aside class="client-view__sidebar">
+      <div class="client-card">
+        <h3>Client Information</h3>
+        <dl class="client-detail-list">
+          <div><dt>Email</dt><dd><?php echo !empty($client['email']) ? '<a href="mailto:' . e((string)$client['email']) . '">' . e((string)$client['email']) . '</a>' : '<span style="color:var(--muted)">None</span>'; ?></dd></div>
+          <div><dt>Phone</dt><dd><?php echo e(format_phone((string)($client['phone'] ?? '')) ?: 'None'); ?></dd></div>
+          <div><dt>Organization</dt><dd><?php echo !empty($client['organization_name']) ? e((string)$client['organization_name']) : '<span style="color:var(--muted)">None</span>'; ?></dd></div>
+          <div><dt>Address</dt><dd><?php echo $addressLines ? implode('<br>', array_map('e', $addressLines)) : '<span style="color:var(--muted)">None</span>'; ?></dd></div>
+          <?php if (trim((string)($client['notes'] ?? '')) !== ''): ?>
+            <div><dt>Notes</dt><dd><?php echo nl2br(e((string)$client['notes'])); ?></dd></div>
+          <?php endif; ?>
+        </dl>
+      </div>
+
+      <div class="client-card">
+        <h3>Documents</h3>
+        <div class="client-stats">
+          <?php foreach ($documentCounts as $label => $count): ?>
+            <div class="client-stat"><span><?php echo e($label); ?></span><strong><?php echo $count; ?></strong></div>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </aside>
+
+    <main class="client-view__main">
+      <div class="client-card client-links-card">
+        <?php
+        $entityType = 'client';
+        $entityId = $id;
+        include __DIR__ . '/../../components/links_section.php';
+        ?>
+      </div>
+
+      <div class="client-card">
+        <h3>Projects</h3>
+        <?php if ($projects): ?>
+          <div class="client-projects">
+            <?php foreach ($projects as $project): ?>
+              <a class="client-project" href="/?page=project/projects-details&id=<?php echo (int)$project['id']; ?>">
+                <span><strong><?php echo e((string)($project['name'] ?: 'Project')); ?></strong></span>
+                <span><?php echo e(ucwords(str_replace('_', ' ', (string)($project['status'] ?? '')))); ?></span>
+              </a>
+            <?php endforeach; ?>
+          </div>
+        <?php else: ?>
+          <div class="client-empty">No projects for this client yet.</div>
+        <?php endif; ?>
+      </div>
+    </main>
+  </div>
+</section>

--- a/src/views/pages/client/clients-list.php
+++ b/src/views/pages/client/clients-list.php
@@ -105,7 +105,7 @@ function client_list_email_html(?string $email): string
       <tbody>
         <?php foreach ($clients as $c): ?>
           <tr style="border-top:1px solid #f3f4f6">
-            <td style="padding:10px"><a href="/?page=client/clients-list&selected_client_id=<?php echo (int)$c['id']; ?>" style="text-decoration:none;color:inherit;"><?php echo htmlspecialchars($c['name']); ?></a></td>
+            <td style="padding:10px"><a href="/?page=client/client-details&id=<?php echo (int)$c['id']; ?>" style="text-decoration:none;color:inherit;font-weight:600"><?php echo htmlspecialchars($c['name']); ?></a></td>
             <td style="padding:10px"><?php echo client_list_email_html($c['email'] ?? null); ?></td>
             <td style="padding:10px"><?php echo htmlspecialchars(format_phone($c['phone'] ?? '')); ?></td>
             <td style="padding:10px"><?php echo htmlspecialchars($c['organization_name'] ?? ''); ?></td>

--- a/src/views/pages/organization/organization-view.php
+++ b/src/views/pages/organization/organization-view.php
@@ -280,7 +280,7 @@ $taxFileUrl = !empty($org['tax_exempt_file'])
             <?php foreach ($clients as $client): ?>
               <div style="display:grid;gap:4px;border:1px solid #eef2f7;border-radius:8px;padding:10px">
                 <div style="display:flex;justify-content:space-between;gap:8px;align-items:start">
-                  <a href="/?page=client/clients-edit&id=<?php echo (int)$client['id']; ?>" style="font-weight:700;text-decoration:none;color:inherit">
+                  <a href="/?page=client/client-details&id=<?php echo (int)$client['id']; ?>" style="font-weight:700;text-decoration:none;color:inherit">
                     <?php echo htmlspecialchars($client['name']); ?>
                   </a>
                   <form method="post" action="/?page=organization/organization-remove-client" style="margin:0" onsubmit="return confirm('Remove <?php echo e(substr(json_encode((string)$client['name'], JSON_HEX_QUOT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS), 1, -1)); ?> from this organization?')">

--- a/src/views/pages/settings/links.php
+++ b/src/views/pages/settings/links.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../../../config/db.php';
 require_once __DIR__ . '/../../../utils/escaper.php';
 require_once __DIR__ . '/../../../utils/link_provider_config.php';
+require_once __DIR__ . '/../../../utils/cron_state.php';
 
 // Fetch global app config
 $appConfig = [];
@@ -39,6 +40,16 @@ try {
     $linkStats['auto_links'] = (int)$pdo->query("SELECT COUNT(*) FROM entity_links WHERE link_type IN ('auto_dropbox','auto_gdrive','auto_s3')")->fetchColumn();
 } catch (Throwable $e) {
     @error_log('[links] Error fetching link stats: ' . $e->getMessage());
+}
+
+$dailyScanRun = null;
+try {
+    cron_state_ensure_schema($pdo);
+    $dailyScanStmt = $pdo->prepare('SELECT last_run, status, result, error_message FROM cron_job_runs WHERE job_name = ? LIMIT 1');
+    $dailyScanStmt->execute(['daily_link_resolver']);
+    $dailyScanRun = $dailyScanStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+} catch (Throwable $e) {
+    @error_log('[links] Error fetching daily resolver status: ' . $e->getMessage());
 }
 
 // Make CSRF token available to JavaScript
@@ -115,6 +126,24 @@ $dropboxCallbackUri = rtrim($dropboxCallbackBase, '/') . '/?page=settings/dropbo
             <div style="font-size:24px;font-weight:700;color:#374151"><?php echo $linkStats['ignored_clients']; ?></div>
             <div style="font-size:13px;color:#6b7280">Ignored</div>
         </div>
+    </div>
+
+    <?php
+    $dailyScanStatus = (string)($dailyScanRun['status'] ?? '');
+    $dailyScanLastRun = (string)($dailyScanRun['last_run'] ?? '');
+    $dailyScanFailed = $dailyScanStatus === 'failed';
+    $dailyScanMessage = $dailyScanFailed
+        ? (string)($dailyScanRun['error_message'] ?? 'The last scan failed. Check the cron log for details.')
+        : (string)($dailyScanRun['result'] ?? 'The nightly scan has not run yet.');
+    ?>
+    <div style="padding:12px 14px;margin-bottom:20px;border:1px solid <?php echo $dailyScanFailed ? '#fecaca' : '#dbeafe'; ?>;background:<?php echo $dailyScanFailed ? '#fef2f2' : '#eff6ff'; ?>;border-radius:8px;font-size:13px">
+        <strong>Nightly folder scan:</strong>
+        <?php if ($dailyScanLastRun !== ''): ?>
+            <?php echo e(ucfirst($dailyScanStatus ?: 'unknown')); ?> on <?php echo e(date('M j, Y g:i A', strtotime($dailyScanLastRun))); ?>.
+        <?php else: ?>
+            Not run yet.
+        <?php endif; ?>
+        <span style="display:block;margin-top:4px;color:<?php echo $dailyScanFailed ? '#991b1b' : 'var(--muted)'; ?>"><?php echo e($dailyScanMessage); ?></span>
     </div>
 
     <form method="POST" action="/?page=settings/links-handler">
@@ -225,7 +254,7 @@ $dropboxCallbackUri = rtrim($dropboxCallbackBase, '/') . '/?page=settings/dropbo
                 <span class="font-600">Enable <?php echo e($providerName); ?> auto-generation</span>
             </label>
             <div class="pa-provider-note">
-                Manual links do not require auto-generation. Enable this provider only when PA should scan for exact organization or department folders and create share links automatically.
+                Manual links do not require auto-generation. Enable this provider only when PA should scan for exact organization, department, or standalone-client folders and create share links automatically.
             </div>
 
             <div id="fields_<?php echo e($provider); ?>" style="<?php echo !$isEnabled ? 'display:none' : ''; ?>">

--- a/tests/Workflows/FinancialSchedulingTest.php
+++ b/tests/Workflows/FinancialSchedulingTest.php
@@ -78,6 +78,26 @@ final class FinancialSchedulingTest extends TestCase
         self::assertStringContainsString('set_time_limit', (string)$handler);
     }
 
+    public function testDailyLinkResolverIsScheduledAndHonorsItsFeatureFlags(): void
+    {
+        $cron = file_get_contents($this->root . '/src/cron/daily_link_resolver.php');
+        $crontab = file_get_contents($this->root . '/cron/crontab');
+        $state = file_get_contents($this->root . '/src/utils/cron_state.php');
+        $settings = file_get_contents($this->root . '/src/views/pages/settings/links.php');
+
+        self::assertStringContainsString("empty(\$appConfig['link_resolver_enabled'])", (string)$cron);
+        self::assertStringContainsString("empty(\$appConfig['link_resolver_daily_scan_enabled'])", (string)$cron);
+        self::assertStringContainsString('pa_link_provider_best_rows($pdo)', (string)$cron);
+        self::assertStringContainsString('$service->runProviderScan($provider)', (string)$cron);
+        self::assertStringContainsString('cron_state_mark_success($pdo, $jobName, $summary)', (string)$cron);
+        self::assertStringContainsString('cron_state_mark_failure($pdo, $jobName, $e)', (string)$cron);
+        self::assertStringContainsString('15 4 * * * root', (string)$crontab);
+        self::assertStringContainsString('daily_link_resolver.php', (string)$crontab);
+        self::assertStringContainsString("'daily_link_resolver'", (string)$state);
+        self::assertStringContainsString("['daily_link_resolver']", (string)$settings);
+        self::assertStringContainsString('Nightly folder scan:', (string)$settings);
+    }
+
     public function testAuditAndOrganizationScriptsInitializeAfterAjaxNavigation(): void
     {
         $audit = file_get_contents($this->root . '/public/assets/js/audit-logic.js');

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -140,6 +140,23 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('function removeResolverOrganizationLinks', (string)$resolver);
     }
 
+    public function testStandaloneClientsHaveAFirstClassDetailsPageForLinks(): void
+    {
+        $list = file_get_contents($this->root . '/src/views/pages/client/clients-list.php');
+        $details = file_get_contents($this->root . '/src/views/pages/client/client-details.php');
+        $organization = file_get_contents($this->root . '/src/views/pages/organization/organization-view.php');
+        $permissions = file_get_contents($this->root . '/src/utils/acl_middleware.php');
+        $update = file_get_contents($this->root . '/src/controllers/client/clients_update.php');
+
+        self::assertStringContainsString('/?page=client/client-details&id=', (string)$list);
+        self::assertStringContainsString("\$entityType = 'client'", (string)$details);
+        self::assertStringContainsString("include __DIR__ . '/../../components/links_section.php'", (string)$details);
+        self::assertStringContainsString('Standalone client', (string)$details);
+        self::assertStringContainsString('/?page=client/client-details&id=', (string)$organization);
+        self::assertStringContainsString("'client/client-details'  => 'clients.view'", (string)$permissions);
+        self::assertStringContainsString("page=client/client-details&id=' . \$id", (string)$update);
+    }
+
     public function testClientAndOrganizationSuiteAddressesFlowToDocuments(): void
     {
         $baseline = file_get_contents($this->root . '/database/baseline.sql');


### PR DESCRIPTION
## What changed

- added a dedicated client details page with first-class link management for standalone clients
- linked client names to the details page and kept editing as a separate action
- added the missing nightly link resolver cron job for enabled providers
- scheduled provider scans for 4:15 AM in the configured Project Alpha timezone
- exposed the last nightly scan result on Settings > Links
- recorded nightly scan success and failure through `cron_job_runs`

## Why

Standalone-client links were difficult to discover because link management was buried on the edit page. The Daily folder scan setting also had no scheduled job behind it, so enabled Dropbox scans never ran overnight.

## Impact

Standalone clients can now manage and inspect their links from a dedicated details page. Enabled Dropbox and other provider scans run nightly and report their latest status in the UI.

## Validation

- 43 tests passed
- 403 assertions passed
- 14 MySQL-dependent tests skipped because the local database service was unavailable
- PHP syntax checks passed for the new cron job and client/settings views
