### PR TITLE
Restore external ops migration checksum

### DIFF
--- a/database/migrations/0049_external_ops_integration.sql
+++ b/database/migrations/0049_external_ops_integration.sql
@@ -1,6 +1,5 @@
 -- Optional external operations projection and entitlement synchronization.
--- Optional external operations integration. The application key is configured
--- per deployment.
+-- Optional LTDS Operations integration. The application contract uses ltds_ops;
 -- the column remains explicit so webhook and snapshot records are self-describing.
 
 CREATE TABLE IF NOT EXISTS application_entitlements (


### PR DESCRIPTION
## Fix

Restore `0049_external_ops_integration.sql` to its exact previously published content and checksum.

The integration release changed only comments in this immutable, already-applied migration. Project Alpha correctly rejected that checksum drift before applying migration 0054.

## Validation

- Git blob matches the pre-release `0049` blob exactly: `80605ba75b22d11c859a4df3049baf58e5e2790d`
- Migration and External Operations suites: 24 tests, 128 assertions
- `git diff --check` passed
