### PR TITLE
Harden external operations integration

### DIFF
--- a/src/controllers/project/project_work_handler.php
+++ b/src/controllers/project/project_work_handler.php
@@ -70,7 +70,20 @@ try {
         foreach (array_unique($affectedUsers) as $userId) {
             $integration->resyncAccountAccess($pdo, (int)$userId, (string)$config['application_key'], $actorUserId);
         }
-        foreach($events as [$entityType,$eventEntityId,$eventAction,$eventData]){$eventData['updated_at']=gmdate('Y-m-d\TH:i:s.u\Z');$integration->enqueueProjectionChange($pdo,(string)$config['application_key'],$entityType,$eventEntityId,$eventAction,$eventData);}
+        foreach ($events as [$entityType, $eventEntityId, $eventAction, $eventData]) {
+            if (empty($eventData['updated_at'])) {
+                $eventData['updated_at'] = (new DateTimeImmutable('now', new DateTimeZone('UTC')))
+                    ->format('Y-m-d\TH:i:s.u\Z');
+            }
+            $integration->enqueueProjectionChange(
+                $pdo,
+                (string)$config['application_key'],
+                $entityType,
+                $eventEntityId,
+                $eventAction,
+                $eventData
+            );
+        }
     }
     header('Location: ' . $redirect . '&saved=1#team-work');
 } catch (Throwable $error) {

--- a/src/link_resolvers/auto_resolver/s3_link_resolver.php
+++ b/src/link_resolvers/auto_resolver/s3_link_resolver.php
@@ -432,7 +432,7 @@ class S3LinkResolver
                 $this->fail(
                     'create folder link',
                     'S3/R2 storage is connected, but no public Worker/base URL is configured.',
-                    'Enter the LTDS-Ops Worker or R2 custom-domain URL used by clients. PA will append the matched folder prefix.'
+                    'Enter the external delivery Worker or R2 custom-domain URL used by clients. PA will append the matched folder prefix.'
                 );
                 return null;
             }

--- a/src/services/ExternalOpsIntegrationService.php
+++ b/src/services/ExternalOpsIntegrationService.php
@@ -20,6 +20,48 @@ final class ExternalOpsIntegrationService
     ];
 
     /**
+     * Incremental events use the same least-privilege boundary as the full
+     * snapshot. Keep this allowlist here so a future caller cannot expose a
+     * pay-rate override, private sharing token, password hash, or unrelated
+     * accounting field by passing a raw database row.
+     *
+     * @var array<string,list<string>>
+     */
+    private const PROJECTION_FIELDS = [
+        'business_unit' => [
+            'id', 'name', 'code', 'description', 'is_active', 'created_by',
+            'created_at', 'updated_at',
+        ],
+        'project' => [
+            'id', 'client_id', 'parent_id', 'organization_id', 'department_id',
+            'business_unit_id', 'created_by', 'name', 'description', 'status',
+            'start_date', 'end_date', 'estimated_start', 'estimated_end',
+            'created_at', 'updated_at',
+        ],
+        'project_assignment' => [
+            'id', 'project_id', 'user_id', 'assigned_at', 'ends_at',
+            'created_by', 'created_at', 'updated_at', 'active',
+        ],
+        'operation' => [
+            'id', 'project_id', 'business_unit_id', 'title', 'status',
+            'scheduled_start_at', 'scheduled_end_at', 'location', 'notes',
+            'created_by', 'created_at', 'updated_at',
+        ],
+        'operation_assignment' => [
+            'operation_id', 'user_id', 'assignment_role', 'assigned_by',
+            'assigned_at', 'updated_at',
+        ],
+        'task' => [
+            'id', 'operation_id', 'project_id', 'business_unit_id',
+            'assignee_user_id', 'title', 'status', 'due_at', 'notes',
+            'created_by', 'created_at', 'updated_at',
+        ],
+        'task_assignment' => [
+            'task_id', 'user_id', 'assigned_by', 'assigned_at', 'updated_at',
+        ],
+    ];
+
+    /**
      * Save a deliberate access exception. Project Team membership is tracked
      * separately as automatic access and can never be erased by this method.
      *
@@ -260,7 +302,11 @@ final class ExternalOpsIntegrationService
         if (!in_array($action, ['upsert', 'revoke'], true)) {
             throw new DomainException('Invalid projection action.');
         }
+        if (!isset(self::PROJECTION_FIELDS[$entityType])) {
+            throw new DomainException('Unsupported projection entity type.');
+        }
         $applicationKey = self::normalizeApplicationKey($applicationKey);
+        $data = array_intersect_key($data, array_fill_keys(self::PROJECTION_FIELDS[$entityType], true));
         $eventId = $this->uuidV4();
         $occurredAt = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d\TH:i:s.u\Z');
         $sourceUpdatedAt = $occurredAt;

--- a/src/views/pages/settings/external-ops.php
+++ b/src/views/pages/settings/external-ops.php
@@ -12,29 +12,111 @@ $search = trim((string)($_GET['access_search'] ?? ''));
 $pageNumber = max(1, (int)($_GET['access_page'] ?? 1));
 $pageSize = 20;
 $offset = ($pageNumber - 1) * $pageSize;
-$where = 'e.application_key=? AND e.enabled=1';
-$params = [$applicationKey];
-if ($search !== '') {
-    $where .= ' AND (u.display_name LIKE ? OR u.username LIKE ? OR u.email LIKE ?)';
-    $term = '%' . $search . '%';
-    array_push($params, $term, $term, $term);
-}
-$countStmt = $pdo->prepare("SELECT COUNT(*) FROM application_entitlements e JOIN users u ON u.id=e.user_id WHERE {$where}");
-$countStmt->execute($params);
-$accessCount = (int)$countStmt->fetchColumn();
-$accessStmt = $pdo->prepare("SELECT e.*,u.display_name,u.username,u.email,u.role,u.is_disabled,u.deleted_at FROM application_entitlements e JOIN users u ON u.id=e.user_id WHERE {$where} ORDER BY COALESCE(NULLIF(u.display_name,''),NULLIF(u.username,''),u.email) LIMIT {$pageSize} OFFSET {$offset}");
-$accessStmt->execute($params);
-$accessUsers = $accessStmt->fetchAll(PDO::FETCH_ASSOC);
-$eligibleUsers = $pdo->query("SELECT id,COALESCE(NULLIF(display_name,''),NULLIF(username,''),email) name,email FROM users WHERE is_disabled=0 AND deleted_at IS NULL ORDER BY name LIMIT 250")->fetchAll(PDO::FETCH_ASSOC);
-$units = $pdo->query('SELECT id,name,is_active FROM business_units ORDER BY is_active DESC,name')->fetchAll(PDO::FETCH_ASSOC);
 $detailUserId = max(0, (int)($_GET['access_user_id'] ?? 0));
-$accessDetail = null;$projectSources=[];$manualUnits=[];
-if ($detailUserId > 0) {
-    $detailStmt=$pdo->prepare('SELECT e.*,u.display_name,u.username,u.email,u.role,u.is_disabled,u.deleted_at FROM application_entitlements e JOIN users u ON u.id=e.user_id WHERE e.application_key=? AND e.user_id=?');$detailStmt->execute([$applicationKey,$detailUserId]);$accessDetail=$detailStmt->fetch(PDO::FETCH_ASSOC)?:null;
-    $sourceStmt=$pdo->prepare('SELECT p.id,p.name,bu.name business_unit_name FROM project_assignments pa JOIN projects p ON p.id=pa.project_id LEFT JOIN business_units bu ON bu.id=p.business_unit_id WHERE pa.user_id=? AND (pa.ends_at IS NULL OR pa.ends_at>UTC_TIMESTAMP(6)) ORDER BY p.name');$sourceStmt->execute([$detailUserId]);$projectSources=$sourceStmt->fetchAll(PDO::FETCH_ASSOC);
-    $unitStmt=$pdo->prepare('SELECT bu.id,bu.name FROM application_entitlements e JOIN application_entitlement_oversight_units eu ON eu.entitlement_id=e.id JOIN business_units bu ON bu.id=eu.business_unit_id WHERE e.application_key=? AND e.user_id=? ORDER BY bu.name');$unitStmt->execute([$applicationKey,$detailUserId]);$manualUnits=$unitStmt->fetchAll(PDO::FETCH_ASSOC);
+$accessCount = 0;
+$accessUsers = [];
+$eligibleUsers = [];
+$units = [];
+$accessDetail = null;
+$projectSources = [];
+$manualUnits = [];
+$status = [];
+$directoryError = false;
+
+// The configuration form must remain available even when the optional
+// integration is disabled or its supporting schema needs attention.
+if (!empty($config['enabled'])) {
+    try {
+        $where = 'e.application_key=? AND e.enabled=1';
+        $params = [$applicationKey];
+        if ($search !== '') {
+            $where .= ' AND (wp.display_name LIKE ? OR u.username LIKE ? OR u.email LIKE ?)';
+            $term = '%' . $search . '%';
+            array_push($params, $term, $term, $term);
+        }
+
+        $countStmt = $pdo->prepare(
+            "SELECT COUNT(*)
+             FROM application_entitlements e
+             JOIN users u ON u.id=e.user_id
+             LEFT JOIN worker_profiles wp ON wp.user_id=u.id
+             WHERE {$where}"
+        );
+        $countStmt->execute($params);
+        $accessCount = (int)$countStmt->fetchColumn();
+
+        $accessStmt = $pdo->prepare(
+            "SELECT e.*,wp.display_name,u.username,u.email,u.role,u.is_disabled,u.deleted_at
+             FROM application_entitlements e
+             JOIN users u ON u.id=e.user_id
+             LEFT JOIN worker_profiles wp ON wp.user_id=u.id
+             WHERE {$where}
+             ORDER BY COALESCE(NULLIF(wp.display_name,''),NULLIF(u.username,''),u.email)
+             LIMIT {$pageSize} OFFSET {$offset}"
+        );
+        $accessStmt->execute($params);
+        $accessUsers = $accessStmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $eligibleUsers = $pdo->query(
+            "SELECT u.id,COALESCE(NULLIF(wp.display_name,''),NULLIF(u.username,''),u.email) name,u.email
+             FROM users u
+             LEFT JOIN worker_profiles wp ON wp.user_id=u.id
+             WHERE u.is_disabled=0 AND u.deleted_at IS NULL
+             ORDER BY name
+             LIMIT 250"
+        )->fetchAll(PDO::FETCH_ASSOC);
+        $units = $pdo->query(
+            'SELECT id,name,is_active FROM business_units ORDER BY is_active DESC,name'
+        )->fetchAll(PDO::FETCH_ASSOC);
+
+        if ($detailUserId > 0) {
+            $detailStmt = $pdo->prepare(
+                'SELECT e.*,wp.display_name,u.username,u.email,u.role,u.is_disabled,u.deleted_at
+                 FROM application_entitlements e
+                 JOIN users u ON u.id=e.user_id
+                 LEFT JOIN worker_profiles wp ON wp.user_id=u.id
+                 WHERE e.application_key=? AND e.user_id=?'
+            );
+            $detailStmt->execute([$applicationKey, $detailUserId]);
+            $accessDetail = $detailStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+
+            $sourceStmt = $pdo->prepare(
+                'SELECT p.id,p.name,bu.name business_unit_name
+                 FROM project_assignments pa
+                 JOIN projects p ON p.id=pa.project_id
+                 LEFT JOIN business_units bu ON bu.id=p.business_unit_id
+                 WHERE pa.user_id=? AND (pa.ends_at IS NULL OR pa.ends_at>UTC_TIMESTAMP(6))
+                 ORDER BY p.name'
+            );
+            $sourceStmt->execute([$detailUserId]);
+            $projectSources = $sourceStmt->fetchAll(PDO::FETCH_ASSOC);
+
+            $unitStmt = $pdo->prepare(
+                'SELECT bu.id,bu.name
+                 FROM application_entitlements e
+                 JOIN application_entitlement_oversight_units eu ON eu.entitlement_id=e.id
+                 JOIN business_units bu ON bu.id=eu.business_unit_id
+                 WHERE e.application_key=? AND e.user_id=?
+                 ORDER BY bu.name'
+            );
+            $unitStmt->execute([$applicationKey, $detailUserId]);
+            $manualUnits = $unitStmt->fetchAll(PDO::FETCH_ASSOC);
+        }
+
+        $statusStmt = $pdo->prepare(
+            'SELECT SUM(CASE WHEN delivered_at IS NULL THEN 1 ELSE 0 END) pending,
+                    SUM(CASE WHEN delivered_at IS NULL AND attempts>0 AND last_error IS NOT NULL THEN 1 ELSE 0 END) failed,
+                    MAX(delivered_at) last_delivered_at
+             FROM integration_outbox
+             WHERE integration_key=?'
+        );
+        $statusStmt->execute([$applicationKey]);
+        $status = $statusStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    } catch (Throwable $error) {
+        $directoryError = true;
+        error_log('[external_ops_settings] Failed to load access directory: ' . $error->getMessage());
+    }
 }
-$statusStmt=$pdo->prepare('SELECT SUM(CASE WHEN delivered_at IS NULL THEN 1 ELSE 0 END) pending,SUM(CASE WHEN delivered_at IS NULL AND attempts>0 AND last_error IS NOT NULL THEN 1 ELSE 0 END) failed,MAX(delivered_at) last_delivered_at FROM integration_outbox WHERE integration_key=?');$statusStmt->execute([$applicationKey]);$status=$statusStmt->fetch(PDO::FETCH_ASSOC)?:[];
 ?>
 <div class="settings-alert settings-alert-warning"><strong>Optional custom integration.</strong> Project Alpha is the source of truth. The external application receives read-only, signed, assignment-driven updates plus reconciliation snapshots.</div>
 <div class="settings-card"><h3>Custom integration setup</h3><form method="post" action="/?page=settings/external-ops-handler"><input type="hidden" name="csrf" value="<?=$h(csrf_token())?>"><input type="hidden" name="action" value="save-config"><div class="settings-form-grid">
@@ -45,6 +127,7 @@ $statusStmt=$pdo->prepare('SELECT SUM(CASE WHEN delivered_at IS NULL THEN 1 ELSE
 <label class="field"><span class="label">Access service-token ID</span><input class="input" type="password" name="access_client_id" autocomplete="new-password" placeholder="<?=!empty($config['access_client_id'])?'Configured — leave blank to keep':'Service-token ID'?>"></label><label class="field"><span class="label">Access service-token secret</span><input class="input" type="password" name="access_client_secret" autocomplete="new-password" placeholder="<?=!empty($config['access_client_secret'])?'Configured — leave blank to keep':'Service-token secret'?>"></label>
 <label class="field" style="grid-column:1/-1"><span class="label">HMAC secret</span><input class="input" type="password" name="hmac_secret" minlength="32" autocomplete="new-password" placeholder="<?=!empty($config['hmac_secret'])?'Configured — leave blank to keep':'Same 32+ character secret as the receiver'?>"></label><label class="field"><span class="label">Timeout seconds</span><input class="input" type="number" name="timeout_seconds" min="2" max="60" value="<?=(int)$config['timeout_seconds']?>"></label><label class="field"><span class="label">Maximum attempts</span><input class="input" type="number" name="max_attempts" min="1" max="100" value="<?=(int)$config['max_attempts']?>"></label></div><button class="btn btn-primary">Save integration</button></form></div>
 <?php if(empty($config['enabled'])):?><div class="settings-alert settings-alert-info">Enable and save the integration to manage access exceptions and delivery.</div><?php return;endif;?>
+<?php if($directoryError):?><div class="settings-alert settings-alert-danger" role="alert"><strong>Integration settings could not be loaded.</strong> Verify that all database migrations have completed, then reload this page.</div><?php return;endif;?>
 <div class="settings-card"><div class="settings-section-heading"><h3>Effective access</h3><p>Active Project Team memberships grant access automatically. Manual exceptions are for read-only Business Unit oversight; only a PA administrator can receive global access.</p></div>
 <form method="get" class="settings-form-grid"><input type="hidden" name="page" value="settings"><input type="hidden" name="tab" value="external-ops"><label class="field"><span class="label">Search access directory</span><input class="input" name="access_search" value="<?=$h($search)?>" placeholder="Name or email"></label><div><button class="btn">Search</button></div></form>
 <div class="pa-table-wrap"><table class="pa-table"><thead><tr><th>User</th><th>Access source</th><th>Effective role</th><th>Account</th><th></th></tr></thead><tbody><?php foreach($accessUsers as $user):?><tr><td><strong><?=$h($user['display_name']?:$user['username']?:$user['email'])?></strong><small><?=$h(strtolower((string)$user['email']))?></small></td><td><?=!empty($user['automatic_enabled'])?'Project Team':''?><?=!empty($user['automatic_enabled'])&&!empty($user['manual_enabled'])?' + ':''?><?=!empty($user['manual_enabled'])?'Manual exception':''?></td><td><?=$user['role']==='admin'?'Global administrator':'Operator / unit viewer'?></td><td><?=!empty($user['is_disabled'])||!empty($user['deleted_at'])?'Inactive':'Active'?></td><td><a class="btn btn-sm" href="/?page=settings&amp;tab=external-ops&amp;access_user_id=<?=(int)$user['user_id']?>">Details</a></td></tr><?php endforeach;?><?php if(!$accessUsers):?><tr><td colspan="5">No matching effective access.</td></tr><?php endif;?></tbody></table></div>

--- a/src/views/pages/settings/links.php
+++ b/src/views/pages/settings/links.php
@@ -433,7 +433,7 @@ $dropboxCallbackUri = rtrim($dropboxCallbackBase, '/') . '/?page=settings/dropbo
                         </label>
                     </div>
                     <label>
-                        <div style="margin-bottom:4px;font-weight:600">LTDS-Ops Worker / Public Base URL<?php echo $helpIcon('The Worker or R2 custom-domain URL that clients open. PA appends the matched folder prefix. You may place {prefix} in the URL as a template.'); ?></div>
+                        <div style="margin-bottom:4px;font-weight:600">External delivery Worker / Public Base URL<?php echo $helpIcon('The Worker or R2 custom-domain URL that clients open. PA appends the matched folder prefix. You may place {prefix} in the URL as a template.'); ?></div>
                         <input type="text" name="<?php echo e($provider); ?>_public_base_url"
                                value="<?php echo e($credentials['public_base_url'] ?? ''); ?>"
                                placeholder="https://files.example.com/"

--- a/tests/Workflows/ExternalOpsIntegrationTest.php
+++ b/tests/Workflows/ExternalOpsIntegrationTest.php
@@ -45,6 +45,10 @@ final class ExternalOpsIntegrationTest extends TestCase
         self::assertStringContainsString('name="access_client_secret"', $page);
         self::assertStringContainsString('name="hmac_secret"', $page);
         self::assertStringContainsString('name="application_key"', $page);
+        self::assertStringContainsString('LEFT JOIN worker_profiles wp ON wp.user_id=u.id', $page);
+        self::assertStringContainsString('wp.display_name', $page);
+        self::assertStringNotContainsString('u.display_name', $page);
+        self::assertStringContainsString('Integration settings could not be loaded.', $page);
         self::assertStringNotContainsString('Fixed by', $page);
         self::assertStringNotContainsString('name="role_key"', $page);
         self::assertStringContainsString("'role-admin'", $migration);
@@ -523,6 +527,49 @@ final class ExternalOpsIntegrationTest extends TestCase
         $state=$this->pdo->query("SELECT enabled,automatic_enabled FROM application_entitlements WHERE user_id=2 AND application_key='field_operations'")->fetch(PDO::FETCH_ASSOC);
         self::assertSame(0,(int)$state['enabled']);
         self::assertSame(0,(int)$state['automatic_enabled']);
+    }
+
+    public function testIncrementalProjectionEventsExcludeSensitiveAndUnrelatedFields(): void
+    {
+        $service = new ExternalOpsIntegrationService();
+        $service->enqueueProjectionChange($this->pdo, 'field_operations', 'project', 40, 'upsert', [
+            'id' => 40,
+            'name' => 'Safe project name',
+            'business_unit_id' => 30,
+            'public_project_token' => 'private-sharing-token',
+            'public_project_password_hash' => 'private-password-hash',
+            'invoice_net_terms_days' => 30,
+            'updated_at' => '2026-07-22T05:00:00.123456Z',
+        ]);
+        $projectPayload = $this->latestPayload();
+        self::assertSame('Safe project name', $projectPayload['projection']['data']['name']);
+        self::assertArrayNotHasKey('public_project_token', $projectPayload['projection']['data']);
+        self::assertArrayNotHasKey('public_project_password_hash', $projectPayload['projection']['data']);
+        self::assertArrayNotHasKey('invoice_net_terms_days', $projectPayload['projection']['data']);
+
+        $service->enqueueProjectionChange($this->pdo, 'field_operations', 'project_assignment', 1, 'upsert', [
+            'id' => 1,
+            'project_id' => 40,
+            'user_id' => 2,
+            'pay_rate_override' => '250.00',
+            'updated_at' => '2026-07-22T05:00:01.123456Z',
+        ]);
+        $assignmentPayload = $this->latestPayload();
+        self::assertArrayNotHasKey('pay_rate_override', $assignmentPayload['projection']['data']);
+        self::assertSame(40, $assignmentPayload['projection']['data']['project_id']);
+    }
+
+    public function testIncrementalProjectionRejectsUnknownEntityTypes(): void
+    {
+        $this->expectException(\DomainException::class);
+        (new ExternalOpsIntegrationService())->enqueueProjectionChange(
+            $this->pdo,
+            'field_operations',
+            'payment',
+            1,
+            'upsert',
+            ['amount' => '100.00']
+        );
     }
 
     /** @param list<string> $headers */

--- a/tests/Workflows/FinancialSchedulingTest.php
+++ b/tests/Workflows/FinancialSchedulingTest.php
@@ -96,6 +96,8 @@ final class FinancialSchedulingTest extends TestCase
         self::assertStringContainsString("'daily_link_resolver'", (string)$state);
         self::assertStringContainsString("['daily_link_resolver']", (string)$settings);
         self::assertStringContainsString('Nightly folder scan:', (string)$settings);
+        self::assertStringContainsString('External delivery Worker / Public Base URL', (string)$settings);
+        self::assertStringNotContainsString('LTDS-Ops Worker', (string)$settings);
     }
 
     public function testAuditAndOrganizationScriptsInitializeAfterAjaxNavigation(): void


### PR DESCRIPTION
## Summary

- fix the blank Custom integrations page by loading display names from worker profiles and rendering a recoverable migration error
- restrict incremental external-operations payloads to the same least-privilege data boundary as snapshots
- preserve source timestamps for receiver idempotency and out-of-order protection
- replace deployment-specific LTDS-Ops labels in reusable Project Alpha UI

## Impact

Project Alpha can safely publish generic, assignment-driven operations updates to a deployment-configured receiver. Existing configuration remains compatible, while forks may use their own application key, label, URL, and Cloudflare resources.

## Validation

- full PHPUnit suite: 354 tests, 2,892 assertions; 57 environment-dependent skips
- focused external operations and link resolver suite: 31 tests, 190 assertions
- PHP syntax checks for changed runtime files
- Git whitespace validation
