### PR TITLE
Keep package publishing resilient to cache failures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -86,7 +86,9 @@ jobs:
           build-args: |
             APP_VERSION=${{ steps.ver.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Package publishing must not fail only because the optional Actions
+          # cache is full or temporarily unable to reserve another layer.
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Build and push cron image
         uses: docker/build-push-action@v7
@@ -100,7 +102,7 @@ jobs:
           build-args: |
             APP_VERSION=${{ steps.ver.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Build and push encrypted database image
         uses: docker/build-push-action@v7
@@ -112,7 +114,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.tag.outputs.db_tag }}
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:db-sha-${{ steps.source.outputs.sha }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0

--- a/tests/Security/SecurityHardeningTest.php
+++ b/tests/Security/SecurityHardeningTest.php
@@ -485,6 +485,7 @@ final class SecurityHardeningTest extends TestCase
         self::assertStringContainsString('github.event.pull_request.merge_commit_sha', $docker);
         self::assertStringContainsString('cancel-in-progress: true', $docker);
         self::assertStringContainsString('github.event_name }}" == "pull_request_target"', $docker);
+        self::assertSame(3, substr_count($docker, 'cache-to: type=gha,mode=max,ignore-error=true'));
     }
 
     public function testNavigationDiagnosticsDoNotTreatExternalInputAsCodeOrMarkup(): void


### PR DESCRIPTION
## What changed

- keep GitHub Actions cache import/export enabled for all Docker targets
- make cache export failures non-fatal for web, cron, and encrypted database images
- add a regression assertion covering all three package build steps

## Why

The restored production trigger ran correctly, but GitHub’s Actions cache backend repeatedly returned `error writing layer blob: failed to reserve cache`. Buildx treated the optional cache export error as fatal and cancelled the GHCR image push.

## Impact

Production packages and vulnerability scans can complete even when GitHub’s optional layer cache is full or temporarily unavailable. Successful cache writes continue to accelerate later builds.

## Validation

- focused Docker publishing regression test passed: 1 test, 10 assertions
- `git diff --check` passed
- failure reproduced twice and confirmed in Actions logs as cache-export-only
