### PR TITLE
Restore production package rebuild triggers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,12 +4,23 @@ on:
   push:
     branches: ["dev", "main"]
     tags: ['v*.*.*']
+  # Some API-assisted squash merges do not emit a follow-up push workflow.
+  # The closed-PR fallback still runs only after GitHub has merged into main.
+  pull_request_target:
+    branches: ["main"]
+    types: [closed]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref_name }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
 
 jobs:
   build-and-push:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,6 +29,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # Never execute an unmerged PR head with package-write permission.
+          # For the fallback event, build the commit GitHub merged into main.
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.ref }}
+
+      - name: Resolve source commit
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -41,7 +60,7 @@ jobs:
             echo "tag=${version}" >> $GITHUB_OUTPUT
             echo "cron_tag=cron-${version}" >> $GITHUB_OUTPUT
             echo "db_tag=db-${version}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          elif [[ "${{ github.event_name }}" == "pull_request_target" || "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "tag=latest" >> $GITHUB_OUTPUT
             echo "cron_tag=cron-latest" >> $GITHUB_OUTPUT
             echo "db_tag=db-latest" >> $GITHUB_OUTPUT
@@ -63,7 +82,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.tag.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:sha-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:sha-${{ steps.source.outputs.sha }}
           build-args: |
             APP_VERSION=${{ steps.ver.outputs.version }}
           cache-from: type=gha
@@ -77,7 +96,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.tag.outputs.cron_tag }}
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:cron-sha-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:cron-sha-${{ steps.source.outputs.sha }}
           build-args: |
             APP_VERSION=${{ steps.ver.outputs.version }}
           cache-from: type=gha
@@ -91,7 +110,7 @@ jobs:
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.tag.outputs.db_tag }}
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:db-sha-${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:db-sha-${{ steps.source.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/tests/Security/SecurityHardeningTest.php
+++ b/tests/Security/SecurityHardeningTest.php
@@ -468,8 +468,23 @@ final class SecurityHardeningTest extends TestCase
         $docker = $this->read('.github/workflows/docker-publish.yml');
         self::assertStringContainsString('exit-code: \'1\'', $docker);
         self::assertStringContainsString("severity: 'CRITICAL,HIGH'", $docker);
-        self::assertStringContainsString(':sha-${{ github.sha }}', $docker);
-        self::assertStringContainsString(':cron-sha-${{ github.sha }}', $docker);
+        self::assertStringContainsString(':sha-${{ steps.source.outputs.sha }}', $docker);
+        self::assertStringContainsString(':cron-sha-${{ steps.source.outputs.sha }}', $docker);
+        self::assertStringContainsString(':db-sha-${{ steps.source.outputs.sha }}', $docker);
+    }
+
+    public function testDockerPublishingRecoversFromApiAssistedMainMerges(): void
+    {
+        $docker = $this->read('.github/workflows/docker-publish.yml');
+
+        self::assertStringContainsString('branches: ["dev", "main"]', $docker);
+        self::assertStringContainsString('pull_request_target:', $docker);
+        self::assertStringContainsString('types: [closed]', $docker);
+        self::assertStringContainsString('workflow_dispatch:', $docker);
+        self::assertStringContainsString("github.event.pull_request.merged == true", $docker);
+        self::assertStringContainsString('github.event.pull_request.merge_commit_sha', $docker);
+        self::assertStringContainsString('cancel-in-progress: true', $docker);
+        self::assertStringContainsString('github.event_name }}" == "pull_request_target"', $docker);
     }
 
     public function testNavigationDiagnosticsDoNotTreatExternalInputAsCodeOrMarkup(): void


### PR DESCRIPTION
## What changed

- retain Docker package publishing on pushes to `dev`, `main`, and version tags
- add a merged-PR fallback for API-assisted squash merges that do not emit a follow-up push workflow
- add `workflow_dispatch` so production packages can be rebuilt manually when recovery is needed
- deduplicate simultaneous push and merged-PR builds with workflow concurrency
- build only the commit GitHub actually merged into `main` and derive immutable image tags from that checked-out commit

## Why

The workforce release reached `main`, but GitHub created no push-triggered Actions runs for the squash commit. Development packages were rebuilt while `latest`, `cron-latest`, and `db-latest` remained stale.

## Security

The fallback uses `pull_request_target` only after `pull_request.merged == true` and checks out the resulting merge commit, never an unmerged PR head. Existing least-privilege `contents: read` and `packages: write` permissions remain unchanged.

## Validation

- SecurityHardeningTest: 19 tests, 383 assertions, 3 database-dependent skips
- PHP syntax check passed
- `git diff --check` passed
