### PR TITLE
Harden session and OAuth lifecycle

### DIFF
--- a/database/migrations/0057_session_revocation_tombstones.sql
+++ b/database/migrations/0057_session_revocation_tombstones.sql
@@ -1,0 +1,5 @@
+-- Preserve revoked session identifiers long enough to prevent delayed requests
+-- from recreating authenticated state after logout, expiry, or rotation.
+ALTER TABLE app_sessions
+    ADD COLUMN revoked_at DATETIME(6) NULL AFTER absolute_expires_at,
+    ADD INDEX idx_app_sessions_revoked (revoked_at);

--- a/public/index.php
+++ b/public/index.php
@@ -1,21 +1,20 @@
 <?php
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../src/config/db.php';
+require_once __DIR__ . '/../src/utils/request_security.php';
 // Secure session cookies and start session
-$isSecure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on')
-    || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
-    || (!empty($_SERVER['HTTP_CF_VISITOR']) && strpos((string)$_SERVER['HTTP_CF_VISITOR'], 'https') !== false)
-    || (!empty($_SERVER['HTTP_X_SCHEME']) && strtolower((string)$_SERVER['HTTP_X_SCHEME']) === 'https');
+$isSecure = request_is_https();
+ini_set('session.use_strict_mode', '1');
 session_set_cookie_params([
     'lifetime' => 0,
     'path' => '/',
     'domain' => '',
     'secure' => $isSecure,
     'httponly' => true,
-    'samesite' => 'Strict',
+    'samesite' => 'Lax',
 ]);
 if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_set_save_handler(new App\Security\DatabaseSessionHandler($pdo, 900, 7 * 24 * 60 * 60), true);
+    session_set_save_handler(new App\Security\DatabaseSessionHandler($pdo), true);
     session_start();
 }
 ob_start();
@@ -269,9 +268,16 @@ if ($apiEnabled && substr($page, 0, 4) === 'api-' && !str_starts_with($page, 'ap
 
 // Handle logout early
 if ($page === 'logout') {
-    // Start session if not already started
-    if (session_status() !== PHP_SESSION_ACTIVE) {
-        session_start();
+    // SameSite=Lax sends cookies on cross-site top-level GETs, so logout must
+    // remain a same-origin, CSRF-protected mutation.
+    $logoutToken = (string)($_POST['csrf'] ?? '');
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST'
+        || empty($_SESSION['csrf'])
+        || !hash_equals((string)$_SESSION['csrf'], $logoutToken)) {
+        http_response_code(405);
+        header('Allow: POST');
+        header('Content-Type: text/plain; charset=UTF-8');
+        exit('Logout requires a same-origin POST request.');
     }
     
     // Audit the logout before clearing session
@@ -387,7 +393,7 @@ if ($authDisabled && empty($_SESSION['user']) && !in_array($page, $publicPages, 
                     $activeOrgId = 0;
                 }
             }
-            session_regenerate_id(true);
+            App\Security\SessionPolicy::rotateAuthenticatedId();
             $_SESSION['user'] = [
                 'id' => (int)$bypassUser['id'],
                 'email' => (string)$bypassUser['email'],
@@ -396,7 +402,7 @@ if ($authDisabled && empty($_SESSION['user']) && !in_array($page, $publicPages, 
                 'active_org_id' => $activeOrgId,
                 'auth_bypass' => true,
             ];
-            $_SESSION['last_activity'] = time();
+            App\Security\SessionPolicy::completeAuthentication('development_bypass');
             if (empty($_SESSION['auth_bypass_logged'])) {
                 error_log('[security] Development auth bypass signed in user id ' . (int)$bypassUser['id']);
                 $_SESSION['auth_bypass_logged'] = 1;
@@ -446,7 +452,7 @@ if (!empty($_SESSION['user'])) {
         exit;
     }
 
-    $sessionTimeout = 15 * 60;
+    $sessionTimeout = App\Security\SessionPolicy::IDLE_SECONDS;
     if (isset($_SESSION['last_activity']) && (time() - $_SESSION['last_activity']) > $sessionTimeout) {
         $_SESSION = [];
         session_destroy();
@@ -457,8 +463,8 @@ if (!empty($_SESSION['user'])) {
         header('Location: /?page=login&error=' . urlencode('Session expired. Please log in again.'));
         exit;
     }
-    // Passive status polling must not keep an otherwise inactive session alive.
-    if ($page !== 'session-status') {
+    // Only explicitly classified user activity refreshes the idle deadline.
+    if (App\Security\SessionPolicy::isIntentionalActivity($page, $_GET)) {
         $_SESSION['last_activity'] = time();
     }
 }
@@ -593,7 +599,7 @@ if ($page === 'settings/dropbox-oauth') {
     require_once __DIR__ . '/../src/controllers/settings/dropbox_oauth.php';
     exit;
 }
-if ($page === 'settings/gmail-oauth' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+if ($page === 'settings/gmail-oauth') {
     require_once __DIR__ . '/../src/controllers/settings/gmail_oauth.php';
     exit;
 }

--- a/src/Security/AccountSessionPolicy.php
+++ b/src/Security/AccountSessionPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+final class AccountSessionPolicy
+{
+    /**
+     * @param array<string,mixed> $before
+     * @param array<string,mixed> $after
+     */
+    public static function requiresGlobalRevocation(array $before, array $after, bool $permissionsChanged): bool
+    {
+        foreach (['email', 'username', 'role', 'is_disabled', 'force_password_reset'] as $field) {
+            if ((string)($before[$field] ?? '') !== (string)($after[$field] ?? '')) {
+                return true;
+            }
+        }
+        return $permissionsChanged;
+    }
+}

--- a/src/Security/DatabaseSessionHandler.php
+++ b/src/Security/DatabaseSessionHandler.php
@@ -5,61 +5,250 @@ declare(strict_types=1);
 namespace App\Security;
 
 use PDO;
+use RuntimeException;
 use SessionHandlerInterface;
+use SessionUpdateTimestampHandlerInterface;
 
-final class DatabaseSessionHandler implements SessionHandlerInterface
+final class DatabaseSessionHandler implements SessionHandlerInterface, SessionUpdateTimestampHandlerInterface
 {
+    /** @var array<string,string> hash => lock name */
+    private array $locks = [];
+    /** @var array<string,'active'|'new'|'revoked'> */
+    private array $states = [];
+    private ?string $preservedAbsoluteDeadline = null;
+    private int $requestStartedAt;
+
     public function __construct(
         private readonly PDO $pdo,
-        private readonly int $idleSeconds = 900,
-        private readonly int $absoluteSeconds = 604800
-    ) {}
+        private readonly int $idleSeconds = SessionPolicy::IDLE_SECONDS,
+        private readonly int $absoluteSeconds = SessionPolicy::ABSOLUTE_SECONDS,
+        private readonly int $lockWaitSeconds = 30
+    ) {
+        $this->requestStartedAt = time();
+    }
 
     public function open(string $path, string $name): bool { return true; }
-    public function close(): bool { return true; }
+
+    public function close(): bool
+    {
+        $ok = true;
+        foreach ($this->locks as $lockName) {
+            try {
+                $stmt = $this->pdo->prepare('SELECT RELEASE_LOCK(?)');
+                $stmt->execute([$lockName]);
+                $ok = (int)$stmt->fetchColumn() === 1 && $ok;
+            } catch (\Throwable) {
+                $ok = false;
+            }
+        }
+        $this->locks = [];
+        $this->states = [];
+        $this->preservedAbsoluteDeadline = null;
+        return $ok;
+    }
 
     public function read(string $id): string|false
     {
-        $stmt = $this->pdo->prepare(
-            'SELECT payload FROM app_sessions
-             WHERE session_hash=? AND last_activity_at>=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL ? SECOND)
-             AND absolute_expires_at>UTC_TIMESTAMP(6) LIMIT 1'
-        );
-        $stmt->execute([$this->hash($id), $this->idleSeconds]);
-        $payload = $stmt->fetchColumn();
-        if ($payload === false) {
-            $this->destroy($id);
+        $hash = $this->hash($id);
+        $this->lock($hash);
+        $row = $this->row($hash);
+        if ($row === null) {
+            $this->states[$hash] = 'new';
             return '';
         }
-        return (string) $payload;
+        if (!$this->rowIsActive($row)) {
+            $this->tombstone($hash);
+            $this->states[$hash] = 'revoked';
+            return '';
+        }
+        $this->states[$hash] = 'active';
+        $rowDeadline = (string)$row['absolute_expires_at'];
+        if (strtotime($rowDeadline . ' UTC') !== false
+            && ($this->preservedAbsoluteDeadline === null
+                || strcmp($rowDeadline, $this->preservedAbsoluteDeadline) < 0)) {
+            $this->preservedAbsoluteDeadline = $rowDeadline;
+        }
+        return (string)$row['payload'];
     }
 
     public function write(string $id, string $data): bool
     {
-        $userId = isset($_SESSION['user']['id']) ? (int) $_SESSION['user']['id'] : null;
+        $hash = $this->hash($id);
+        $this->lock($hash);
+        $state = $this->states[$hash] ?? null;
+        if ($state === null) {
+            $row = $this->row($hash);
+            $state = $row === null ? 'new' : ($this->rowIsActive($row) ? 'active' : 'revoked');
+            $this->states[$hash] = $state;
+        }
+        if ($state === 'revoked') {
+            return true;
+        }
+
+        $userId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : null;
+        $now = time();
+        $lastActivity = $userId === null ? $now : (int)($_SESSION['last_activity'] ?? $now);
+        $deadline = $userId === null
+            ? $now + $this->absoluteSeconds
+            : SessionPolicy::authenticationDeadline($now);
+        $deadlineUtc = $this->utc($deadline);
+        $authenticatedAt = (int)($_SESSION['authn']['authenticated_at'] ?? 0);
+        $isNewAuthentication = $authenticatedAt >= $this->requestStartedAt;
+        $deadlineComparable = $deadlineUtc . '.000000';
+        if ($userId !== null && !$isNewAuthentication && $this->preservedAbsoluteDeadline !== null
+            && strcmp($this->preservedAbsoluteDeadline, $deadlineComparable) <= 0) {
+            $deadlineUtc = $this->preservedAbsoluteDeadline;
+        }
+
+        if ($state === 'active') {
+            $stmt = $this->pdo->prepare(
+                'UPDATE app_sessions
+                 SET user_id=?,payload=?,last_activity_at=?,absolute_expires_at=LEAST(absolute_expires_at,?)
+                 WHERE session_hash=? AND revoked_at IS NULL
+                   AND last_activity_at>=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL ? SECOND)
+                   AND absolute_expires_at>UTC_TIMESTAMP(6)'
+            );
+            $stmt->execute([
+                $userId,
+                $data,
+                $this->utc($lastActivity),
+                $deadlineUtc,
+                $hash,
+                $this->idleSeconds,
+            ]);
+            if ($stmt->rowCount() === 0 && !$this->validateId($id)) {
+                $this->tombstone($hash);
+                $this->states[$hash] = 'revoked';
+            }
+            return true;
+        }
+
         $stmt = $this->pdo->prepare(
-            'INSERT INTO app_sessions (session_hash,user_id,payload,last_activity_at,absolute_expires_at)
-             VALUES (?,?,?,UTC_TIMESTAMP(6),DATE_ADD(UTC_TIMESTAMP(6),INTERVAL ? SECOND))
-             ON DUPLICATE KEY UPDATE user_id=VALUES(user_id),payload=VALUES(payload),last_activity_at=VALUES(last_activity_at)'
+            'INSERT INTO app_sessions
+                (session_hash,user_id,payload,last_activity_at,absolute_expires_at,revoked_at)
+             VALUES (?,?,?,?,?,NULL)'
         );
-        return $stmt->execute([$this->hash($id), $userId, $data, $this->absoluteSeconds]);
+        try {
+            $created = $stmt->execute([
+                $hash,
+                $userId,
+                $data,
+                $this->utc($lastActivity),
+                $deadlineUtc,
+            ]);
+            $this->states[$hash] = $created ? 'active' : 'revoked';
+            return $created;
+        } catch (\Throwable $error) {
+            // A collision or tombstone must never be overwritten/upserted.
+            $this->states[$hash] = 'revoked';
+            if ($this->row($hash) !== null) {
+                $this->tombstone($hash);
+                return true;
+            }
+            throw $error;
+        }
     }
 
     public function destroy(string $id): bool
     {
-        $stmt = $this->pdo->prepare('DELETE FROM app_sessions WHERE session_hash=?');
-        return $stmt->execute([$this->hash($id)]);
+        $hash = $this->hash($id);
+        $this->lock($hash);
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO app_sessions
+                (session_hash,user_id,payload,last_activity_at,absolute_expires_at,revoked_at)
+             VALUES (?,NULL,?,UTC_TIMESTAMP(6),DATE_ADD(UTC_TIMESTAMP(6),INTERVAL ? SECOND),UTC_TIMESTAMP(6))
+             ON DUPLICATE KEY UPDATE user_id=NULL,payload=VALUES(payload),revoked_at=COALESCE(revoked_at,UTC_TIMESTAMP(6))'
+        );
+        $ok = $stmt->execute([$hash, '', $this->absoluteSeconds]);
+        $this->states[$hash] = 'revoked';
+        return $ok;
     }
 
     public function gc(int $maxLifetime): int|false
     {
-        $stmt = $this->pdo->prepare(
-            'DELETE FROM app_sessions WHERE absolute_expires_at<=UTC_TIMESTAMP(6)
-             OR last_activity_at<DATE_SUB(UTC_TIMESTAMP(6),INTERVAL ? SECOND)'
+        $expired = $this->pdo->prepare(
+            'UPDATE app_sessions SET user_id=NULL,payload=?,revoked_at=COALESCE(revoked_at,UTC_TIMESTAMP(6))
+             WHERE revoked_at IS NULL AND (
+                absolute_expires_at<=UTC_TIMESTAMP(6)
+                OR last_activity_at<DATE_SUB(UTC_TIMESTAMP(6),INTERVAL ? SECOND)
+             )'
         );
-        $stmt->execute([$this->idleSeconds]);
-        return $stmt->rowCount();
+        $expired->execute(['', $this->idleSeconds]);
+        $expiredCount = $expired->rowCount();
+
+        $delete = $this->pdo->prepare(
+            'DELETE FROM app_sessions
+             WHERE revoked_at<DATE_SUB(UTC_TIMESTAMP(6),INTERVAL ? SECOND)'
+        );
+        $delete->execute([$this->absoluteSeconds]);
+        return $expiredCount + $delete->rowCount();
+    }
+
+    public function validateId(string $id): bool
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT 1 FROM app_sessions
+             WHERE session_hash=? AND revoked_at IS NULL
+               AND last_activity_at>=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL ? SECOND)
+               AND absolute_expires_at>UTC_TIMESTAMP(6) LIMIT 1'
+        );
+        $stmt->execute([$this->hash($id), $this->idleSeconds]);
+        return $stmt->fetchColumn() !== false;
+    }
+
+    public function updateTimestamp(string $id, string $data): bool
+    {
+        // Intentional activity changes $_SESSION['last_activity'], causing PHP
+        // to call write(). Passive/read-only traffic must not move DB idle time.
+        return $this->validateId($id);
+    }
+
+    /** @return array<string,mixed>|null */
+    private function row(string $hash): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT payload,last_activity_at,absolute_expires_at,revoked_at,
+                    last_activity_at>=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL ? SECOND) idle_valid,
+                    absolute_expires_at>UTC_TIMESTAMP(6) absolute_valid
+             FROM app_sessions WHERE session_hash=? LIMIT 1'
+        );
+        $stmt->execute([$this->idleSeconds, $hash]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return is_array($row) ? $row : null;
+    }
+
+    /** @param array<string,mixed> $row */
+    private function rowIsActive(array $row): bool
+    {
+        return $row['revoked_at'] === null
+            && (int)$row['idle_valid'] === 1
+            && (int)$row['absolute_valid'] === 1;
+    }
+
+    private function tombstone(string $hash): void
+    {
+        $stmt = $this->pdo->prepare(
+            'UPDATE app_sessions
+             SET user_id=NULL,payload=?,revoked_at=COALESCE(revoked_at,UTC_TIMESTAMP(6))
+             WHERE session_hash=?'
+        );
+        $stmt->execute(['', $hash]);
+    }
+
+    private function lock(string $hash): void
+    {
+        if (isset($this->locks[$hash])) {
+            return;
+        }
+        $lockName = 'pa:' . substr($hash, 0, 61);
+        $stmt = $this->pdo->prepare('SELECT GET_LOCK(?,?)');
+        $stmt->execute([$lockName, $this->lockWaitSeconds]);
+        if ((int)$stmt->fetchColumn() !== 1) {
+            throw new RuntimeException('Could not acquire the database session lock.');
+        }
+        $this->locks[$hash] = $lockName;
     }
 
     private function hash(string $id): string { return hash('sha256', $id); }
+    private function utc(int $timestamp): string { return gmdate('Y-m-d H:i:s', $timestamp); }
 }

--- a/src/Security/SessionPolicy.php
+++ b/src/Security/SessionPolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+final class SessionPolicy
+{
+    public const IDLE_SECONDS = 900;
+    public const ABSOLUTE_SECONDS = 604800;
+
+    public static function completeAuthentication(string $method, ?int $now = null): void
+    {
+        $now ??= time();
+        $_SESSION['authn'] = [
+            'method' => $method,
+            'authenticated_at' => $now,
+            'absolute_expires_at' => $now + self::ABSOLUTE_SECONDS,
+        ];
+        $_SESSION['last_activity'] = $now;
+    }
+
+    public static function authenticationDeadline(?int $now = null): int
+    {
+        $now ??= time();
+        $authenticatedAt = (int)($_SESSION['authn']['authenticated_at'] ?? 0);
+        $deadline = (int)($_SESSION['authn']['absolute_expires_at'] ?? 0);
+        if ($deadline > 0) {
+            return $deadline;
+        }
+        if ($authenticatedAt > 0) {
+            return $authenticatedAt + self::ABSOLUTE_SECONDS;
+        }
+        return $now + self::ABSOLUTE_SECONDS;
+    }
+
+    /**
+     * Background/status traffic is deliberately passive. Normal navigations
+     * and user-triggered browser actions remain active by default.
+     *
+     * @param array<string,mixed> $query
+     */
+    public static function isIntentionalActivity(string $page, array $query = []): bool
+    {
+        if ($page === 'session-status') {
+            return false;
+        }
+        if ($page === 'financial/mileage-tracking-api'
+            && in_array((string)($query['action'] ?? ''), ['status', 'points'], true)) {
+            return false;
+        }
+        return true;
+    }
+
+    /** Preserve the authentication anchor and invalidate the old identifier. */
+    public static function rotateAuthenticatedId(): bool
+    {
+        $hasAuthenticationAnchor = (int)($_SESSION['authn']['absolute_expires_at'] ?? 0) > 0
+            || (int)($_SESSION['authn']['authenticated_at'] ?? 0) > 0;
+        $deadline = $hasAuthenticationAnchor ? self::authenticationDeadline() : null;
+        $result = session_regenerate_id(true);
+        if ($result && $deadline !== null) {
+            $_SESSION['authn']['absolute_expires_at'] = $deadline;
+        }
+        return $result;
+    }
+}

--- a/src/Security/SessionRevocation.php
+++ b/src/Security/SessionRevocation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use PDO;
+
+final class SessionRevocation
+{
+    public static function revokeUserSessions(PDO $pdo, int $userId, ?string $exceptSessionId = null): int
+    {
+        if ($userId < 1) {
+            return 0;
+        }
+        $sql = 'UPDATE app_sessions
+                SET user_id=NULL,payload=?,revoked_at=COALESCE(revoked_at,UTC_TIMESTAMP(6))
+                WHERE user_id=? AND revoked_at IS NULL';
+        $params = ['', $userId];
+        if ($exceptSessionId !== null && $exceptSessionId !== '') {
+            $sql .= ' AND session_hash<>?';
+            $params[] = hash('sha256', $exceptSessionId);
+        }
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->rowCount();
+    }
+}

--- a/src/controllers/accounts/accounts_reset_password.php
+++ b/src/controllers/accounts/accounts_reset_password.php
@@ -42,6 +42,13 @@ try {
     
     audit_log($pdo, 'user.password_reset_by_admin', 'user', $userId);
     $pdo->commit();
+    App\Security\SessionRevocation::revokeUserSessions($pdo, $userId);
+    if ($userId === (int)$_SESSION['user']['id']) {
+        $_SESSION = [];
+        session_destroy();
+        header('Location: /?page=login&error=' . urlencode('Password reset. Please sign in again.'));
+        exit;
+    }
     header('Location: /?page=account-edit&id=' . $userId . '&success=pwd_reset');
 } catch (Throwable $e) {
     if ($pdo->inTransaction()) { $pdo->rollBack(); }

--- a/src/controllers/accounts/accounts_update.php
+++ b/src/controllers/accounts/accounts_update.php
@@ -139,6 +139,65 @@ if ($username !== '') {
 // Update user
 try {
     $pdo->beginTransaction();
+    $lockedAccountStmt = $pdo->prepare('SELECT email,username,role,is_disabled,force_password_reset,auth_version FROM users WHERE id=? FOR UPDATE');
+    $lockedAccountStmt->execute([$userId]);
+    $previousAccount = $lockedAccountStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$previousAccount) {
+        throw new DomainException('User not found');
+    }
+
+    $permissionSnapshot = static function (PDO $pdo, int $targetUserId, string $targetRole, ?array $posted = null): array {
+        if ($targetRole === 'admin') {
+            return ['*' => true];
+        }
+        $catalog = permission_catalog_flat();
+        if ($posted !== null) {
+            $snapshot = [];
+            foreach ($catalog as $permission => $_group) {
+                $allowKey = 'allow_' . str_replace('.', '_', $permission);
+                $snapshot[$permission] = !empty($posted[$allowKey]);
+            }
+            ksort($snapshot);
+            return $snapshot;
+        }
+        $rules = [];
+        $targetRoleId = role_id_by_name($pdo, $targetRole, null);
+        if ($targetRoleId !== null) {
+            $rolePermissions = $pdo->prepare('SELECT permission,allowed FROM role_permissions WHERE role_id=?');
+            $rolePermissions->execute([$targetRoleId]);
+            foreach ($rolePermissions->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $rules[(string)$row['permission']] = (bool)$row['allowed'];
+            }
+        }
+        $overrides = $pdo->prepare('SELECT permission,allowed FROM user_permissions_overrides WHERE user_id=? AND organization_id IS NULL');
+        $overrides->execute([$targetUserId]);
+        foreach ($overrides->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $rules[(string)$row['permission']] = (bool)$row['allowed'];
+        }
+        $snapshot = [];
+        foreach ($catalog as $permission => $_group) {
+            $module = explode('.', $permission, 2)[0];
+            $snapshot[$permission] = $rules[$permission] ?? $rules[$module . '.*'] ?? false;
+        }
+        ksort($snapshot);
+        return $snapshot;
+    };
+    $permissionsBefore = $permissionSnapshot($pdo, $userId, (string)$previousAccount['role']);
+    $permissionsAfter = !empty($_POST['save_account_permissions'])
+        ? $permissionSnapshot($pdo, $userId, $role, $_POST)
+        : $permissionSnapshot($pdo, $userId, $role);
+    $securitySensitiveChange = App\Security\AccountSessionPolicy::requiresGlobalRevocation(
+        $previousAccount,
+        [
+            'email' => $email,
+            'username' => $username,
+            'role' => $role,
+            'is_disabled' => $accountDisabled ? 1 : 0,
+            'force_password_reset' => $forceReset ? 1 : 0,
+        ],
+        $permissionsBefore !== $permissionsAfter
+    );
+
     assert_not_removing_final_active_admin($pdo, $userId, $role === 'admin' && !$accountDisabled);
     if ($accountDisabled) {
         $managedProjectStmt = $pdo->prepare("SELECT name FROM projects WHERE manager_user_id=? AND status NOT IN ('completed','cancelled') ORDER BY id LIMIT 1 FOR UPDATE");
@@ -181,7 +240,7 @@ try {
         document_sender_country = ?,
         document_sender_phone = ?,
         document_sender_email = ?,
-        auth_version = auth_version + 1
+        auth_version = auth_version + ?
         WHERE id = ?');
     $stmt->execute([
         $email,
@@ -200,6 +259,7 @@ try {
         $documentSenderCountry !== '' ? $documentSenderCountry : null,
         $documentSenderPhone !== '' ? $documentSenderPhone : null,
         $documentSenderEmail !== '' ? $documentSenderEmail : null,
+        $securitySensitiveChange ? 1 : 0,
         $userId
     ]);
 
@@ -348,10 +408,19 @@ try {
         }
     }
 
+    if ($securitySensitiveChange) {
+        App\Security\SessionRevocation::revokeUserSessions($pdo, $userId);
+    }
     $pdo->commit();
 
-    audit_log($pdo, 'user.update', 'user', $userId, ['email' => $email, 'role' => $role, 'acl_role' => $roleName, 'role_id' => $roleId, 'is_disabled' => $accountDisabled ? 1 : 0, 'document_sender_enabled' => $documentSenderEnabled ? 1 : 0, 'project_assignments' => count($employeeProjectIds)]);
-    header('Location: /?page=account-edit&id=' . $userId . '&success=updated');
+    audit_log($pdo, 'user.update', 'user', $userId, ['email' => $email, 'role' => $role, 'acl_role' => $roleName, 'role_id' => $roleId, 'is_disabled' => $accountDisabled ? 1 : 0, 'document_sender_enabled' => $documentSenderEnabled ? 1 : 0, 'project_assignments' => count($employeeProjectIds), 'sessions_revoked' => $securitySensitiveChange]);
+    if ($securitySensitiveChange && $userId === (int)$_SESSION['user']['id']) {
+        $_SESSION = [];
+        session_destroy();
+        header('Location: /?page=login&error=' . urlencode('Your account security settings changed. Please sign in again.'));
+        exit;
+    }
+    header('Location: /?page=account-edit&id=' . $userId . '&success=updated' . ($securitySensitiveChange ? '&sessions_revoked=1' : ''));
 } catch (Throwable $e) {
     if ($pdo->inTransaction()) {
         $pdo->rollBack();

--- a/src/controllers/auth/account_update.php
+++ b/src/controllers/auth/account_update.php
@@ -4,6 +4,7 @@ if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/audit.php';
 require_once __DIR__ . '/../../utils/password_policy.php';
+require_once __DIR__ . '/../../utils/password_reset_tokens.php';
 
 if (empty($_SESSION['user'])) {
   header('Location: /?page=login');
@@ -46,12 +47,16 @@ try {
   $newHash = password_hash($new, PASSWORD_DEFAULT);
   $up = $pdo->prepare('UPDATE users SET password_hash=?, force_password_reset=0, auth_version=auth_version+1 WHERE id=?');
   $up->execute([$newHash, $uid]);
+  password_reset_revoke_for_user($pdo, $uid);
+  $pdo->prepare('DELETE FROM trusted_devices WHERE user_id=?')->execute([$uid]);
   $version = $pdo->prepare('SELECT auth_version, totp_reenroll_required FROM users WHERE id=?');
   $version->execute([$uid]);
   $recoveryState = $version->fetch(PDO::FETCH_ASSOC) ?: [];
   audit_log($pdo, 'user.password_changed', 'user', $uid);
   $pdo->commit();
   $_SESSION['user']['auth_version'] = (int)($recoveryState['auth_version'] ?? 0);
+  App\Security\SessionRevocation::revokeUserSessions($pdo, $uid, session_id());
+  App\Security\SessionPolicy::rotateAuthenticatedId();
   if ((int)($recoveryState['totp_reenroll_required'] ?? 0) === 1) {
     header('Location: /?page=2fa-setup&required=1&recovery=1');
     exit;

--- a/src/controllers/auth/admin_2fa_disable.php
+++ b/src/controllers/auth/admin_2fa_disable.php
@@ -31,9 +31,17 @@ if ($userId <= 0) {
 try {
     $pdo->beginTransaction();
     $pdo->prepare('DELETE FROM user_2fa WHERE user_id = ?')->execute([$userId]);
+    $pdo->prepare('DELETE FROM trusted_devices WHERE user_id = ?')->execute([$userId]);
     $pdo->prepare('UPDATE users SET auth_version = auth_version + 1 WHERE id = ?')->execute([$userId]);
     audit_log($pdo, 'auth.totp_admin_reset', 'user', $userId, [], $actorId);
     $pdo->commit();
+    App\Security\SessionRevocation::revokeUserSessions($pdo, $userId);
+    if ($userId === $actorId) {
+        $_SESSION = [];
+        session_destroy();
+        header('Location: /?page=login&error=' . urlencode('Two-factor authentication reset. Please sign in again.'));
+        exit;
+    }
     header('Location: /?page=account-edit&id=' . $userId . '&success=2fa_disabled');
 } catch (Throwable $e) {
     if ($pdo->inTransaction()) { $pdo->rollBack(); }

--- a/src/controllers/auth/admin_passkey_reset.php
+++ b/src/controllers/auth/admin_passkey_reset.php
@@ -31,6 +31,13 @@ try {
     $pdo->prepare('UPDATE users SET auth_version=auth_version+1 WHERE id=?')->execute([$userId]);
     audit_log($pdo, 'auth.passkeys_admin_reset', 'user', $userId, ['revoked_count' => $revoked], $actorId);
     $pdo->commit();
+    App\Security\SessionRevocation::revokeUserSessions($pdo, $userId);
+    if ($userId === $actorId) {
+        $_SESSION = [];
+        session_destroy();
+        header('Location: /?page=login&error=' . urlencode('Passkeys reset. Please sign in again.'));
+        exit;
+    }
     header('Location: /?page=account-edit&id=' . $userId . '&success=passkeys_reset');
 } catch (Throwable $e) {
     if ($pdo->inTransaction()) { $pdo->rollBack(); }

--- a/src/controllers/auth/auth_handler.php
+++ b/src/controllers/auth/auth_handler.php
@@ -226,7 +226,7 @@ if ($action === 'login') {
         // on success (no 2FA), regenerate session and optionally clear attempts
         session_regenerate_id(true);
         $_SESSION['user'] = $userSession;
-        $_SESSION['authn'] = ['method' => $trustedDevice ? 'password_trusted_device' : 'password', 'authenticated_at' => time()];
+        App\Security\SessionPolicy::completeAuthentication($trustedDevice ? 'password_trusted_device' : 'password');
         password_reset_revoke_for_user($pdo, (int)$u['id']);
         // Clear old login attempts on success
         try {

--- a/src/controllers/auth/passkey_complete.php
+++ b/src/controllers/auth/passkey_complete.php
@@ -38,7 +38,7 @@ try {
     session_regenerate_id(true);
     unset($_SESSION['2fa_pending']);
     $_SESSION['user'] = $sessionUser;
-    $_SESSION['authn'] = ['method' => 'passkey', 'authenticated_at' => time()];
+    App\Security\SessionPolicy::completeAuthentication('passkey');
     password_reset_revoke_for_user($pdo, $userId);
     audit_log($pdo, 'auth.passkey_login_success', 'user', $userId, ['ip' => get_client_ip()], $userId);
 

--- a/src/controllers/auth/passkey_register_complete.php
+++ b/src/controllers/auth/passkey_register_complete.php
@@ -28,7 +28,8 @@ try {
         is_array($data['credential'] ?? null) ? $data['credential'] : [],
         get_client_ip()
     );
-    $_SESSION['authn'] = ['method' => 'passkey_registration', 'authenticated_at' => time()];
+    App\Security\SessionPolicy::rotateAuthenticatedId();
+    $_SESSION['authn']['reauthenticated_at'] = time();
     audit_log($pdo, 'auth.passkey_registered', 'passkey', (int)$result['id'], ['name' => $result['name']], $userId);
     passkey_json(true, 'passkey_registered', 'Passkey added.', 201, $result);
 } catch (PasskeyException $e) {

--- a/src/controllers/auth/reset_update.php
+++ b/src/controllers/auth/reset_update.php
@@ -51,17 +51,23 @@ if ($uid > 0) {
 }
 
 try {
+  $pdo->beginTransaction();
   $hash = password_hash($new, PASSWORD_DEFAULT);
   $st = $pdo->prepare('UPDATE users SET password_hash=?, force_password_reset=0, auth_version=auth_version+1 WHERE id=? AND auth_version=? AND is_disabled=0 AND deleted_at IS NULL');
   $st->execute([$hash, $uid, $expectedAuthVersion]);
   if ($st->rowCount() !== 1) {
     throw new RuntimeException('Reset authorization was revoked.');
   }
+  password_reset_revoke_for_user($pdo, $uid);
+  $pdo->prepare('DELETE FROM trusted_devices WHERE user_id=?')->execute([$uid]);
   audit_log($pdo, 'user.password_reset_via_token', 'user', $uid, [], $uid);
+  $pdo->commit();
+  App\Security\SessionRevocation::revokeUserSessions($pdo, $uid);
   unset($_SESSION['reset_user_id'], $_SESSION['reset_auth_version'], $_SESSION['reset_verified_at']);
   header('Location: /?page=login&pwd_reset=1');
   exit;
 } catch (Throwable $e) {
+  if ($pdo->inTransaction()) { $pdo->rollBack(); }
   header('Location: /?page=reset-new&email=' . urlencode($email) . '&error=' . urlencode('Could not update password'));
   exit;
 }

--- a/src/controllers/auth/two_factor_setup.php
+++ b/src/controllers/auth/two_factor_setup.php
@@ -20,16 +20,19 @@ if (!isset($_SESSION['user'])) {
 }
 
 $userId = (int)$_SESSION['user']['id'];
-$action = $_POST['action'] ?? $_GET['action'] ?? '';
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+    http_response_code(405);
+    header('Allow: POST');
+    exit('Two-factor setup actions require POST.');
+}
+$action = $_POST['action'] ?? '';
 
-// CSRF check
+// Every setup mutation is protected by the form-specific CSRF token.
 require_once __DIR__ . '/../../utils/csrf_sf.php';
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $submitted = $_POST['_token'] ?? '';
-    if (!csrf_sf_is_valid('2fa_setup', is_string($submitted) ? $submitted : '')) {
-        header('Location: /?page=2fa-setup&error=' . urlencode('Invalid request (CSRF)'));
-        exit;
-    }
+$submitted = $_POST['_token'] ?? '';
+if (!csrf_sf_is_valid('2fa_setup', is_string($submitted) ? $submitted : '')) {
+    header('Location: /?page=2fa-setup&error=' . urlencode('Invalid request (CSRF)'));
+    exit;
 }
 
 try {
@@ -83,7 +86,9 @@ try {
             }
             $pdo->prepare('UPDATE users SET totp_reenroll_required = 0 WHERE id = ?')->execute([$userId]);
             $pdo->commit();
-            
+            App\Security\SessionPolicy::rotateAuthenticatedId();
+            $_SESSION['authn']['reauthenticated_at'] = time();
+
             app_log('2fa', '2FA enabled', ['user_id' => $userId]);
             
             header('Location: /?page=2fa-setup&success=enabled');
@@ -124,6 +129,8 @@ try {
             $version->execute([$userId]);
             $_SESSION['user']['auth_version'] = (int)$version->fetchColumn();
             $pdo->commit();
+            App\Security\SessionRevocation::revokeUserSessions($pdo, $userId, session_id());
+            App\Security\SessionPolicy::rotateAuthenticatedId();
             app_log('2fa', '2FA disabled', ['user_id' => $userId]);
         }
         

--- a/src/controllers/auth/two_factor_verify.php
+++ b/src/controllers/auth/two_factor_verify.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../../utils/logger.php';
 require_once __DIR__ . '/../../utils/two_factor_auth.php';
 require_once __DIR__ . '/../../utils/client_ip.php';
 require_once __DIR__ . '/../../utils/password_reset_tokens.php';
+require_once __DIR__ . '/../../utils/request_security.php';
 
 use App\Utils\TwoFactorAuth;
 
@@ -36,15 +37,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 $action = $_POST['action'] ?? '';
 $code = trim($_POST['code'] ?? '');
 
-/**
- * Detect whether the connection is HTTPS, including reverse-proxy headers.
- */
-function is_cookie_secure(): bool {
-    return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on')
-        || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string)($_SERVER['HTTP_X_FORWARDED_PROTO'])) === 'https')
-        || (!empty($_SERVER['HTTP_CF_VISITOR']) && strpos((string)$_SERVER['HTTP_CF_VISITOR'], 'https') !== false)
-        || (!empty($_SERVER['HTTP_X_SCHEME']) && strtolower((string)$_SERVER['HTTP_X_SCHEME']) === 'https');
-}
 
 /**
  * Create or update a trusted device token
@@ -59,7 +51,7 @@ function set_trusted_device(PDO $pdo, int $userId, string $ip): void {
         'expires' => strtotime('+30 days'),
         'path' => '/',
         'domain' => '',
-        'secure' => is_cookie_secure(),
+        'secure' => request_is_https(),
         'httponly' => true,
         'samesite' => 'Strict',
     ];
@@ -91,13 +83,10 @@ try {
     $twofa = $st->fetch(PDO::FETCH_ASSOC);
     
     if (!$twofa) {
-        // 2FA not enabled, clear pending state and proceed
-        $pendingUser = $_SESSION['2fa_pending']['user_data'] ?? null;
+        // The factor changed while this login was pending. Restart rather than
+        // promoting a partially authenticated session.
         unset($_SESSION['2fa_pending']);
-        if ($pendingUser) {
-            $_SESSION['user'] = $pendingUser;
-        }
-        header('Location: /');
+        header('Location: /?page=login&error=' . urlencode('Authentication changed. Please sign in again.'));
         exit;
     }
     
@@ -131,7 +120,7 @@ try {
             // Complete login
             session_regenerate_id(true);
             $_SESSION['user'] = $_SESSION['2fa_pending']['user_data'];
-            $_SESSION['authn'] = ['method' => 'password_totp', 'authenticated_at' => time()];
+            App\Security\SessionPolicy::completeAuthentication('password_totp');
             unset($_SESSION['2fa_pending']);
             password_reset_revoke_for_user($pdo, $userId);
             

--- a/src/controllers/settings/dropbox_oauth.php
+++ b/src/controllers/settings/dropbox_oauth.php
@@ -9,6 +9,7 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../utils/logger.php';
 require_once __DIR__ . '/../../utils/link_provider_config.php';
+require_once __DIR__ . '/../../utils/request_security.php';
 
 // Require authenticated user
 if (!isset($_SESSION['user'])) {
@@ -22,30 +23,11 @@ $userId = (int)$_SESSION['user']['id'];
 // CSRF check
 require_once __DIR__ . '/../../utils/csrf_sf.php';
 
-function dropbox_oauth_is_secure_request(): bool
-{
-    return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on')
-        || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
-        || (!empty($_SERVER['HTTP_CF_VISITOR']) && strpos((string)$_SERVER['HTTP_CF_VISITOR'], 'https') !== false)
-        || (!empty($_SERVER['HTTP_X_SCHEME']) && strtolower((string)$_SERVER['HTTP_X_SCHEME']) === 'https');
-}
-
-function dropbox_oauth_state_cookie_options(int $expires): array
-{
-    return [
-        'expires' => $expires,
-        'path' => '/',
-        'domain' => '',
-        'secure' => dropbox_oauth_is_secure_request(),
-        'httponly' => true,
-        'samesite' => 'Lax',
-    ];
-}
 
 function dropbox_oauth_redirect_uri(?string $configuredHost = null): string
 {
     $host = trim((string)($configuredHost ?? ''));
-    $scheme = dropbox_oauth_is_secure_request() ? 'https' : 'http';
+    $scheme = request_is_https() ? 'https' : 'http';
     if ($host !== '') {
         if (preg_match('#^https?://#i', $host)) {
             $parts = parse_url($host);
@@ -84,18 +66,25 @@ try {
 } catch (Throwable $e) {}
 
 if ($action === 'start') {
-    // Start OAuth flow
+    // Start OAuth flow from an authenticated, CSRF-protected form submission.
+    $csrf = (string)($_POST['csrf'] ?? '');
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST'
+        || $csrf === ''
+        || !hash_equals(csrf_token(), $csrf)) {
+        http_response_code(405);
+        header('Allow: POST');
+        exit('Invalid Dropbox connection request.');
+    }
     if (empty($dropboxAppKey)) {
         header('Location: /?page=settings&tab=links&error=' . urlencode('Dropbox App Key not configured. Please add it in the settings.'));
         exit;
     }
 
-    session_regenerate_id(false);
-    
-    // Generate state token for CSRF protection
+    App\Security\SessionPolicy::rotateAuthenticatedId();
+
+    // State stays bound to this authenticated session and expires after ten minutes.
     $state = bin2hex(random_bytes(32));
-    $_SESSION['dropbox_oauth_state'] = $state;
-    setcookie('pa_dropbox_oauth_state', $state, dropbox_oauth_state_cookie_options(time() + 600));
+    $_SESSION['dropbox_oauth'] = ['state' => $state, 'created_at' => time()];
     
     // Build authorization URL
     $redirectUri = dropbox_oauth_redirect_uri(is_string($dropboxRedirectHost) ? $dropboxRedirectHost : null);
@@ -122,16 +111,15 @@ if ($action === 'callback') {
     $code = $_GET['code'] ?? '';
     $state = $_GET['state'] ?? '';
     
-    // Verify state
-    $hadSessionState = isset($_SESSION['dropbox_oauth_state']);
-    $hadCookieState = isset($_COOKIE['pa_dropbox_oauth_state']);
-    $expectedState = (string)($_SESSION['dropbox_oauth_state'] ?? ($_COOKIE['pa_dropbox_oauth_state'] ?? ''));
-    unset($_SESSION['dropbox_oauth_state']);
-    setcookie('pa_dropbox_oauth_state', '', dropbox_oauth_state_cookie_options(time() - 3600));
-    if (empty($state) || $expectedState === '' || !hash_equals($expectedState, $state)) {
+    // Verify single-use, session-bound state and its ten-minute lifetime.
+    $pending = $_SESSION['dropbox_oauth'] ?? null;
+    unset($_SESSION['dropbox_oauth']);
+    $expectedState = is_array($pending) ? (string)($pending['state'] ?? '') : '';
+    $stateAge = is_array($pending) ? time() - (int)($pending['created_at'] ?? 0) : PHP_INT_MAX;
+    if (empty($state) || $expectedState === '' || $stateAge < 0 || $stateAge > 600 || !hash_equals($expectedState, $state)) {
         app_log('dropbox_oauth', 'Invalid OAuth state', [
-            'has_session_state' => $hadSessionState,
-            'has_cookie_state' => $hadCookieState,
+            'has_session_state' => is_array($pending),
+            'state_age' => $stateAge,
         ]);
         header('Location: /?page=settings&tab=links&error=' . urlencode('Invalid OAuth state'));
         exit;
@@ -224,6 +212,14 @@ if ($action === 'callback') {
 }
 
 if ($action === 'disconnect') {
+    $submitted = (string)($_POST['csrf'] ?? '');
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST'
+        || $submitted === ''
+        || !hash_equals(csrf_token(), $submitted)) {
+        http_response_code(405);
+        header('Allow: POST');
+        exit('Invalid Dropbox disconnect request.');
+    }
     // Disconnect Dropbox OAuth
     try {
         // Revoke the token with Dropbox first

--- a/src/controllers/settings/gmail_oauth.php
+++ b/src/controllers/settings/gmail_oauth.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../../config/db.php';
 require_once __DIR__ . '/../../config/app.php';
 require_once __DIR__ . '/../../utils/crypto.php';
 require_once __DIR__ . '/../../utils/csrf.php';
+require_once __DIR__ . '/../../utils/request_security.php';
 require_once __DIR__ . '/../../services/EmailService.php';
 require_once __DIR__ . '/../../services/EmailProviderManager.php';
 
@@ -19,7 +20,7 @@ function gmail_oauth_redirect_uri(array $appConfig): string
         $host = 'https://' . $host;
     }
     if ($host === '') {
-        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') || strtolower((string)($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '')) === 'https' ? 'https' : 'http';
+        $scheme = request_is_https() ? 'https' : 'http';
         $host = $scheme . '://' . (string)($_SERVER['HTTP_HOST'] ?? 'localhost');
     }
     return rtrim($host, '/') . '/?page=settings/gmail-oauth&action=callback';
@@ -60,11 +61,15 @@ if ($clientId === '' || !is_string($clientSecret) || $clientSecret === '') {
 }
 
 if ($action === 'connect') {
-    $csrf = (string)($_GET['csrf'] ?? '');
-    if ($csrf === '' || !hash_equals(csrf_token(), $csrf)) {
-        header('Location: ' . $return . '&email_err=' . rawurlencode('Invalid Google connection request.'));
-        exit;
+    $csrf = (string)($_POST['csrf'] ?? '');
+    if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST'
+        || $csrf === ''
+        || !hash_equals(csrf_token(), $csrf)) {
+        http_response_code(405);
+        header('Allow: POST');
+        exit('Invalid Google connection request.');
     }
+    App\Security\SessionPolicy::rotateAuthenticatedId();
     $state = bin2hex(random_bytes(24));
     $verifier = rtrim(strtr(base64_encode(random_bytes(48)), '+/', '-_'), '=');
     $_SESSION['gmail_oauth'] = ['state' => $state, 'verifier' => $verifier, 'created_at' => time()];

--- a/src/migrations/migration_lib.php
+++ b/src/migrations/migration_lib.php
@@ -316,7 +316,7 @@ function migration_schema_health(PDO $pdo): void
         'work_approval_snapshots' => ['time_entry_id','entry_revision','pay_rate','billing_rate','pay_amount','currency'],
         'work_pay_accruals' => ['approval_snapshot_id','employee_user_id','amount','currency','status'],
         'work_billing_consumptions' => ['approval_snapshot_id','billing_time_entry_id','consumption_type'],
-        'app_sessions' => ['session_hash','user_id','payload','last_activity_at','absolute_expires_at'],
+        'app_sessions' => ['session_hash','user_id','payload','last_activity_at','absolute_expires_at','revoked_at'],
         'background_jobs' => ['queue_name','job_type','payload','state','available_at'],
         'email_provider_connections' => ['provider','credentials_enc','status','token_expires_at'],
         'addresses' => ['address_line1','city','postal_code','google_place_id','source'],

--- a/src/utils/acl_middleware.php
+++ b/src/utils/acl_middleware.php
@@ -402,7 +402,8 @@ function deny_response(string $page): void
         echo '<div style="text-align:center;padding:40px;background:#fff;border-radius:8px;box-shadow:0 1px 3px rgba(0,0,0,0.1)">';
         echo '<h1 style="color:#dc2626;margin:0 0 12px">Access Denied</h1>';
         echo '<p style="color:#6b7280;margin:0">You do not have permission to access this page. Please contact an administrator.</p>';
-        echo '<p style="margin:16px 0 0"><a href="/?page=logout" style="color:#3b82f6;text-decoration:none">Log out</a></p>';
+        $logoutCsrf = htmlspecialchars((string)($_SESSION['csrf'] ?? ''), ENT_QUOTES, 'UTF-8');
+        echo '<form method="post" action="/?page=logout" style="margin:16px 0 0"><input type="hidden" name="csrf" value="' . $logoutCsrf . '"><button type="submit" style="border:0;background:none;padding:0;color:#3b82f6;text-decoration:none;cursor:pointer">Log out</button></form>';
         echo '</div></body></html>';
         exit;
     }

--- a/src/utils/request_security.php
+++ b/src/utils/request_security.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/client_ip.php';
+
+/**
+ * Determine whether the browser-facing request is HTTPS.
+ *
+ * Forwarding headers are accepted only from the configured/trusted immediate
+ * proxy. Ambiguous or malformed values fail closed instead of making cookies
+ * Secure based on attacker-controlled headers.
+ *
+ * @param array<string,mixed>|null $server
+ */
+function request_is_https(?array $server = null): bool
+{
+    $server ??= $_SERVER;
+    $directHttps = strtolower(trim((string)($server['HTTPS'] ?? '')));
+    if (in_array($directHttps, ['on', '1', 'true'], true) || (int)($server['SERVER_PORT'] ?? 0) === 443) {
+        return true;
+    }
+
+    $remoteAddress = trim((string)($server['REMOTE_ADDR'] ?? ''));
+    if (!is_trusted_proxy($remoteAddress)) {
+        return false;
+    }
+
+    $forwarded = trim((string)($server['HTTP_FORWARDED'] ?? ''));
+    if ($forwarded !== '' && !str_contains($forwarded, ',')) {
+        if (preg_match('/(?:^|;)\s*proto=(?:"([^"]+)"|([^;\s]+))/i', $forwarded, $match) === 1) {
+            $proto = strtolower((string)($match[1] !== '' ? $match[1] : $match[2]));
+            return $proto === 'https';
+        }
+    }
+
+    foreach (['HTTP_X_FORWARDED_PROTO', 'HTTP_X_SCHEME'] as $header) {
+        $value = strtolower(trim((string)($server[$header] ?? '')));
+        if ($value !== '') {
+            return !str_contains($value, ',') && $value === 'https';
+        }
+    }
+
+    $cfVisitor = trim((string)($server['HTTP_CF_VISITOR'] ?? ''));
+    if ($cfVisitor !== '') {
+        $decoded = json_decode($cfVisitor, true);
+        return is_array($decoded) && strtolower((string)($decoded['scheme'] ?? '')) === 'https';
+    }
+
+    return false;
+}

--- a/src/utils/request_security.php
+++ b/src/utils/request_security.php
@@ -5,6 +5,32 @@ declare(strict_types=1);
 require_once __DIR__ . '/client_ip.php';
 
 /**
+ * Forwarded protocol headers affect cookie and redirect security decisions, so
+ * they require an explicitly configured immediate proxy. The broader
+ * client-IP helper intentionally accepts private networks for legacy address
+ * discovery; that permissive fallback is not appropriate for HTTPS trust.
+ */
+function request_is_explicitly_trusted_proxy(string $ip): bool
+{
+    if ($ip === '') {
+        return false;
+    }
+
+    $configured = trim((string)(getenv('TRUSTED_PROXIES') ?: ''));
+    if ($configured === '') {
+        return false;
+    }
+
+    foreach (preg_split('/[,\s]+/', $configured, -1, PREG_SPLIT_NO_EMPTY) as $trusted) {
+        if (ip_in_cidr($ip, $trusted)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Determine whether the browser-facing request is HTTPS.
  *
  * Forwarding headers are accepted only from the configured/trusted immediate
@@ -22,7 +48,7 @@ function request_is_https(?array $server = null): bool
     }
 
     $remoteAddress = trim((string)($server['REMOTE_ADDR'] ?? ''));
-    if (!is_trusted_proxy($remoteAddress)) {
+    if (!request_is_explicitly_trusted_proxy($remoteAddress)) {
         return false;
     }
 

--- a/src/utils/security_headers.php
+++ b/src/utils/security_headers.php
@@ -2,11 +2,10 @@
 // src/utils/security_headers.php
 // Sends a consistent set of security response headers.
 
+require_once __DIR__ . '/request_security.php';
+
 function send_security_headers(): void {
-    $isHttps =
-        (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on')
-        || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
-        || (!empty($_SERVER['HTTP_CF_VISITOR']) && strpos((string)$_SERVER['HTTP_CF_VISITOR'], 'https') !== false);
+    $isHttps = request_is_https();
 
     // Prevent cross-site clickjacking while allowing PA to embed its own PDF previews.
     header('X-Frame-Options: SAMEORIGIN');

--- a/src/views/pages/auth/two_factor_verify.php
+++ b/src/views/pages/auth/two_factor_verify.php
@@ -55,7 +55,7 @@ $h = static fn(mixed $value): string => htmlspecialchars((string)$value, ENT_QUO
 
         <div class="login-divider"><span>or</span></div>
         <a href="/?page=login" class="login-passkey two-factor-option">Use a passkey instead</a>
-        <a href="/?page=logout" class="two-factor-cancel">Cancel and log out</a>
+        <form method="post" action="/?page=logout"><input type="hidden" name="csrf" value="<?php echo htmlspecialchars((string)($_SESSION['csrf'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><button type="submit" class="two-factor-cancel" style="border:0;background:none;cursor:pointer">Cancel and log out</button></form>
         <p class="login-footnote">Protected access to <?php echo $h($brandName); ?></p>
       </div>
     </section>

--- a/src/views/pages/settings/links.php
+++ b/src/views/pages/settings/links.php
@@ -299,9 +299,7 @@ $dropboxCallbackUri = rtrim($dropboxCallbackBase, '/') . '/?page=settings/dropbo
                                         <?php endif; ?>
                                     </div>
                                 </div>
-                                <a href="/?page=settings/dropbox-oauth&action=disconnect" 
-                                   style="padding:6px 12px;border-radius:6px;border:1px solid #dc2626;background:#fff;color:#dc2626;font-size:13px;text-decoration:none"
-                                   onclick="return confirm('Disconnect Dropbox? This will revoke the token.');">Disconnect</a>
+                                <button type="submit" formmethod="post" formaction="/?page=settings/dropbox-oauth&amp;action=disconnect" style="padding:6px 12px;border-radius:6px;border:1px solid #dc2626;background:#fff;color:#dc2626;font-size:13px;cursor:pointer" onclick="return confirm('Disconnect Dropbox? This will revoke the token.');">Disconnect</button>
                             </div>
                         <?php else: ?>
                             <!-- OAuth Disconnected State -->
@@ -312,8 +310,7 @@ $dropboxCallbackUri = rtrim($dropboxCallbackBase, '/') . '/?page=settings/dropbo
                                     <div style="font-size:12px;color:#6b7280"><?php echo $dropboxCanConnect ? 'Connect via OAuth for a secure, permanent connection.' : 'Enter and save the Dropbox app key and secret first.'; ?></div>
                                 </div>
                                 <?php if ($dropboxCanConnect): ?>
-                                    <a href="/?page=settings/dropbox-oauth&action=start"
-                                       style="padding:8px 16px;border-radius:6px;border:0;background:#2563eb;color:#fff;font-size:13px;text-decoration:none;font-weight:600">Connect Dropbox</a>
+                                    <button type="submit" formmethod="post" formaction="/?page=settings/dropbox-oauth&amp;action=start" style="padding:8px 16px;border-radius:6px;border:0;background:#2563eb;color:#fff;font-size:13px;font-weight:600;cursor:pointer">Connect Dropbox</button>
                                 <?php else: ?>
                                     <span style="padding:8px 16px;border-radius:6px;border:1px solid #d1d5db;background:#f3f4f6;color:#6b7280;font-size:13px;font-weight:600">Save credentials first</span>
                                 <?php endif; ?>

--- a/src/views/pages/settings/system.php
+++ b/src/views/pages/settings/system.php
@@ -15,7 +15,8 @@ if ($googleCallbackBase !== '' && !preg_match('#^https?://#i', $googleCallbackBa
   $googleCallbackBase = 'https://' . $googleCallbackBase;
 }
 if ($googleCallbackBase === '') {
-  $googleCallbackScheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') || strtolower((string)($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '')) === 'https' ? 'https' : 'http';
+  require_once __DIR__ . '/../../../utils/request_security.php';
+  $googleCallbackScheme = request_is_https() ? 'https' : 'http';
   $googleCallbackBase = $googleCallbackScheme . '://' . (string)($_SERVER['HTTP_HOST'] ?? 'localhost');
 }
 $googleEmailCallback = rtrim($googleCallbackBase, '/') . '/?page=settings/gmail-oauth&action=callback';
@@ -168,7 +169,7 @@ $googleEmailCallback = rtrim($googleCallbackBase, '/') . '/?page=settings/gmail-
     <strong>Sign in with Google to send email</strong>
     <p style="margin:4px 0 10px;color:var(--muted);font-size:13px">Once the installation is configured, the normal experience is one click: sign in to the business Google account, approve sending email, and return to Project Alpha automatically. This affects outgoing email only—not PA login.</p>
     <?php if ($googleEmailSetupReady): ?>
-      <a class="btn btn-primary" href="/?page=settings/gmail-oauth&amp;action=connect&amp;csrf=<?php echo rawurlencode(csrf_token()); ?>">Sign in with Google</a>
+      <button class="btn btn-primary" type="submit" formmethod="post" formaction="/?page=settings/gmail-oauth&amp;action=connect">Sign in with Google</button>
     <?php else: ?>
       <button class="btn" type="button" disabled title="Complete the one-time installation setup below">Sign in with Google</button>
       <span style="margin-left:8px;color:#92400e;font-size:12px">One-time installation setup required</span>

--- a/src/views/partials/header.php
+++ b/src/views/partials/header.php
@@ -61,32 +61,7 @@ function nav_can(string $permission): bool {
   <script src="<?php echo htmlspecialchars(asset_url('/assets/js/item-library.js'), ENT_QUOTES, 'UTF-8'); ?>" data-pa-shell-asset defer></script>
   <script src="<?php echo htmlspecialchars(asset_url('/assets/js/workforce.js'), ENT_QUOTES, 'UTF-8'); ?>" data-pa-shell-asset defer></script>
   <script src="<?php echo htmlspecialchars(asset_url('/assets/item-autocomplete.js'), ENT_QUOTES, 'UTF-8'); ?>" data-pa-shell-asset defer></script>
-  <script>
-    (function() {
-      var timer = null;
-      function scheduleRefresh() {
-        if (timer) clearTimeout(timer);
-        timer = setTimeout(function() {
-          if (document.visibilityState === 'visible' && !isFormDirty()) {
-            location.reload();
-          } else {
-            scheduleRefresh();
-          }
-        }, 300000);
-      }
-      function isFormDirty() {
-        var inputs = document.querySelectorAll('input, textarea, select');
-        for (var i = 0; i < inputs.length; i++) {
-          if (inputs[i].type === 'hidden' || inputs[i].type === 'submit') continue;
-          if (inputs[i].value !== inputs[i].defaultValue) return true;
-        }
-        return false;
-      }
-      scheduleRefresh();
-      document.addEventListener('click', scheduleRefresh);
-      document.addEventListener('keypress', scheduleRefresh);
-    })();
-  </script>
+
 </head>
 
 <body>
@@ -274,7 +249,7 @@ function nav_can(string $permission): bool {
           <?php else: ?>
             <a class="settings" href="/?page=account" data-page="account" style="margin-top:8px;display:block">My Account</a>
           <?php endif; ?>
-          <a class="settings" href="/?page=logout" data-skip-nav style="margin-top:8px;display:block">Logout</a>
+          <form method="post" action="/?page=logout" data-skip-nav style="margin-top:8px"><input type="hidden" name="csrf" value="<?php echo htmlspecialchars((string)($_SESSION['csrf'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"><button class="settings" type="submit" style="display:block;width:100%;text-align:left;border:0;background:none;cursor:pointer">Logout</button></form>
         </div>
       </div>
     </aside>

--- a/tests/Database/DatabaseSessionHandlerTest.php
+++ b/tests/Database/DatabaseSessionHandlerTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/src/migrations/migration_lib.php';
+
+use App\Security\DatabaseSessionHandler;
+use App\Security\SessionPolicy;
+use App\Security\SessionRevocation;
+use PHPUnit\Framework\TestCase;
+
+final class DatabaseSessionHandlerTest extends TestCase
+{
+    private PDO $pdo;
+    private int $userId;
+    private string $prefix;
+
+    protected function setUp(): void
+    {
+        try {
+            $this->pdo = migration_connection();
+            $column = $this->pdo->query(
+                "SELECT COUNT(*) FROM information_schema.columns
+                 WHERE table_schema=DATABASE() AND table_name='app_sessions' AND column_name='revoked_at'"
+            )->fetchColumn();
+            if ((int)$column !== 1) {
+                $this->markTestSkipped('Apply migration 0057 in the isolated test database first.');
+            }
+        } catch (Throwable $error) {
+            $this->markTestSkipped('MySQL session backend unavailable: ' . $error->getMessage());
+        }
+        $this->prefix = 'session-test-' . bin2hex(random_bytes(6));
+        $stmt = $this->pdo->prepare("INSERT INTO users (email,username,password_hash,role) VALUES (?,?,?,'member')");
+        $stmt->execute([$this->prefix . '@example.invalid', $this->prefix, password_hash('Session-Test-Password-123!', PASSWORD_DEFAULT)]);
+        $this->userId = (int)$this->pdo->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+        if (!isset($this->pdo) || !isset($this->userId)) {
+            return;
+        }
+        foreach (['normal', 'old', 'new', 'race', 'logout', 'legacy-old', 'legacy-new', 'current', 'other'] as $suffix) {
+            $this->pdo->prepare('DELETE FROM app_sessions WHERE session_hash=?')
+                ->execute([hash('sha256', $this->prefix . '-' . $suffix)]);
+        }
+        $this->pdo->prepare('DELETE FROM users WHERE id=?')->execute([$this->userId]);
+    }
+
+    public function testNormalSessionAndIdleBoundaries(): void
+    {
+        $id = $this->prefix . '-normal';
+        $this->authenticatedSession(time());
+        $handler = new DatabaseSessionHandler($this->pdo);
+        self::assertTrue($handler->write($id, 'normal-payload'));
+        self::assertTrue($handler->close());
+
+        $handler = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('normal-payload', $handler->read($id));
+        $handler->close();
+
+        $hash = hash('sha256', $id);
+        $this->pdo->prepare('UPDATE app_sessions SET last_activity_at=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL 899 SECOND) WHERE session_hash=?')->execute([$hash]);
+        $handler = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('normal-payload', $handler->read($id));
+        $handler->close();
+
+        $this->pdo->prepare('UPDATE app_sessions SET last_activity_at=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL 901 SECOND) WHERE session_hash=?')->execute([$hash]);
+        $handler = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('', $handler->read($id));
+        $handler->close();
+        self::assertNotNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [$hash]));
+
+        self::assertSame('1', (string)$this->value(
+            "SELECT TIMESTAMP('2026-01-01 00:00:00') >= DATE_SUB(TIMESTAMP('2026-01-01 00:15:00'),INTERVAL 900 SECOND)"
+        ));
+    }
+
+    public function testAbsoluteBoundaryAndRotationPreserveOriginalDeadline(): void
+    {
+        $oldId = $this->prefix . '-old';
+        $newId = $this->prefix . '-new';
+        $authenticatedAt = time() - 3600;
+        $this->authenticatedSession($authenticatedAt);
+        $handler = new DatabaseSessionHandler($this->pdo);
+        $handler->write($oldId, 'authenticated');
+        $handler->close();
+        $deadline = (string)$this->value('SELECT absolute_expires_at FROM app_sessions WHERE session_hash=?', [hash('sha256', $oldId)]);
+
+        $handler = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('authenticated', $handler->read($oldId));
+        self::assertTrue($handler->destroy($oldId));
+        self::assertTrue($handler->write($newId, 'authenticated'));
+        $handler->close();
+
+        self::assertSame($deadline, (string)$this->value('SELECT absolute_expires_at FROM app_sessions WHERE session_hash=?', [hash('sha256', $newId)]));
+        self::assertNotNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [hash('sha256', $oldId)]));
+
+        $this->pdo->prepare('UPDATE app_sessions SET absolute_expires_at=UTC_TIMESTAMP(6) WHERE session_hash=?')->execute([hash('sha256', $newId)]);
+        $expired = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('', $expired->read($newId));
+        $expired->close();
+    }
+
+    public function testLockSerializesRequestsAndExternalRevocationCannotBeResurrected(): void
+    {
+        $id = $this->prefix . '-race';
+        $this->authenticatedSession(time());
+        $seed = new DatabaseSessionHandler($this->pdo);
+        $seed->write($id, 'first');
+        $seed->close();
+
+        $first = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('first', $first->read($id));
+        $secondPdo = migration_connection();
+        $contender = new DatabaseSessionHandler($secondPdo, 900, 604800, 0);
+        try {
+            $contender->read($id);
+            self::fail('A second request acquired the same session lock concurrently.');
+        } catch (RuntimeException $expected) {
+            self::assertStringContainsString('session lock', $expected->getMessage());
+        }
+
+        $secondPdo->prepare('UPDATE app_sessions SET user_id=NULL,payload=?,revoked_at=UTC_TIMESTAMP(6) WHERE session_hash=?')
+            ->execute(['', hash('sha256', $id)]);
+        self::assertTrue($first->write($id, 'stale-delayed-payload'));
+        $first->close();
+
+        self::assertSame('', (string)$this->value('SELECT payload FROM app_sessions WHERE session_hash=?', [hash('sha256', $id)]));
+        self::assertNotNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [hash('sha256', $id)]));
+    }
+
+    public function testDestroyAndPassiveTimestampCannotReviveOrRefreshSession(): void
+    {
+        $id = $this->prefix . '-logout';
+        $this->authenticatedSession(time());
+        $handler = new DatabaseSessionHandler($this->pdo);
+        $handler->write($id, 'authenticated');
+        $handler->close();
+        $hash = hash('sha256', $id);
+
+        $this->pdo->prepare('UPDATE app_sessions SET last_activity_at=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL 120 SECOND) WHERE session_hash=?')->execute([$hash]);
+        $before = (string)$this->value('SELECT last_activity_at FROM app_sessions WHERE session_hash=?', [$hash]);
+        $passive = new DatabaseSessionHandler($this->pdo);
+        self::assertTrue($passive->updateTimestamp($id, 'authenticated'));
+        $passive->close();
+        self::assertSame($before, (string)$this->value('SELECT last_activity_at FROM app_sessions WHERE session_hash=?', [$hash]));
+
+        $logout = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('authenticated', $logout->read($id));
+        self::assertTrue($logout->destroy($id));
+        self::assertTrue($logout->write($id, 'delayed-after-logout'));
+        $logout->close();
+        self::assertSame('', (string)$this->value('SELECT payload FROM app_sessions WHERE session_hash=?', [$hash]));
+        self::assertNotNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [$hash]));
+    }
+
+    public function testLegacyAuthenticatedRotationCannotGainANewAbsoluteWindow(): void
+    {
+        $oldId = $this->prefix . '-legacy-old';
+        $newId = $this->prefix . '-legacy-new';
+        $this->authenticatedSession(time() - 3600);
+        $seed = new DatabaseSessionHandler($this->pdo);
+        self::assertTrue($seed->write($oldId, 'legacy-authenticated'));
+        self::assertTrue($seed->close());
+
+        $oldHash = hash('sha256', $oldId);
+        $this->pdo->prepare('UPDATE app_sessions SET absolute_expires_at=DATE_ADD(UTC_TIMESTAMP(6),INTERVAL 1 HOUR) WHERE session_hash=?')
+            ->execute([$oldHash]);
+        $deadline = (string)$this->value('SELECT absolute_expires_at FROM app_sessions WHERE session_hash=?', [$oldHash]);
+        unset($_SESSION['authn']);
+
+        $handler = new DatabaseSessionHandler($this->pdo);
+        self::assertSame('legacy-authenticated', $handler->read($oldId));
+        self::assertTrue($handler->destroy($oldId));
+        self::assertTrue($handler->write($newId, 'legacy-authenticated'));
+        self::assertTrue($handler->close());
+
+        self::assertSame($deadline, (string)$this->value(
+            'SELECT absolute_expires_at FROM app_sessions WHERE session_hash=?',
+            [hash('sha256', $newId)]
+        ));
+        self::assertNotNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [$oldHash]));
+    }
+    public function testBulkRevocationCanPreserveCurrentSessionDeliberately(): void
+    {
+        $currentId = $this->prefix . '-current';
+        $otherId = $this->prefix . '-other';
+        $this->authenticatedSession(time());
+        foreach ([$currentId, $otherId] as $id) {
+            $handler = new DatabaseSessionHandler($this->pdo);
+            self::assertTrue($handler->write($id, 'authenticated'));
+            self::assertTrue($handler->close());
+        }
+
+        self::assertSame(1, SessionRevocation::revokeUserSessions($this->pdo, $this->userId, $currentId));
+        self::assertNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [hash('sha256', $currentId)]));
+        self::assertNotNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [hash('sha256', $otherId)]));
+
+        self::assertSame(1, SessionRevocation::revokeUserSessions($this->pdo, $this->userId));
+        self::assertNotNull($this->value('SELECT revoked_at FROM app_sessions WHERE session_hash=?', [hash('sha256', $currentId)]));
+    }
+
+    private function authenticatedSession(int $authenticatedAt): void
+    {
+        $_SESSION = ['user' => ['id' => $this->userId], 'last_activity' => time()];
+        $_SESSION['authn'] = [
+            'method' => 'test',
+            'authenticated_at' => $authenticatedAt,
+            'absolute_expires_at' => $authenticatedAt + SessionPolicy::ABSOLUTE_SECONDS,
+        ];
+    }
+
+    /** @param list<mixed> $params */
+    private function value(string $sql, array $params = []): mixed
+    {
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return $stmt->fetchColumn();
+    }
+}

--- a/tests/Database/UnifiedWorkforceDatabaseTest.php
+++ b/tests/Database/UnifiedWorkforceDatabaseTest.php
@@ -81,7 +81,7 @@ final class UnifiedWorkforceDatabaseTest extends TestCase
             $pdo->prepare('UPDATE app_sessions SET last_activity_at=DATE_SUB(UTC_TIMESTAMP(6),INTERVAL 901 SECOND) WHERE session_hash=?')
                 ->execute([hash('sha256', "verification-{$suffix}")]);
             self::assertSame('', $sessions->read("verification-{$suffix}"));
-            self::assertSame('0', (string) $this->value($pdo, 'SELECT COUNT(*) FROM app_sessions WHERE session_hash=?', [hash('sha256', "verification-{$suffix}")]));
+            self::assertSame('1', (string) $this->value($pdo, 'SELECT COUNT(*) FROM app_sessions WHERE session_hash=? AND revoked_at IS NOT NULL AND payload=""', [hash('sha256', "verification-{$suffix}")]));
 
             $time = new TimekeepingService($pdo, new AuditRecorder($pdo));
             $approval = new ApprovalService($pdo, new AuditRecorder($pdo), new BillingTimeConsumer($pdo));

--- a/tests/Security/PasskeyAndTotpTest.php
+++ b/tests/Security/PasskeyAndTotpTest.php
@@ -163,7 +163,7 @@ final class PasskeyAndTotpTest extends TestCase
         $controller = $this->read('src/controllers/auth/passkey_complete.php');
 
         self::assertStringContainsString("unset(\$_SESSION['2fa_pending'])", $controller);
-        self::assertStringContainsString("\$_SESSION['authn'] = ['method' => 'passkey'", $controller);
+        self::assertStringContainsString("SessionPolicy::completeAuthentication('passkey')", $controller);
         self::assertStringNotContainsString("page=2fa-verify", $controller);
     }
 

--- a/tests/Security/SessionSecurityPolicyTest.php
+++ b/tests/Security/SessionSecurityPolicyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . '/src/utils/request_security.php';
+
+use App\Security\AccountSessionPolicy;
+use App\Security\SessionPolicy;
+use PHPUnit\Framework\TestCase;
+
+final class SessionSecurityPolicyTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    public function testAuthenticationHasFixedSevenDayDeadlineAndInitialActivity(): void
+    {
+        $_SESSION = [];
+        SessionPolicy::completeAuthentication('password', 1_000_000);
+
+        self::assertSame(1_000_000, $_SESSION['last_activity']);
+        self::assertSame(1_000_000, $_SESSION['authn']['authenticated_at']);
+        self::assertSame(1_604_800, $_SESSION['authn']['absolute_expires_at']);
+        self::assertSame(1_604_800, SessionPolicy::authenticationDeadline(1_300_000));
+    }
+
+    public function testActivityClassificationIsExplicit(): void
+    {
+        self::assertFalse(SessionPolicy::isIntentionalActivity('session-status'));
+        self::assertFalse(SessionPolicy::isIntentionalActivity('financial/mileage-tracking-api', ['action' => 'status']));
+        self::assertFalse(SessionPolicy::isIntentionalActivity('financial/mileage-tracking-api', ['action' => 'points']));
+        self::assertTrue(SessionPolicy::isIntentionalActivity('financial/mileage-tracking-api', ['action' => 'start']));
+        self::assertTrue(SessionPolicy::isIntentionalActivity('invoice/invoice-details'));
+    }
+
+    public function testOnlySecuritySensitiveAccountChangesRequireGlobalRevocation(): void
+    {
+        $before = ['email' => 'user@example.test', 'username' => 'user', 'role' => 'member', 'is_disabled' => 0, 'force_password_reset' => 0];
+        self::assertFalse(AccountSessionPolicy::requiresGlobalRevocation($before, $before, false));
+
+        $documentOnly = $before + ['document_sender_name' => 'Updated sender'];
+        self::assertFalse(AccountSessionPolicy::requiresGlobalRevocation($before, $documentOnly, false));
+
+        foreach (['email', 'username', 'role', 'is_disabled', 'force_password_reset'] as $field) {
+            $after = $before;
+            $after[$field] = $field === 'role' ? 'staff' : 'changed';
+            self::assertTrue(AccountSessionPolicy::requiresGlobalRevocation($before, $after, false), $field);
+        }
+        self::assertTrue(AccountSessionPolicy::requiresGlobalRevocation($before, $before, true));
+    }
+
+    public function testPasswordAndAccountSecurityChangesWireDeliberateRevocation(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $selfPassword = (string)file_get_contents($root . '/src/controllers/auth/account_update.php');
+        $tokenReset = (string)file_get_contents($root . '/src/controllers/auth/reset_update.php');
+        $adminAccount = (string)file_get_contents($root . '/src/controllers/accounts/accounts_update.php');
+        $totpSetup = (string)file_get_contents($root . '/src/controllers/auth/two_factor_setup.php');
+
+        self::assertStringContainsString('revokeUserSessions($pdo, $uid, session_id())', $selfPassword);
+        self::assertStringContainsString('SessionPolicy::rotateAuthenticatedId()', $selfPassword);
+        self::assertStringContainsString('revokeUserSessions($pdo, $uid)', $tokenReset);
+        self::assertStringContainsString('auth_version = auth_version + ?', $adminAccount);
+        self::assertStringContainsString('if ($securitySensitiveChange)', $adminAccount);
+        self::assertStringContainsString("(\$_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST'", $totpSetup);
+        self::assertStringNotContainsString("\$_GET['action']", $totpSetup);
+    }
+
+    public function testHttpsDetectionTrustsOnlyDirectTlsOrTrustedExactProxyValues(): void
+    {
+        self::assertTrue(request_is_https(['HTTPS' => 'on', 'REMOTE_ADDR' => '203.0.113.5']));
+        self::assertFalse(request_is_https(['REMOTE_ADDR' => '203.0.113.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+        self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https,http']));
+        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_FORWARDED' => 'for=198.51.100.7;proto=https, for=10.0.0.4;proto=https']));
+        self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_FORWARDED' => 'for=198.51.100.7;proto=https, for=10.0.0.4;proto=https', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https.evil']));
+        self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_CF_VISITOR' => '{"scheme":"https"}']));
+        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_CF_VISITOR' => '{"note":"https"}']));
+        self::assertTrue(request_is_https(['REMOTE_ADDR' => '::1', 'HTTP_FORWARDED' => 'for=192.0.2.1;proto=https']));
+    }
+
+    public function testFrontControllerAndOauthUseCrossSiteSafeSessionContract(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $front = (string)file_get_contents($root . '/public/index.php');
+        $dropbox = (string)file_get_contents($root . '/src/controllers/settings/dropbox_oauth.php');
+        $gmail = (string)file_get_contents($root . '/src/controllers/settings/gmail_oauth.php');
+        $linksView = (string)file_get_contents($root . '/src/views/pages/settings/links.php');
+        $systemView = (string)file_get_contents($root . '/src/views/pages/settings/system.php');
+        $header = (string)file_get_contents($root . '/src/views/partials/header.php');
+
+        self::assertStringContainsString("'samesite' => 'Lax'", $front);
+        self::assertStringContainsString("session.use_strict_mode", $front);
+        self::assertStringContainsString("if (\$page === 'settings/gmail-oauth')", $front);
+        self::assertStringNotContainsString("\$page === 'settings/gmail-oauth' && \$_SERVER['REQUEST_METHOD'] === 'GET'", $front);
+        self::assertStringContainsString("REQUEST_METHOD", $front);
+        self::assertStringContainsString("hash_equals((string)\$_SESSION['csrf']", $front);
+        self::assertStringContainsString('SessionPolicy::rotateAuthenticatedId()', $dropbox);
+        self::assertStringContainsString("(\$_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST'", $dropbox);
+        self::assertStringContainsString("(\$_POST['csrf'] ?? '')", $dropbox);
+        self::assertStringContainsString('$stateAge > 600', $dropbox);
+        self::assertStringNotContainsString('pa_dropbox_oauth_state', $dropbox);
+        self::assertStringNotContainsString('session_regenerate_id(false)', $dropbox);
+        self::assertStringContainsString('SessionPolicy::rotateAuthenticatedId()', $gmail);
+        self::assertStringContainsString("(\$_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST'", $gmail);
+        self::assertStringContainsString("(\$_POST['csrf'] ?? '')", $gmail);
+        self::assertStringContainsString('formaction="/?page=settings/dropbox-oauth&amp;action=start"', $linksView);
+        self::assertStringContainsString('formaction="/?page=settings/dropbox-oauth&amp;action=disconnect"', $linksView);
+        self::assertStringNotContainsString('<form method="post" action="/?page=settings/dropbox-oauth', $linksView);
+        self::assertStringContainsString('formaction="/?page=settings/gmail-oauth&amp;action=connect"', $systemView);
+        self::assertStringNotContainsString('<form method="post" action="/?page=settings/gmail-oauth', $systemView);
+        self::assertStringNotContainsString('location.reload()', $header);
+    }
+}

--- a/tests/Security/SessionSecurityPolicyTest.php
+++ b/tests/Security/SessionSecurityPolicyTest.php
@@ -70,16 +70,30 @@ final class SessionSecurityPolicyTest extends TestCase
 
     public function testHttpsDetectionTrustsOnlyDirectTlsOrTrustedExactProxyValues(): void
     {
-        self::assertTrue(request_is_https(['HTTPS' => 'on', 'REMOTE_ADDR' => '203.0.113.5']));
-        self::assertFalse(request_is_https(['REMOTE_ADDR' => '203.0.113.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
-        self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
-        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https,http']));
-        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_FORWARDED' => 'for=198.51.100.7;proto=https, for=10.0.0.4;proto=https']));
-        self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_FORWARDED' => 'for=198.51.100.7;proto=https, for=10.0.0.4;proto=https', 'HTTP_X_FORWARDED_PROTO' => 'https']));
-        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https.evil']));
-        self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_CF_VISITOR' => '{"scheme":"https"}']));
-        self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_CF_VISITOR' => '{"note":"https"}']));
-        self::assertTrue(request_is_https(['REMOTE_ADDR' => '::1', 'HTTP_FORWARDED' => 'for=192.0.2.1;proto=https']));
+        $originalTrustedProxies = getenv('TRUSTED_PROXIES');
+        try {
+            putenv('TRUSTED_PROXIES');
+            self::assertTrue(request_is_https(['HTTPS' => 'on', 'REMOTE_ADDR' => '203.0.113.5']));
+            self::assertFalse(request_is_https(['REMOTE_ADDR' => '203.0.113.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+            self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+
+            putenv('TRUSTED_PROXIES=10.0.0.0/24,::1');
+            self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+            self::assertFalse(request_is_https(['REMOTE_ADDR' => '172.20.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+            self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https,http']));
+            self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_FORWARDED' => 'for=198.51.100.7;proto=https, for=10.0.0.4;proto=https']));
+            self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_FORWARDED' => 'for=198.51.100.7;proto=https, for=10.0.0.4;proto=https', 'HTTP_X_FORWARDED_PROTO' => 'https']));
+            self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_X_FORWARDED_PROTO' => 'https.evil']));
+            self::assertTrue(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_CF_VISITOR' => '{"scheme":"https"}']));
+            self::assertFalse(request_is_https(['REMOTE_ADDR' => '10.0.0.5', 'HTTP_CF_VISITOR' => '{"note":"https"}']));
+            self::assertTrue(request_is_https(['REMOTE_ADDR' => '::1', 'HTTP_FORWARDED' => 'for=192.0.2.1;proto=https']));
+        } finally {
+            if ($originalTrustedProxies === false) {
+                putenv('TRUSTED_PROXIES');
+            } else {
+                putenv('TRUSTED_PROXIES=' . $originalTrustedProxies);
+            }
+        }
     }
 
     public function testFrontControllerAndOauthUseCrossSiteSafeSessionContract(): void

--- a/tests/Workflows/UnifiedAlphaLedgerModuleTest.php
+++ b/tests/Workflows/UnifiedAlphaLedgerModuleTest.php
@@ -122,10 +122,10 @@ final class UnifiedAlphaLedgerModuleTest extends TestCase
         $front = (string) file_get_contents($this->root . '/public/index.php');
         $handler = (string) file_get_contents($this->root . '/src/Security/DatabaseSessionHandler.php');
         $policy = (string) file_get_contents($this->root . '/src/utils/two_factor_policy.php');
-        self::assertStringContainsString("'samesite' => 'Strict'", $front);
-        self::assertStringContainsString('$sessionTimeout = 15 * 60', $front);
+        self::assertStringContainsString("'samesite' => 'Lax'", $front);
+        self::assertStringContainsString('SessionPolicy::IDLE_SECONDS', $front);
         self::assertStringContainsString("hash('sha256', \$id)", $handler);
-        self::assertStringContainsString('604800', $handler);
+        self::assertStringContainsString('SessionPolicy::ABSOLUTE_SECONDS', $handler);
         self::assertStringContainsString('approvals.review', $policy);
     }
 }


### PR DESCRIPTION
## Summary

- make legitimate email/Slack/OAuth top-level navigation compatible with the session cookie while preserving CSRF and OAuth state/PKCE validation
- serialize database session access, retain revocation tombstones, prevent delayed-request resurrection, and preserve fixed absolute expiry across session ID rotation
- make account/session invalidation deliberate for password, role, permission, disabled-account, forced-reset, passkey, and TOTP changes while keeping ordinary profile edits non-disruptive
- classify passive/background endpoints so they do not accidentally refresh the 15-minute idle window
- centralize HTTPS detection and honor forwarded protocol data only from explicitly configured immediate proxies
- add migration `0057_session_revocation_tombstones.sql` and focused policy/database regression coverage

## Security review

Two mandatory Codex Security diff scans completed and sealed:

- full session/auth patch scan `eaff7b16-de6f-43f4-9885-a56c47d310a4`: 27/27 deterministic source receipts, 0 reportable or deferred findings
- explicit trusted-proxy follow-up scan `547bf627-6c26-4799-844f-75b5be01995d`: 2/2 full-file receipts, 0 reportable findings

The review caught and corrected four pre-publication defects: POST dispatch for Gmail OAuth entry, invalid nested OAuth forms, fallback behavior for ambiguous `Forwarded` headers, and implicit private-network trust for cookie/redirect HTTPS decisions.

## Verification

- `composer validate --strict --no-check-publish` — pass
- complete PHPUnit suite — 398 tests, 3,175 assertions, 64 environment-dependent skips
- focused session/proxy policy suite — 6 tests, 57 assertions
- changed PHP files lint clean
- `git diff --check` — pass
- corrected Docker `web` target build — pass
- isolated local staging at `127.0.0.1:1628` — web healthy, readiness 200, worker and cron running
- real-MySQL staging session suite — 6 tests, 42 assertions
- staging migration ledger max — 57
- staging `app_sessions` — `absolute_expires_at`, `revoked_at`, and `idx_app_sessions_revoked` present
- test cleanup — zero residual `session-test-*` users and zero known test payloads
- untrusted `172.20.0.3` peer with `X-Forwarded-Proto: https` — cookie remains non-`Secure`, no HSTS/upgrade signal
- explicitly trusted loopback peer with the same header — `Secure` cookie, HSTS, and CSP upgrade emitted

## Migration 0057

`0057_session_revocation_tombstones.sql` is the first pending migration in the linear ledger. It additively creates nullable `app_sessions.revoked_at` plus `idx_app_sessions_revoked`; the session handler uses tombstones so logout, expiry, revocation, and ID rotation win over delayed requests.

The isolated staging database was backed up before applying only 0057. Both the encrypted application backup and a pre-migration SQL dump were retained, and the encrypted backup was restored successfully into a disposable schema-56 database as rollback evidence.

## Product-policy choices

- status/polling and mileage-status requests are passive and do not extend idle lifetime
- adding an authentication factor rotates the current session without revoking every device; removing/resetting factors and password/security changes revoke the appropriate sessions
- ordinary profile/operational edits preserve sessions; identity, role, disabled/forced-reset, and effective-permission changes deliberately revoke affected sessions

## Staging rollout

1. Back up the staging database and apply migration 0057 before any new web code.
2. Quiesce/drain old replicas during the change; old session-handler code does not understand revocation tombstones, so mixed-version traffic is unsafe.
3. Validate `APP_HOST`, provider callback URIs, cookie attributes, and `TRUSTED_PROXIES`; only the real TLS-terminating immediate proxy addresses or narrow CIDRs should be trusted.
4. Exercise email/Slack entry plus Dropbox/Gmail OAuth end to end in a real browser, including callback state/PKCE, session rotation, logout, 15-minute idle expiry, and 7-day absolute expiry.
5. Monitor session-lock timeouts, authentication failures, revocation/GC behavior, and OAuth callback errors before production promotion.

## Rollback

- Leave the additive `revoked_at` column/index in place; do not drop it during an application rollback.
- Drain/quiesce all new-version replicas before restoring old application code; never run mixed session-handler versions.
- Because old code ignores tombstones, force reauthentication/revoke existing sessions before reverting, or otherwise isolate all old-version traffic from sessions created or revoked by the new code.
- Restore the pre-migration backup only for a genuine migration failure; MySQL DDL auto-commits, so prefer forward repair after successful application.

## Residual validation gaps

No production deployment, configuration, credentials, or remote database migration was accessed. Live provider OAuth ceremonies, a real-browser cross-site cookie pass, and the actual production proxy/TLS allowlist remain deployment gates; production must not be described as fixed until those checks and controlled rollout complete.
