### PR TITLE
Fix draft time billing and soft navigation assets

### DIFF
--- a/docs/workflows/workforce-time-billing-and-pay.md
+++ b/docs/workflows/workforce-time-billing-and-pay.md
@@ -50,6 +50,8 @@ After time is confirmed:
 - Finalized invoices are never automatic destinations.
 - An admin may move the entry while the affected billing records remain mutable. Conflicting client, Project, or Job context requires an explicit correction and is never silently overwritten.
 
+Selecting a draft invoice while entering time records the intended destination, but it does not create a financial line before confirmation. The draft invoice editor shows matching pending time and its current review state. A verified Owner can use **Confirm and add** for their own nonpayable owner time; employee and contractor entries remain behind the normal reviewer control. Once confirmed, the selected draft invoice is updated automatically and its totals are recalculated.
+
 Hourly Service lines on quotes and contracts are estimates. They show estimated hours, hourly price, and an estimated total. They do not become collectible invoice charges during conversion. Confirmed time creates the actual hourly invoice lines. Fixed-price time is operational history and does not create an additional client charge.
 
 ## Corrections and disputes

--- a/public/assets/navigation.js
+++ b/public/assets/navigation.js
@@ -24,7 +24,15 @@ function getCurrentPage() {
         '/approvals': 'workforce/approvals',
         '/pay': 'workforce/pay'
     };
-    return urlParams.get('page') || pathPages[window.location.pathname] || 'home';
+    const page = urlParams.get('page') || pathPages[window.location.pathname] || 'home';
+    if (!urlParams.has('page')) return page;
+
+    urlParams.delete('page');
+    urlParams.delete('_');
+    const additionalParams = Array.from(urlParams)
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+        .join('&');
+    return additionalParams ? `${page}&${additionalParams}` : page;
 }
 
 function normalizePageName(page) {
@@ -33,6 +41,17 @@ function normalizePageName(page) {
 
 function getMainContentRoot() {
     return document.querySelector('.main-content') || document;
+}
+
+function shellAssetSignature(doc = document) {
+    const version = doc.querySelector('meta[name="project-alpha-version"]')?.getAttribute('content') || '';
+    const assets = Array.from(doc.querySelectorAll('[data-pa-shell-asset]'))
+        .map(asset => asset.getAttribute('href') || asset.getAttribute('src') || '')
+        .filter(Boolean)
+        .map(path => {
+            try { return new URL(path, window.location.href).href; } catch (error) { return path; }
+        });
+    return JSON.stringify({ version, assets });
 }
 
 function runPageCleanups() {
@@ -179,6 +198,14 @@ async function loadPageContent(page) {
         const parser = new DOMParser();
         const doc = parser.parseFromString(html, 'text/html');
         const newMainContent = doc.querySelector('.main-content');
+
+        // A long-lived soft-navigation shell can survive a deployment while its
+        // Settings/Workforce CSS and JavaScript are now older than the fragment
+        // returned by the server. Reload the full document once so the shell and
+        // fragment always use the same versioned assets.
+        if (shellAssetSignature(doc) !== shellAssetSignature(document)) {
+            return { reloadRequired: true, url: buildUrlFromPageString(page) };
+        }
 
         const redirectedPage = (() => {
             try { return new URL(response.url).searchParams.get('page'); } catch (err) { return null; }
@@ -370,6 +397,11 @@ async function navigateToPage(page, updateHistory = true, targetHash = '') {
             return;
         }
 
+        if (content && content.reloadRequired) {
+            window.location.href = content.url || buildUrlFromPageString(page);
+            return;
+        }
+
         if (content === null) {
             // Fallback to full page reload using canonical builder
             const fallbackUrl = new URL(buildUrlFromPageString(page));
@@ -471,7 +503,7 @@ function updatePageTitle(page) {
         'workforce/pay': 'Employee Pay'
     };
 
-    const pageTitle = pageTitles[page] || 'Project Alpha';
+    const pageTitle = pageTitles[normalizePageName(page)] || 'Project Alpha';
     document.title = `${pageTitle} · Project Alpha`;
 }
 

--- a/src/Modules/Timekeeping/ApprovalService.php
+++ b/src/Modules/Timekeeping/ApprovalService.php
@@ -40,15 +40,29 @@ final class ApprovalService
         return $this->finalize($ownerId, $entryId, true, false);
     }
 
-    /** Materialize snapshots for owner entries created by the pre-0045 direct-approved path. */
+    /** Materialize or repair the immutable projection for verified-owner time. */
     public function ensureOwnerProjection(int $ownerId, string $entryId): string
     {
         $existing = $this->pdo->prepare(
-            'SELECT id FROM work_approval_snapshots WHERE time_entry_id=? ORDER BY entry_revision DESC LIMIT 1'
+            "SELECT t.status,t.workflow_status,s.id snapshot_id
+             FROM work_time_entries t
+             LEFT JOIN work_approval_snapshots s ON s.id=(
+                SELECT s2.id FROM work_approval_snapshots s2
+                WHERE s2.time_entry_id=t.id AND s2.voided_at IS NULL
+                ORDER BY s2.entry_revision DESC LIMIT 1
+             )
+             WHERE t.id=? AND t.user_id=?"
         );
-        $existing->execute([$entryId]);
-        $snapshotId = (string)($existing->fetchColumn() ?: '');
-        return $snapshotId !== '' ? $snapshotId : $this->finalize($ownerId, $entryId, true, true);
+        $existing->execute([$entryId, $ownerId]);
+        $entry = $existing->fetch(PDO::FETCH_ASSOC);
+        if (!$entry) {
+            throw new DomainException('Owner time entry not found.');
+        }
+        $snapshotId = (string)($entry['snapshot_id'] ?? '');
+        if ($entry['status'] === 'approved' && $entry['workflow_status'] === 'confirmed' && $snapshotId !== '') {
+            return $snapshotId;
+        }
+        return $this->finalize($ownerId, $entryId, true, true);
     }
 
     public function canSelfConfirmOwner(int $userId): bool
@@ -147,7 +161,7 @@ final class ApprovalService
             $entry = $stmt->fetch(PDO::FETCH_ASSOC);
             $readyStatus = $entry && (
                 ($entry['status'] === 'review'
-                    && (($ownerSelfConfirmation && in_array((string)($entry['workflow_status'] ?? ''), ['draft','returned'], true))
+                    && (($ownerSelfConfirmation && in_array((string)($entry['workflow_status'] ?? ''), ['draft','returned','submitted'], true))
                         || (!$ownerSelfConfirmation && (string)($entry['workflow_status'] ?? '') === 'submitted')))
                 || ($ownerSelfConfirmation && $allowLegacyApproved
                     && $entry['status'] === 'approved' && !empty($entry['owner_self_confirmed']))

--- a/src/views/pages/invoice/invoices-edit.php
+++ b/src/views/pages/invoice/invoices-edit.php
@@ -29,7 +29,7 @@ foreach ($clients as $c) {
   }
 }
 $availableTimeStmt = $pdo->prepare(
-  "SELECT t.id,t.start_time,t.duration_seconds,t.description,t.job_id,t.project_id,
+  "SELECT t.id,t.user_id,t.start_time,t.duration_seconds,t.description,t.job_id,t.project_id,
           wt.name work_type_name,j.job_code,p.name project_name,
           COALESCE(NULLIF(TRIM(CONCAT(ep.first_name,' ',ep.last_name)),''),NULLIF(u.username,''),u.email) worker_name,
           COALESCE(NULLIF(bt.rate,0),NULLIF(s.billing_rate,0)) billing_rate
@@ -51,10 +51,36 @@ $availableTimeStmt = $pdo->prepare(
      AND t.billable=1 AND t.end_time IS NOT NULL
      AND COALESCE(bt.billed,0)=0 AND bt.invoice_item_id IS NULL
      AND (t.invoice_id IS NULL OR t.invoice_id=?)
+     AND (t.job_id IS NULL OR t.job_id=?)
    ORDER BY t.start_time DESC"
 );
-$availableTimeStmt->execute([(int)$inv['client_id'], $id]);
+$availableTimeStmt->execute([(int)$inv['client_id'], $id, (int)($inv['job_id'] ?? 0)]);
 $availableTimeEntries = $availableTimeStmt->fetchAll(PDO::FETCH_ASSOC);
+$pendingTimeStmt = $pdo->prepare(
+  "SELECT t.id,t.user_id,t.start_time,t.duration_seconds,t.description,t.job_id,t.project_id,
+          t.status,t.workflow_status,wt.name work_type_name,j.job_code,p.name project_name,
+          COALESCE(NULLIF(TRIM(CONCAT(ep.first_name,' ',ep.last_name)),''),NULLIF(u.username,''),u.email) worker_name
+   FROM work_time_entries t
+   JOIN users u ON u.id=t.user_id
+   LEFT JOIN employee_profiles ep ON ep.user_id=t.user_id
+   LEFT JOIN work_types wt ON wt.id=t.work_type_id
+   LEFT JOIN jobs j ON j.id=t.job_id
+   LEFT JOIN projects p ON p.id=t.project_id
+   WHERE t.client_id=? AND t.billable=1 AND t.end_time IS NOT NULL
+     AND t.workflow_status IN ('draft','submitted','returned')
+     AND (t.invoice_id=? OR (t.invoice_id IS NULL AND (t.job_id IS NULL OR t.job_id=?)))
+   ORDER BY t.start_time DESC"
+);
+$pendingTimeStmt->execute([(int)$inv['client_id'], $id, (int)($inv['job_id'] ?? 0)]);
+$pendingTimeEntries = $pendingTimeStmt->fetchAll(PDO::FETCH_ASSOC);
+$invoiceActorId = (int)($_SESSION['user']['id'] ?? 0);
+$invoiceActorOwnerStmt = $pdo->prepare(
+  "SELECT 1 FROM worker_profiles
+   WHERE user_id=? AND status='active' AND relationship_type='owner'
+     AND relationship_review_required=0 LIMIT 1"
+);
+$invoiceActorOwnerStmt->execute([$invoiceActorId]);
+$invoiceActorIsVerifiedOwner = (bool)$invoiceActorOwnerStmt->fetchColumn();
 $contractEstimateLines = [];
 if (!empty($inv['contract_id'])) {
   $estimateStmt = $pdo->prepare(
@@ -68,6 +94,11 @@ if (!empty($inv['contract_id'])) {
 ?>
 <section>
   <h2>Edit Invoice <?php echo htmlspecialchars(pa_invoice_label_from_row($inv)); ?><?php if (!empty($inv['project_code'])) echo ' (Job ' . htmlspecialchars($inv['project_code']) . ')'; ?></h2>
+  <?php if (!empty($_GET['success'])): ?>
+    <div class="alert alert-success" role="status"><?php echo htmlspecialchars((string)$_GET['success']); ?></div>
+  <?php elseif (!empty($_GET['error'])): ?>
+    <div class="alert alert-danger" role="alert"><?php echo htmlspecialchars((string)$_GET['error']); ?></div>
+  <?php endif; ?>
   <?php if ($contractEstimateLines): ?>
   <div style="max-width:900px;margin:0 0 18px;padding:14px;border:1px solid #cbd5e1;border-radius:10px;background:#f8fafc">
     <strong>Contract estimate — reference only</strong>
@@ -81,7 +112,9 @@ if (!empty($inv['contract_id'])) {
       <div style="font-size:13px;color:#475569">Confirmed, billable time for this client stays available until it is attached. Finalizing the invoice locks this workflow.</div>
     </div>
     <?php if (!$availableTimeEntries): ?>
-      <p style="margin:0;color:#64748b">No additional confirmed time is currently available for this client.</p>
+      <p style="margin:0;color:#64748b"><?php echo $pendingTimeEntries
+        ? 'No time is ready to add yet. Pending entries and their next action are shown below.'
+        : 'No additional confirmed time is currently available for this client.'; ?></p>
     <?php else: ?>
       <div style="display:grid;gap:8px">
         <?php foreach ($availableTimeEntries as $timeEntry): ?>
@@ -89,6 +122,7 @@ if (!empty($inv['contract_id'])) {
             <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token(), ENT_QUOTES, 'UTF-8'); ?>">
             <input type="hidden" name="action" value="link-invoice">
             <input type="hidden" name="entry_id" value="<?php echo htmlspecialchars((string)$timeEntry['id'], ENT_QUOTES, 'UTF-8'); ?>">
+            <input type="hidden" name="entry_user_id" value="<?php echo (int)$timeEntry['user_id']; ?>">
             <input type="hidden" name="invoice_id" value="<?php echo $id; ?>">
             <input type="hidden" name="return_to" value="invoice-edit">
             <div>
@@ -101,6 +135,49 @@ if (!empty($inv['contract_id'])) {
             </div>
           </form>
         <?php endforeach; ?>
+      </div>
+    <?php endif; ?>
+    <?php if ($pendingTimeEntries): ?>
+      <div style="display:grid;gap:8px;padding-top:10px;border-top:1px solid #bfdbfe">
+        <div>
+          <strong style="color:#92400e">Time waiting for confirmation</strong>
+          <small style="display:block;color:#64748b">Entries selected for this invoice or matching its Job cannot become invoice charges until their time review is complete.</small>
+        </div>
+        <?php foreach ($pendingTimeEntries as $timeEntry):
+          $pendingState = match ((string)$timeEntry['workflow_status']) {
+            'submitted' => 'Awaiting time review',
+            'returned' => 'Returned for changes',
+            default => 'Not submitted for review',
+          };
+          $canConfirmAndAdd = $invoiceActorIsVerifiedOwner && (int)$timeEntry['user_id'] === $invoiceActorId;
+        ?>
+          <div style="display:grid;grid-template-columns:minmax(0,1fr) auto;gap:10px;align-items:center;padding:10px;background:#fffbeb;border:1px solid #fde68a;border-radius:8px">
+            <div>
+              <strong><?php echo htmlspecialchars($timeEntry['work_type_name'] ?: ($timeEntry['job_code'] ?: ($timeEntry['project_name'] ?: 'Unclassified work'))); ?></strong>
+              <small style="display:block;color:#64748b"><?php echo htmlspecialchars($timeEntry['worker_name']); ?> · <?php echo htmlspecialchars(date('M j, Y', strtotime((string)$timeEntry['start_time']))); ?> · <?php echo number_format(((int)$timeEntry['duration_seconds']) / 3600, 2); ?> h · <?php echo htmlspecialchars($pendingState); ?></small>
+            </div>
+            <?php if ($canConfirmAndAdd): ?>
+              <form method="post" action="/?page=workforce/action">
+                <input type="hidden" name="csrf" value="<?php echo htmlspecialchars(csrf_token(), ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="action" value="link-invoice">
+                <input type="hidden" name="entry_id" value="<?php echo htmlspecialchars((string)$timeEntry['id'], ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="entry_user_id" value="<?php echo (int)$timeEntry['user_id']; ?>">
+                <input type="hidden" name="invoice_id" value="<?php echo $id; ?>">
+                <input type="hidden" name="return_to" value="invoice-edit">
+                <button class="btn btn-primary btn-sm" type="submit">Confirm and add</button>
+              </form>
+            <?php elseif ((string)$timeEntry['workflow_status'] === 'submitted' && (int)$timeEntry['user_id'] !== $invoiceActorId): ?>
+              <a class="btn btn-sm" href="/?page=workforce/approvals">Review time</a>
+            <?php elseif ((string)$timeEntry['workflow_status'] === 'submitted'): ?>
+              <span style="color:#92400e;font-size:13px;font-weight:600">Another reviewer is required</span>
+            <?php else: ?>
+              <a class="btn btn-sm" href="/?page=workforce/time&amp;user=<?php echo (int)$timeEntry['user_id']; ?>">Open time entry</a>
+            <?php endif; ?>
+          </div>
+        <?php endforeach; ?>
+        <?php if (!$invoiceActorIsVerifiedOwner && array_filter($pendingTimeEntries, static fn(array $entry): bool => (int)$entry['user_id'] === $invoiceActorId)): ?>
+          <p style="margin:0;color:#92400e;font-size:13px">Your own submitted time needs another reviewer. If this account represents the business owner, confirm its <a href="/?page=settings&amp;tab=business-units">Owner relationship</a> to use self-confirmation and nonpayable owner time.</p>
+        <?php endif; ?>
       </div>
     <?php endif; ?>
   </div>

--- a/src/views/pages/workforce/time.php
+++ b/src/views/pages/workforce/time.php
@@ -369,11 +369,14 @@ foreach ($entries as $entry) {
                 || ($canonicalWorkflowState === 'confirmed' && (string)$entry['status'] === 'approved' && !empty($entry['owner_self_confirmed']))
             );
             $canonicalBillingState = (string)($entry['billing_state'] ?? '');
+            $timeIsConfirmed = $canonicalWorkflowState === 'confirmed' && (string)$entry['status'] === 'approved';
             $billingState = $projectionBilled
                 ? 'Invoiced'
-                : ($entryBillingLabels[$canonicalBillingState] ?? (!empty($entry['billable'])
-                    ? ((string)$entry['status'] === 'approved' ? 'Ready to invoice' : 'Available after approval')
-                    : 'Internal / undecided'));
+                : (!$timeIsConfirmed && !empty($entry['billable'])
+                    ? 'Available after confirmation'
+                    : ($entryBillingLabels[$canonicalBillingState] ?? (!empty($entry['billable'])
+                        ? 'Ready to invoice'
+                        : 'Internal / undecided')));
             $canonicalCompensationState = (string)($entry['compensation_state'] ?? '');
             $compensationState = $entryCompensationLabels[$canonicalCompensationState] ?? (!empty($entry['is_payable'])
                 ? ((string)$entry['status'] === 'approved' ? 'Eligible' : 'Awaiting approval')

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -40,6 +40,7 @@ function nav_can(string $permission): bool {
     <link rel="icon" type="image/png" href="/assets/favicon-32.png" />
   <?php endif; ?>
   <meta name="csrf-token" content="<?php echo htmlspecialchars($_SESSION['csrf'] ?? ''); ?>">
+  <meta name="project-alpha-version" content="<?php echo htmlspecialchars(app_version(), ENT_QUOTES, 'UTF-8'); ?>">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
@@ -51,15 +52,15 @@ function nav_can(string $permission): bool {
     <link rel="preload" href="<?php echo htmlspecialchars($logo); ?>" as="image">
   <?php endif; ?>
 
-  <link rel="stylesheet" href="<?php echo htmlspecialchars(asset_url('/assets/styles.css'), ENT_QUOTES, 'UTF-8'); ?>">
-  <link rel="stylesheet" href="<?php echo htmlspecialchars(asset_url('/assets/settings.css'), ENT_QUOTES, 'UTF-8'); ?>">
-  <script src="<?php echo htmlspecialchars(asset_url('/assets/navigation.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+  <link rel="stylesheet" data-pa-shell-asset href="<?php echo htmlspecialchars(asset_url('/assets/styles.css'), ENT_QUOTES, 'UTF-8'); ?>">
+  <link rel="stylesheet" data-pa-shell-asset href="<?php echo htmlspecialchars(asset_url('/assets/settings.css'), ENT_QUOTES, 'UTF-8'); ?>">
+  <script src="<?php echo htmlspecialchars(asset_url('/assets/navigation.js'), ENT_QUOTES, 'UTF-8'); ?>" data-pa-shell-asset defer></script>
   <!-- Settings and Workforce use delegated, idempotent initializers. Loading
        them with the authenticated shell keeps soft navigation identical to a
        hard reload, even when a page fragment contains no executable scripts. -->
-  <script src="<?php echo htmlspecialchars(asset_url('/assets/js/item-library.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
-  <script src="<?php echo htmlspecialchars(asset_url('/assets/js/workforce.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
-  <script src="<?php echo htmlspecialchars(asset_url('/assets/item-autocomplete.js'), ENT_QUOTES, 'UTF-8'); ?>" defer></script>
+  <script src="<?php echo htmlspecialchars(asset_url('/assets/js/item-library.js'), ENT_QUOTES, 'UTF-8'); ?>" data-pa-shell-asset defer></script>
+  <script src="<?php echo htmlspecialchars(asset_url('/assets/js/workforce.js'), ENT_QUOTES, 'UTF-8'); ?>" data-pa-shell-asset defer></script>
+  <script src="<?php echo htmlspecialchars(asset_url('/assets/item-autocomplete.js'), ENT_QUOTES, 'UTF-8'); ?>" data-pa-shell-asset defer></script>
   <script>
     (function() {
       var timer = null;

--- a/tests/Database/WorkforceRedesignDatabaseTest.php
+++ b/tests/Database/WorkforceRedesignDatabaseTest.php
@@ -170,7 +170,11 @@ final class WorkforceRedesignDatabaseTest extends TestCase
             'billing_treatment' => 'nonbillable',
             'entered_by_user_id' => $ownerUserId,
         ]);
-        $approval->selfConfirmOwner($ownerUserId, $ownerEntryId);
+        // A verified owner can recover a pending entry selected for an invoice;
+        // older deployments could leave this state submitted before linking.
+        $pdo->prepare("UPDATE work_time_entries SET workflow_status='submitted' WHERE id=?")
+            ->execute([$ownerEntryId]);
+        $approval->ensureOwnerProjection($ownerUserId, $ownerEntryId);
         self::assertSame('confirmed', $this->value($pdo, 'SELECT workflow_status FROM work_time_entries WHERE id=?', [$ownerEntryId]));
         self::assertSame('owner_no_pay', $this->value($pdo, 'SELECT compensation_state FROM work_time_entries WHERE id=?', [$ownerEntryId]));
         self::assertSame('0', $this->value($pdo, 'SELECT COUNT(*) FROM worker_earnings WHERE work_time_entry_id=?', [$ownerEntryId]));

--- a/tests/Workflows/ProjectWorkflowUiTest.php
+++ b/tests/Workflows/ProjectWorkflowUiTest.php
@@ -496,6 +496,9 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString('function registerPageInitializer', (string)$navigation);
         self::assertStringContainsString('runPageCleanups();', (string)$navigation);
         self::assertStringContainsString('runPageInitializers(page, mainContent);', (string)$navigation);
+        self::assertStringContainsString('function shellAssetSignature', (string)$navigation);
+        self::assertStringContainsString('content.reloadRequired', (string)$navigation);
+        self::assertStringContainsString("urlParams.delete('page')", (string)$navigation);
         self::assertStringContainsString('link[rel~="stylesheet"][href]', (string)$navigation);
         self::assertStringContainsString('await ensurePageStylesheets(stylesheets);', (string)$navigation);
         self::assertStringContainsString("link.dataset.pageStylesheet = '1'", (string)$navigation);
@@ -524,6 +527,8 @@ final class ProjectWorkflowUiTest extends TestCase
         self::assertStringContainsString("\$_SERVER['DOCUMENT_ROOT']", (string)$appVersion);
         self::assertStringContainsString("asset_url('/assets/styles.css')", (string)$header);
         self::assertStringContainsString("asset_url('/assets/settings.css')", (string)$header);
+        self::assertStringContainsString('meta name="project-alpha-version"', (string)$header);
+        self::assertSame(6, substr_count((string)$header, 'data-pa-shell-asset'));
         self::assertStringContainsString("asset_url('/assets/js/item-library.js')", (string)$header);
         self::assertStringContainsString("asset_url('/assets/js/workforce.js')", (string)$header);
         self::assertStringNotContainsString("asset_url('/assets/settings.css')", (string)$settings);

--- a/tests/Workflows/TimekeepingDeferredWorkflowTest.php
+++ b/tests/Workflows/TimekeepingDeferredWorkflowTest.php
@@ -20,6 +20,8 @@ final class TimekeepingDeferredWorkflowTest extends TestCase
         $controller = (string)file_get_contents($this->root . '/src/controllers/workforce/action.php');
 
         self::assertStringContainsString('public function selfConfirmOwner', $approval);
+        self::assertStringContainsString('public function ensureOwnerProjection', $approval);
+        self::assertStringContainsString("['draft','returned','submitted']", $approval);
         self::assertStringContainsString('$effectivePayable = !$ownerSelfConfirmation', $approval);
         self::assertStringContainsString('if(!$ownerSelfConfirmation&&!empty($entry[\'work_assignment_id\']))', $approval);
         self::assertStringContainsString("'time_entry.owner_self_confirmed'", $approval);

--- a/tests/Workflows/TrackedTimeInvoiceAggregationTest.php
+++ b/tests/Workflows/TrackedTimeInvoiceAggregationTest.php
@@ -43,6 +43,13 @@ final class TrackedTimeInvoiceAggregationTest extends TestCase
         self::assertStringContainsString('name="invoice_id" data-workforce-invoice', $timeView);
         self::assertStringContainsString('Add confirmed time to this draft', $invoiceEdit);
         self::assertStringContainsString("t.status='approved' AND t.workflow_status='confirmed'", $invoiceEdit);
+        self::assertStringContainsString("t.workflow_status IN ('draft','submitted','returned')", $invoiceEdit);
+        self::assertStringContainsString('Time waiting for confirmation', $invoiceEdit);
+        self::assertStringContainsString('Confirm and add', $invoiceEdit);
+        self::assertStringContainsString('name="entry_user_id"', $invoiceEdit);
+        self::assertStringContainsString('Available after confirmation', $timeView);
+        self::assertStringContainsString("!empty(\$_GET['error'])", $invoiceEdit);
+        self::assertStringContainsString('role="alert"', $invoiceEdit);
         self::assertStringContainsString('name="return_to" value="invoice-edit"', $invoiceEdit);
         self::assertStringContainsString('workforce_link_preselected_invoice', $workforceAction);
         self::assertStringContainsString("=== 'invoice-edit'", $workforceAction);


### PR DESCRIPTION
## What changed

- Show submitted matching time entries in the draft invoice editor with the correct confirmation or review action.
- Allow verified owners to confirm and attach their own submitted time while preserving employee and contractor review controls.
- Correct workforce billing labels so unconfirmed time is not presented as ready to invoice.
- Reload stale shell CSS and JavaScript automatically during soft navigation.
- Preserve Settings query parameters through navigation and browser history.
- Document the workflow and add regression coverage.

## Why

Draft invoices previously hid submitted but unconfirmed time, making attachment failures appear silent. Long-lived browser shells could also retain stale assets until a manual refresh.

## Validation

- Full suite: 348 tests, 2,845 assertions
- Focused promotion suite: 49 tests, 657 assertions
- PHP and JavaScript syntax checks
- Git whitespace validation